### PR TITLE
Parse destination URL once when adding integrations

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"regexp"
 	"strings"
@@ -142,6 +143,8 @@ type Integration struct {
 
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter
+
+	destinationURL *url.URL `json:"-"`
 }
 
 var integrations = struct {
@@ -156,6 +159,13 @@ func AddIntegration(i *Integration) error {
 	if !nameRegexp.MatchString(i.Name) {
 		return errors.New("invalid integration name")
 	}
+
+	// Parse the destination URL once upfront.
+	u, err := url.Parse(i.Destination)
+	if err != nil {
+		return fmt.Errorf("invalid destination URL: %w", err)
+	}
+	i.destinationURL = u
 
 	// ─── Validate incoming-auth configs ───────────────────────────────────────
 	for idx, a := range i.IncomingAuth {

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -67,3 +67,15 @@ func TestAddIntegrationUnknownParam(t *testing.T) {
 		t.Fatal("expected error for unknown param")
 	}
 }
+
+func TestAddIntegrationInvalidDestination(t *testing.T) {
+	i := &Integration{
+		Name:         "badurl",
+		Destination:  "://bad url",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+	}
+	if err := AddIntegration(i); err == nil {
+		t.Fatal("expected error for invalid destination")
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"os"
 	"os/signal"
 	"strings"
@@ -186,13 +185,12 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	target, err := url.Parse(integ.Destination)
-	if err != nil {
+	if integ.destinationURL == nil {
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(target)
+	proxy := httputil.NewSingleHostReverseProxy(integ.destinationURL)
 	proxy.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
## Summary
- store parsed destination URL in `Integration`
- check destination URL validity in `AddIntegration`
- use cached URL in `proxyHandler`
- test invalid destination handling

## Testing
- `go test ./...`