### PR TITLE
Add CLI help and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The project exists to make it trivial to translate one type of authentication in
    ```bash
    go run ./app -config app/config.json
    ```
+
+   Run `go run ./app --help` to see all available flags.
    
    Or build an executable:
    
@@ -248,6 +250,8 @@ associates the plugin name with a function that parses CLI flags and returns an
 
 ## Integration CLI
 
+Run `go run ./cmd/integrations --help` for a full list of commands and options.
+
 Start the server with `-debug` so the `/integrations` endpoint is available:
 
 ```bash
@@ -323,6 +327,8 @@ go run ./cmd/integrations stripe -token env:STRIPE_TOKEN
 ```
 
 ## Allowlist CLI
+
+Run `go run ./cmd/allowlist --help` to view commands and flags.
 
 The `allowlist` command helps maintain the `allowlist.json` file. Run `allowlist list` to view every capability defined by the integration plugins:
 

--- a/app/main.go
+++ b/app/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -66,6 +67,12 @@ var xAtIntHost = flag.String("x_at_int_host", "", "only respect X-AT-Int header 
 var addr = flag.String("addr", ":8080", "listen address")
 var allowlistFile = flag.String("allowlist", "allowlist.json", "path to allowlist configuration")
 var configFile = flag.String("config", "config.json", "path to configuration file")
+
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), "Usage: authtranslator [options]\n\n")
+	fmt.Fprintf(flag.CommandLine.Output(), "Options:\n")
+	flag.PrintDefaults()
+}
 
 func loadConfig(filename string) (*Config, error) {
 	f, err := os.Open(filename)
@@ -238,6 +245,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	flag.Usage = usage
 	flag.Parse()
 
 	config, err := loadConfig(*configFile)

--- a/cmd/allowlist/main.go
+++ b/cmd/allowlist/main.go
@@ -12,7 +12,14 @@ import (
 
 var file = flag.String("file", "allowlist.json", "allowlist file")
 
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage: allowlist [options] <command>\n\n`)
+	fmt.Fprintf(flag.CommandLine.Output(), "Commands:\n  list   show plugin capabilities\n  add    update the allowlist\n\nOptions:\n")
+	flag.PrintDefaults()
+}
+
 func main() {
+	flag.Usage = usage
 	flag.Parse()
 	if flag.NArg() < 1 {
 		usage()
@@ -27,11 +34,6 @@ func main() {
 	}
 }
 
-func usage() {
-	fmt.Println("usage: allowlist <list|add> [options]")
-	os.Exit(1)
-}
-
 func listCaps() {
 	for integ, caps := range plugins.List() {
 		fmt.Println(integ + ":")
@@ -43,6 +45,10 @@ func listCaps() {
 
 func addEntry(args []string) {
 	fs := flag.NewFlagSet("add", flag.ExitOnError)
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage: allowlist add [flags]\n\n")
+		fs.PrintDefaults()
+	}
 	integ := fs.String("integration", "", "integration name")
 	caller := fs.String("caller", "", "caller id")
 	capName := fs.String("capability", "", "capability name")

--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -14,10 +14,18 @@ import (
 
 var server = flag.String("server", "http://localhost:8080/integrations", "integration endpoint")
 
+func usage() {
+	fmt.Fprintf(flag.CommandLine.Output(), `Usage: integrations [options] <list|plugin> [plugin options]\n\n`)
+	fmt.Fprintf(flag.CommandLine.Output(), "Options:\n")
+	flag.PrintDefaults()
+	fmt.Fprintln(flag.CommandLine.Output(), "\nRun \"integrations <plugin> -help\" to see plugin flags.")
+}
+
 func main() {
+	flag.Usage = usage
 	flag.Parse()
 	if flag.NArg() < 1 {
-		fmt.Fprintln(os.Stderr, "usage: integrations <list|plugin> [options]")
+		usage()
 		os.Exit(1)
 	}
 	plugin := flag.Arg(0)


### PR DESCRIPTION
## Summary
- add `--help` usage information for all CLI binaries
- document new help options in the README

## Testing
- `go vet ./...`
- `go test ./...`
