### PR TITLE
Remove AllowedCallers field

### DIFF
--- a/cmd/integrations/plugins/types.go
+++ b/cmd/integrations/plugins/types.go
@@ -14,5 +14,4 @@ type Integration struct {
 	OutRateLimit   int                `json:"out_rate_limit"`
 	IncomingAuth   []AuthPluginConfig `json:"incoming_auth"`
 	OutgoingAuth   []AuthPluginConfig `json:"outgoing_auth"`
-	AllowedCallers []struct{}         `json:"allowlist,omitempty"`
 }


### PR DESCRIPTION
## Summary
- delete unused `AllowedCallers` from integration plugin types

## Testing
- `go vet ./...`
- `go test ./...`