### PR TITLE
Reuse reverse proxy

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http/httputil"
 	"net/url"
 	"reflect"
 	"regexp"
@@ -131,7 +132,8 @@ type Integration struct {
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter
 
-	destinationURL *url.URL `json:"-"`
+	destinationURL *url.URL               `json:"-"`
+	proxy          *httputil.ReverseProxy `json:"-"`
 }
 
 var integrations = struct {
@@ -153,6 +155,7 @@ func AddIntegration(i *Integration) error {
 		return fmt.Errorf("invalid destination URL: %w", err)
 	}
 	i.destinationURL = u
+	i.proxy = httputil.NewSingleHostReverseProxy(u)
 
 	// ─── Validate incoming-auth configs ───────────────────────────────────────
 	for idx, a := range i.IncomingAuth {

--- a/app/main.go
+++ b/app/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	"net/http/httputil"
 	"os"
 	"os/signal"
 	"strings"
@@ -214,13 +213,12 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if integ.destinationURL == nil {
+	if integ.proxy == nil {
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return
 	}
 
-	proxy := httputil.NewSingleHostReverseProxy(integ.destinationURL)
-	proxy.ServeHTTP(w, r)
+	integ.proxy.ServeHTTP(w, r)
 }
 
 func main() {


### PR DESCRIPTION
## Summary
- embed a `ReverseProxy` on `Integration`
- initialize each `ReverseProxy` during `AddIntegration`
- invoke the stored proxy from `proxyHandler`

## Testing
- `go vet ./...`
- `go test ./...`
