### PR TITLE
Add file secret plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ array.
 
 
 
-   - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:` or KMS-prefixed formats described below.
+   - **integrations**: Defines proxy routes, rate limits and authentication methods. Secret references use the `env:`, `file:` or KMS-prefixed formats described below.
    - **google_oidc**: Outgoing auth plugin that retrieves an ID token from the GCP metadata server and sets it in the `Authorization` header for backend requests. The incoming variant validates Google ID tokens against a configured audience.
    - **jwt**: Validates generic JWTs using provided keys and can attach tokens on outgoing requests.
    - **mtls**: Requires a verified client certificate and optional subject match, and accepts outbound certificate configuration.
@@ -170,6 +170,7 @@ Integration plugins can bundle common allowlist rules into **capabilities**. Ass
 | Prefix | Environment Variables | Description |
 | ------ | -------------------- | ----------- |
 | `env`  | Names referenced in the configuration (e.g. `env:IN_TOKEN`) | Secrets are read directly from those environment variables. |
+| `file` | _none_ | Reads file contents from disk for `file:` secrets. |
 | `aws`  | `AWS_KMS_KEY` | Base64 encoded 32 byte key used for decrypting `aws:` secrets. |
 | `azure`| `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` | Credentials for fetching `azure:` secrets from Key Vault. |
 | `gcp`  | _none_ | Uses the GCP metadata service for authentication when resolving `gcp:` secrets. |

--- a/app/secrets/file_plugin_test.go
+++ b/app/secrets/file_plugin_test.go
@@ -1,0 +1,32 @@
+package secrets_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/winhowes/AuthTransformer/app/secrets"
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins"
+)
+
+func TestLoadSecretFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("top-secret"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	val, err := secrets.LoadSecret("file:" + path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "top-secret" {
+		t.Fatalf("expected 'top-secret', got %s", val)
+	}
+}
+
+func TestLoadSecretFileMissing(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing.txt")
+	if _, err := secrets.LoadSecret("file:" + path); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}

--- a/app/secrets/plugins/file/plugin.go
+++ b/app/secrets/plugins/file/plugin.go
@@ -1,0 +1,22 @@
+package plugins
+
+import (
+	"os"
+
+	"github.com/winhowes/AuthTransformer/app/secrets"
+)
+
+// filePlugin reads secrets from files on disk.
+type filePlugin struct{}
+
+func (filePlugin) Prefix() string { return "file" }
+
+func (filePlugin) Load(id string) (string, error) {
+	b, err := os.ReadFile(id)
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+func init() { secrets.Register(filePlugin{}) }

--- a/app/secrets/plugins/plugins.go
+++ b/app/secrets/plugins/plugins.go
@@ -4,5 +4,6 @@ import (
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins/aws"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins/azure"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins/env"
+	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins/file"
 	_ "github.com/winhowes/AuthTransformer/app/secrets/plugins/gcp"
 )


### PR DESCRIPTION
## Summary
- implement a `file` secret plugin and register it
- support loading secrets from `file:/path` references
- test the new plugin
- document the plugin in README

## Testing
- `go vet ./...`
- `go test ./...`
