### PR TITLE
Add GCP and Azure terraform configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ AuthTransformer writes log messages to standard output. Each request generates a
 
 ## Deploying with Terraform
 
-Example Terraform files are provided in the `terraform` directory to simplify deploying AuthTransformer to AWS using ECS Fargate. Set the required variables for your environment and run `terraform apply` to create the cluster and service.
+Example Terraform files are provided in the `terraform` directory for AWS, GCP and Azure.
+
+- `terraform` (root) contains the AWS configuration for ECS Fargate.
+- `terraform/gcp` contains a configuration for deploying to Google Cloud Run.
+- `terraform/azure` contains a configuration for deploying to Azure Container Instances.
+
+Set the required variables for your environment and run `terraform apply` inside the desired folder to create the service.
 
 ## License
 

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -1,0 +1,43 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.azure_region
+}
+
+resource "azurerm_container_group" "this" {
+  name                = "auth-transformer"
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  os_type             = "Linux"
+
+  container {
+    name   = "auth-transformer"
+    image  = var.container_image
+    cpu    = "0.5"
+    memory = "1.0"
+
+    ports {
+      port     = 8080
+      protocol = "TCP"
+    }
+
+  }
+
+  ip_address_type = "public"
+  dns_name_label  = var.dns_name_label
+  exposed_port    = 8080
+}

--- a/terraform/azure/outputs.tf
+++ b/terraform/azure/outputs.tf
@@ -1,0 +1,3 @@
+output "fqdn" {
+  value = azurerm_container_group.this.fqdn
+}

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -1,0 +1,25 @@
+variable "subscription_id" {
+  description = "Azure subscription ID"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "Resource group name"
+  type        = string
+}
+
+variable "azure_region" {
+  description = "Azure region"
+  type        = string
+}
+
+variable "dns_name_label" {
+  description = "DNS name label for the container"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image for the application"
+  type        = string
+}
+

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -1,0 +1,38 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+resource "google_cloud_run_service" "this" {
+  name     = "auth-transformer"
+  location = var.gcp_region
+
+  template {
+    spec {
+      containers = [
+        {
+          image = var.container_image
+          ports = [{
+            name          = "http1"
+            container_port = 8080
+          }]
+        }
+      ]
+    }
+  }
+
+  traffic {
+    percent         = 100
+    latest_revision = true
+  }
+}

--- a/terraform/gcp/outputs.tf
+++ b/terraform/gcp/outputs.tf
@@ -1,0 +1,3 @@
+output "service_url" {
+  value = google_cloud_run_service.this.status[0].url
+}

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -1,0 +1,15 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+}
+
+variable "container_image" {
+  description = "Container image for the application"
+  type        = string
+}
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,16 +35,6 @@ resource "aws_ecs_task_definition" "this" {
         hostPort      = 8080
         protocol      = "tcp"
       }]
-      environment = [
-        {
-          name  = "IN_TOKEN"
-          value = var.in_token
-        },
-        {
-          name  = "OUT_TOKEN"
-          value = var.out_token
-        }
-      ]
     }
   ])
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,12 +23,3 @@ variable "security_group_id" {
   type        = string
 }
 
-variable "in_token" {
-  description = "Token value for incoming auth"
-  type        = string
-}
-
-variable "out_token" {
-  description = "Token value for outgoing auth"
-  type        = string
-}


### PR DESCRIPTION
## Summary
- add Terraform configs for GCP Cloud Run and Azure Container Instances
- document the new cloud deployment options in the README
- remove in/out auth tokens from all Terraform configs

## Testing
- `go test ./...`
