### PR TITLE
Add Slack/GitHub integration helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ AuthTransformer is a simple Go-based reverse proxy that injects authentication t
    curl -H "Host: example" -H "X-Auth: $IN_TOKEN" http://localhost:8080/
    ```
 
+## Integration CLI
+
+When run with the `-debug` flag the server exposes a `/integrations` endpoint for adding integrations. A helper CLI is available under `cmd/integrations` to create Slack or GitHub integrations with minimal flags.
+
+Add Slack:
+```bash
+go run ./cmd/integrations slack -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING
+```
+Add GitHub:
+```bash
+go run ./cmd/integrations github -token env:GITHUB_TOKEN -webhook-secret env:GITHUB_SECRET
+```
+
 ## Running Tests
 
 Use the Go toolchain to vet and test the code:

--- a/app/authplugins/incoming/github_signature.go
+++ b/app/authplugins/incoming/github_signature.go
@@ -1,0 +1,77 @@
+package incoming
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// githubSigParams configures GitHub webhook signature validation.
+type githubSigParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+	Prefix  string   `json:"prefix"`
+}
+
+type GitHubSignatureAuth struct{}
+
+func (g *GitHubSignatureAuth) Name() string { return "github_signature" }
+
+func (g *GitHubSignatureAuth) RequiredParams() []string { return []string{"secrets"} }
+
+func (g *GitHubSignatureAuth) OptionalParams() []string { return []string{"header", "prefix"} }
+
+func (g *GitHubSignatureAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[githubSigParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Header == "" {
+		p.Header = "X-Hub-Signature-256"
+	}
+	if p.Prefix == "" {
+		p.Prefix = "sha256="
+	}
+	return p, nil
+}
+
+func (g *GitHubSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
+	cfg, ok := p.(*githubSigParams)
+	if !ok {
+		return false
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	sig := r.Header.Get(cfg.Header)
+	if sig == "" {
+		return false
+	}
+	for _, ref := range cfg.Secrets {
+		secret, err := secrets.LoadSecret(ref)
+		if err != nil {
+			continue
+		}
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write(body)
+		expected := cfg.Prefix + hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(expected), []byte(sig)) {
+			return true
+		}
+	}
+	return false
+}
+
+func init() { authplugins.RegisterIncoming(&GitHubSignatureAuth{}) }

--- a/app/authplugins/incoming/slack_signature.go
+++ b/app/authplugins/incoming/slack_signature.go
@@ -1,0 +1,105 @@
+package incoming
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// slackSigParams holds config for Slack signature validation.
+type slackSigParams struct {
+	Secrets         []string `json:"secrets"`
+	Version         string   `json:"version"`
+	SigHeader       string   `json:"sig_header"`
+	TimestampHeader string   `json:"ts_header"`
+	Tolerance       int64    `json:"tolerance"`
+}
+
+type SlackSignatureAuth struct{}
+
+func (s *SlackSignatureAuth) Name() string { return "slack_signature" }
+
+func (s *SlackSignatureAuth) RequiredParams() []string { return []string{"secrets"} }
+
+func (s *SlackSignatureAuth) OptionalParams() []string {
+	return []string{"version", "sig_header", "ts_header", "tolerance"}
+}
+
+func (s *SlackSignatureAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[slackSigParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Version == "" {
+		p.Version = "v0"
+	}
+	if p.SigHeader == "" {
+		p.SigHeader = "X-Slack-Signature"
+	}
+	if p.TimestampHeader == "" {
+		p.TimestampHeader = "X-Slack-Request-Timestamp"
+	}
+	if p.Tolerance == 0 {
+		p.Tolerance = 300
+	}
+	return p, nil
+}
+
+func (s *SlackSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
+	cfg, ok := p.(*slackSigParams)
+	if !ok {
+		return false
+	}
+	tsStr := r.Header.Get(cfg.TimestampHeader)
+	ts, err := strconv.ParseInt(tsStr, 10, 64)
+	if err != nil {
+		return false
+	}
+	if abs(time.Now().Unix()-ts) > cfg.Tolerance {
+		return false
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return false
+	}
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	base := fmt.Sprintf("%s:%s:%s", cfg.Version, tsStr, string(body))
+	sig := r.Header.Get(cfg.SigHeader)
+	if sig == "" {
+		return false
+	}
+	for _, ref := range cfg.Secrets {
+		secret, err := secrets.LoadSecret(ref)
+		if err != nil {
+			continue
+		}
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(base))
+		expected := cfg.Version + "=" + hex.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(expected), []byte(sig)) {
+			return true
+		}
+	}
+	return false
+}
+
+func abs(i int64) int64 {
+	if i < 0 {
+		return -i
+	}
+	return i
+}
+
+func init() { authplugins.RegisterIncoming(&SlackSignatureAuth{}) }

--- a/cmd/integrations/plugins/github.go
+++ b/cmd/integrations/plugins/github.go
@@ -1,0 +1,25 @@
+package plugins
+
+// GitHub returns an Integration configured for the GitHub API.
+func GitHub(name, tokenRef, webhookSecretRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.github.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		IncomingAuth: []AuthPluginConfig{{
+			Type: "github_signature",
+			Params: map[string]interface{}{
+				"secrets": []string{webhookSecretRef},
+			},
+		}},
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "token ",
+			},
+		}},
+	}
+}

--- a/cmd/integrations/plugins/slack.go
+++ b/cmd/integrations/plugins/slack.go
@@ -1,0 +1,25 @@
+package plugins
+
+// Slack returns an Integration configured for the Slack API.
+func Slack(name, tokenRef, signingSecretRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://slack.com/api",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		IncomingAuth: []AuthPluginConfig{{
+			Type: "slack_signature",
+			Params: map[string]interface{}{
+				"secrets": []string{signingSecretRef},
+			},
+		}},
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}

--- a/cmd/integrations/plugins/types.go
+++ b/cmd/integrations/plugins/types.go
@@ -1,0 +1,18 @@
+package plugins
+
+// AuthPluginConfig mirrors the main application's plugin config.
+type AuthPluginConfig struct {
+	Type   string                 `json:"type"`
+	Params map[string]interface{} `json:"params"`
+}
+
+// Integration mirrors the main application's integration structure.
+type Integration struct {
+	Name           string             `json:"name"`
+	Destination    string             `json:"destination"`
+	InRateLimit    int                `json:"in_rate_limit"`
+	OutRateLimit   int                `json:"out_rate_limit"`
+	IncomingAuth   []AuthPluginConfig `json:"incoming_auth"`
+	OutgoingAuth   []AuthPluginConfig `json:"outgoing_auth"`
+	AllowedCallers []struct{}         `json:"allowlist,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add new `SlackSignatureAuth` and `GitHubSignatureAuth` incoming plugins
- add integration CLI with Slack and GitHub helpers
- document how to use the integration CLI

## Testing
- `go vet ./...`
- `go test ./...`
