### PR TITLE
Add prefix optional param support

### DIFF
--- a/app/authplugins/incoming/token.go
+++ b/app/authplugins/incoming/token.go
@@ -2,8 +2,9 @@ package incoming
 
 import (
 	"net/http"
+	"strings"
 
-	"authtransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/authplugins"
 )
 
 // TokenAuth checks that the caller supplied the expected token.
@@ -11,10 +12,15 @@ type TokenAuth struct{}
 
 func (t *TokenAuth) Name() string             { return "token" }
 func (t *TokenAuth) RequiredParams() []string { return []string{"token", "header"} }
+func (t *TokenAuth) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuth) Authenticate(r *http.Request, params map[string]string) bool {
 	header := params["header"]
-	return r.Header.Get(header) == params["token"]
+	value := r.Header.Get(header)
+	if prefix, ok := params["prefix"]; ok {
+		value = strings.TrimPrefix(value, prefix)
+	}
+	return value == params["token"]
 }
 
 func init() { authplugins.RegisterIncoming(&TokenAuth{}) }

--- a/app/authplugins/outgoing/token.go
+++ b/app/authplugins/outgoing/token.go
@@ -3,7 +3,7 @@ package outgoing
 import (
 	"net/http"
 
-	"authtransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/authplugins"
 )
 
 // TokenAuthOut adds a static token header to outbound requests.
@@ -11,9 +11,14 @@ type TokenAuthOut struct{}
 
 func (t *TokenAuthOut) Name() string             { return "token" }
 func (t *TokenAuthOut) RequiredParams() []string { return []string{"token", "header"} }
+func (t *TokenAuthOut) OptionalParams() []string { return []string{"prefix"} }
 
 func (t *TokenAuthOut) AddAuth(r *http.Request, params map[string]string) {
-	r.Header.Set(params["header"], params["token"])
+	token := params["token"]
+	if prefix, ok := params["prefix"]; ok {
+		token = prefix + token
+	}
+	r.Header.Set(params["header"], token)
 }
 
 func init() { authplugins.RegisterOutgoing(&TokenAuthOut{}) }

--- a/app/authplugins/registry.go
+++ b/app/authplugins/registry.go
@@ -6,6 +6,7 @@ import "net/http"
 type IncomingAuthPlugin interface {
 	Name() string
 	RequiredParams() []string
+	OptionalParams() []string
 	Authenticate(r *http.Request, params map[string]string) bool
 }
 
