### PR TITLE
Add url path auth plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The project exists to make it trivial to translate one type of authentication in
 ## Features
 
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host or `X-AT-Int` header. The header can be disabled or restricted to a specific host using command-line flags.
-- **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, "jwt" and "mtls" authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
+- **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls` and `url_path` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
@@ -143,6 +143,7 @@ array.
    - **token**: Header token comparison for simple shared secrets.
    - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets.
    - **hmac_signature**: Computes or verifies request HMAC digests with a configurable algorithm.
+   - **url_path**: Appends a secret to the request path for outgoing calls and verifies it on incoming requests.
 
 ### Capabilities
 

--- a/app/authplugins/urlpath/incoming.go
+++ b/app/authplugins/urlpath/incoming.go
@@ -1,0 +1,54 @@
+package urlpath
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// inParams configures URL path secret validation.
+type inParams struct {
+	Secrets []string `json:"secrets"`
+}
+
+type URLPathAuth struct{}
+
+func (u *URLPathAuth) Name() string             { return "url_path" }
+func (u *URLPathAuth) RequiredParams() []string { return []string{"secrets"} }
+func (u *URLPathAuth) OptionalParams() []string { return nil }
+
+func (u *URLPathAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[inParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	return p, nil
+}
+
+func (u *URLPathAuth) Authenticate(r *http.Request, p interface{}) bool {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return false
+	}
+	for _, ref := range cfg.Secrets {
+		sec, err := secrets.LoadSecret(ref)
+		if err != nil {
+			continue
+		}
+		suffix := "/" + sec
+		if strings.HasSuffix(r.URL.Path, suffix) {
+			r.URL.Path = strings.TrimSuffix(r.URL.Path, suffix)
+			r.RequestURI = r.URL.RequestURI()
+			return true
+		}
+	}
+	return false
+}
+
+func init() { authplugins.RegisterIncoming(&URLPathAuth{}) }

--- a/app/authplugins/urlpath/outgoing.go
+++ b/app/authplugins/urlpath/outgoing.go
@@ -1,0 +1,51 @@
+package urlpath
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/winhowes/AuthTransformer/app/authplugins"
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// outParams configures URL path secret attachment.
+type outParams struct {
+	Secrets []string `json:"secrets"`
+}
+
+type URLPathAuthOut struct{}
+
+func (u *URLPathAuthOut) Name() string             { return "url_path" }
+func (u *URLPathAuthOut) RequiredParams() []string { return []string{"secrets"} }
+func (u *URLPathAuthOut) OptionalParams() []string { return nil }
+
+func (u *URLPathAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[outParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	return p, nil
+}
+
+func (u *URLPathAuthOut) AddAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*outParams)
+	if !ok || len(cfg.Secrets) == 0 {
+		return
+	}
+	sec, err := secrets.LoadRandomSecret(cfg.Secrets)
+	if err != nil {
+		return
+	}
+	if !strings.HasSuffix(r.URL.Path, "/") {
+		r.URL.Path += "/" + sec
+	} else {
+		r.URL.Path += sec
+	}
+	r.RequestURI = r.URL.RequestURI()
+}
+
+func init() { authplugins.RegisterOutgoing(&URLPathAuthOut{}) }

--- a/app/authplugins/urlpath/urlpath_test.go
+++ b/app/authplugins/urlpath/urlpath_test.go
@@ -1,0 +1,63 @@
+package urlpath
+
+import (
+	"net/http"
+	"net/url"
+	"testing"
+
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestURLPathOutgoingAddAuth(t *testing.T) {
+	r := &http.Request{URL: &url.URL{Path: "/api"}}
+	p := URLPathAuthOut{}
+	t.Setenv("SEC", "secret")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SEC"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.AddAuth(r, cfg)
+	if got := r.URL.Path; got != "/api/secret" {
+		t.Fatalf("expected '/api/secret', got %s", got)
+	}
+}
+
+func TestURLPathIncomingAuth(t *testing.T) {
+	r := &http.Request{URL: &url.URL{Path: "/api/secret"}}
+	p := URLPathAuth{}
+	t.Setenv("SEC", "secret")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SEC"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+	if got := r.URL.Path; got != "/api" {
+		t.Fatalf("expected path '/api', got %s", got)
+	}
+}
+
+func TestURLPathIncomingAuthFail(t *testing.T) {
+	r := &http.Request{URL: &url.URL{Path: "/api/bad"}}
+	p := URLPathAuth{}
+	t.Setenv("SEC", "secret")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:SEC"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to fail")
+	}
+}
+
+func TestURLPathPluginOptionalParams(t *testing.T) {
+	in := URLPathAuth{}
+	out := URLPathAuthOut{}
+	if got := in.OptionalParams(); got != nil && len(got) != 0 {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+	if got := out.OptionalParams(); got != nil && len(got) != 0 {
+		t.Fatalf("unexpected optional params: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add URL path auth plugin to verify a secret at the end of the path on incoming requests
- append the secret to outbound requests
- document the new plugin in the README
- test the incoming and outgoing behavior

## Testing
- `go vet ./...`
- `go test ./...`
