### PR TITLE
Trim whitespace from file secrets

### DIFF
--- a/app/secrets/file_plugin_test.go
+++ b/app/secrets/file_plugin_test.go
@@ -24,6 +24,21 @@ func TestLoadSecretFile(t *testing.T) {
 	}
 }
 
+func TestLoadSecretFileTrailingNewline(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secret.txt")
+	if err := os.WriteFile(path, []byte("top-secret\n"), 0600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	val, err := secrets.LoadSecret("file:" + path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "top-secret" {
+		t.Fatalf("expected 'top-secret', got %s", val)
+	}
+}
+
 func TestLoadSecretFileMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing.txt")
 	if _, err := secrets.LoadSecret("file:" + path); err == nil {

--- a/app/secrets/plugins/file/plugin.go
+++ b/app/secrets/plugins/file/plugin.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"os"
+	"strings"
 
 	"github.com/winhowes/AuthTransformer/app/secrets"
 )
@@ -16,7 +17,7 @@ func (filePlugin) Load(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return string(b), nil
+	return strings.TrimSpace(string(b)), nil
 }
 
 func init() { secrets.Register(filePlugin{}) }


### PR DESCRIPTION
## Summary
- trim whitespace from file plugin
- test for secret files with trailing newline

## Testing
- `go test ./...`