@@ -13,6 +14,7 @@ type IncomingAuthPlugin interface {
 type OutgoingAuthPlugin interface {
 	Name() string
 	RequiredParams() []string
+	OptionalParams() []string
 	AddAuth(r *http.Request, params map[string]string)
 }
 

--- a/app/integration.go
+++ b/app/integration.go
@@ -7,7 +7,7 @@ import (
 	"sync"
 	"time"
 
-	"authtransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/authplugins"
 )
 
 // AuthPluginConfig ties an auth plugin type to its parameters.
@@ -47,9 +47,19 @@ func AddIntegration(i *Integration) error {
 		if p == nil {
 			return fmt.Errorf("unknown incoming auth type %s", a.Type)
 		}
+		known := map[string]struct{}{}
 		for _, req := range p.RequiredParams() {
 			if _, ok := a.Params[req]; !ok {
 				return fmt.Errorf("missing param %s for auth %s", req, a.Type)
+			}
+			known[req] = struct{}{}
+		}
+		for _, opt := range p.OptionalParams() {
+			known[opt] = struct{}{}
+		}
+		for k := range a.Params {
+			if _, ok := known[k]; !ok {
+				return fmt.Errorf("unknown param %s for auth %s", k, a.Type)
 			}
 		}
 	}
@@ -59,9 +69,19 @@ func AddIntegration(i *Integration) error {
 		if p == nil {
 			return fmt.Errorf("unknown outgoing auth type %s", a.Type)
 		}
+		known := map[string]struct{}{}
 		for _, req := range p.RequiredParams() {
 			if _, ok := a.Params[req]; !ok {
 				return fmt.Errorf("missing param %s for auth %s", req, a.Type)
+			}
+			known[req] = struct{}{}
+		}
+		for _, opt := range p.OptionalParams() {
+			known[opt] = struct{}{}
+		}
+		for k := range a.Params {
+			if _, ok := known[k]; !ok {
+				return fmt.Errorf("unknown param %s for auth %s", k, a.Type)
 			}
 		}
 	}

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -3,8 +3,8 @@ package main
 import (
 	"testing"
 
-	_ "authtransformer/app/authplugins/incoming"
-	_ "authtransformer/app/authplugins/outgoing"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
+	_ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
 )
 
 func TestAddIntegrationMissingParam(t *testing.T) {
@@ -30,5 +30,31 @@ func TestAddIntegrationValid(t *testing.T) {
 	}
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddIntegrationOptionalParam(t *testing.T) {
+	i := &Integration{
+		Name:         "testoptional",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{"token": "x", "header": "X-Auth", "prefix": "Bearer "}}},
+	}
+	if err := AddIntegration(i); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestAddIntegrationUnknownParam(t *testing.T) {
+	i := &Integration{
+		Name:         "testunknown",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]string{"token": "x", "header": "X-Auth", "bogus": "y"}}},
+	}
+	if err := AddIntegration(i); err == nil {
+		t.Fatal("expected error for unknown param")
 	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -1,18 +1,18 @@
 package main
 
 import (
-	"encoding/json"
-	"log"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"os"
-	"sync"
-	"time"
+        "encoding/json"
+        "log"
+        "net/http"
+        "net/http/httputil"
+        "net/url"
+        "os"
+        "sync"
+        "time"
 
-	"authtransformer/app/authplugins"
-	_ "authtransformer/app/authplugins/incoming"
-	_ "authtransformer/app/authplugins/outgoing"
+        "github.com/winhowes/AuthTransformer/app/authplugins"
+        _ "github.com/winhowes/AuthTransformer/app/authplugins/incoming"
+        _ "github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
 )
 
 type Config struct {

--- a/app/token_plugin_test.go
+++ b/app/token_plugin_test.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins/incoming"
+	"github.com/winhowes/AuthTransformer/app/authplugins/outgoing"
+)
+
+func TestTokenOutgoingPrefix(t *testing.T) {
+	r := &http.Request{Header: http.Header{}}
+	p := outgoing.TokenAuthOut{}
+	params := map[string]string{"token": "secret", "header": "Authorization", "prefix": "Bearer "}
+	p.AddAuth(r, params)
+	if got := r.Header.Get("Authorization"); got != "Bearer secret" {
+		t.Fatalf("expected 'Bearer secret', got %s", got)
+	}
+}
+
+func TestTokenIncomingPrefix(t *testing.T) {
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer secret"}}}
+	p := incoming.TokenAuth{}
+	params := map[string]string{"token": "secret", "header": "Authorization", "prefix": "Bearer "}
+	if !p.Authenticate(r, params) {
+		t.Fatal("expected authentication to succeed with prefix")
+	}
+}
+
+func TestTokenIncomingPrefixMismatch(t *testing.T) {
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer secret"}}}
+	p := incoming.TokenAuth{}
+	params := map[string]string{"token": "secret", "header": "Authorization"}
+	if p.Authenticate(r, params) {
+		t.Fatal("expected authentication to fail when prefix not configured")
+	}
+}
+
+func TestTokenPluginOptionalParams(t *testing.T) {
+	in := incoming.TokenAuth{}
+	out := outgoing.TokenAuthOut{}
+	if got := in.OptionalParams(); len(got) != 1 || got[0] != "prefix" {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+	if got := out.OptionalParams(); len(got) != 1 || got[0] != "prefix" {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add `OptionalParams` to auth plugin interfaces
- implement optional prefix param for token auth plugins
- validate optional and unknown parameters when adding integrations
- test optional parameter behavior

## Testing
- `go test ./...`
