### PR TITLE
Add caching for performance

### DIFF
--- a/app/authplugins/body.go
+++ b/app/authplugins/body.go
@@ -1,0 +1,26 @@
+package authplugins
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+)
+
+type bodyKey struct{}
+
+// GetBody returns the request body bytes while caching the result for
+// subsequent calls. It also resets r.Body so callers can read it again.
+func GetBody(r *http.Request) ([]byte, error) {
+	if b, ok := r.Context().Value(bodyKey{}).([]byte); ok {
+		return b, nil
+	}
+	b, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, err
+	}
+	r.Body = io.NopCloser(bytes.NewReader(b))
+	ctx := context.WithValue(r.Context(), bodyKey{}, b)
+	*r = *r.WithContext(ctx)
+	return b, nil
+}

--- a/app/authplugins/google_oidc/outgoing.go
+++ b/app/authplugins/google_oidc/outgoing.go
@@ -1,10 +1,14 @@
 package googleoidc
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
@@ -26,6 +30,16 @@ var MetadataHost = "http://metadata.google.internal"
 
 // HTTPClient is used for metadata requests and can be overridden in tests.
 var HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+type cachedToken struct {
+	token string
+	exp   time.Time
+}
+
+var tokenCache = struct {
+	sync.Mutex
+	m map[string]cachedToken
+}{m: make(map[string]cachedToken)}
 
 func (g *GoogleOIDC) Name() string { return "google_oidc" }
 
@@ -57,25 +71,73 @@ func (g *GoogleOIDC) AddAuth(r *http.Request, params interface{}) {
 	if !ok {
 		return
 	}
-	metaURL := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s", MetadataHost, url.QueryEscape(cfg.Audience))
+	tok, exp := getCachedToken(cfg.Audience)
+	if tok == "" || time.Now().After(exp) {
+		var err error
+		tok, exp, err = fetchToken(cfg.Audience)
+		if err != nil {
+			return
+		}
+		setCachedToken(cfg.Audience, tok, exp)
+	}
+	r.Header.Set(cfg.Header, cfg.Prefix+tok)
+}
+
+func fetchToken(aud string) (string, time.Time, error) {
+	metaURL := fmt.Sprintf("%s/computeMetadata/v1/instance/service-accounts/default/identity?audience=%s", MetadataHost, url.QueryEscape(aud))
 	req, err := http.NewRequest("GET", metaURL, nil)
 	if err != nil {
-		return
+		return "", time.Time{}, err
 	}
 	req.Header.Set("Metadata-Flavor", "Google")
 	resp, err := HTTPClient.Do(req)
 	if err != nil {
-		return
+		return "", time.Time{}, err
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return
+		return "", time.Time{}, fmt.Errorf("status %s", resp.Status)
 	}
-	token, err := io.ReadAll(resp.Body)
+	tokenBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return
+		return "", time.Time{}, err
 	}
-	r.Header.Set(cfg.Header, cfg.Prefix+string(token))
+	tok := string(tokenBytes)
+	return tok, parseExpiry(tok), nil
+}
+
+func parseExpiry(tok string) time.Time {
+	parts := strings.Split(tok, ".")
+	if len(parts) < 2 {
+		return time.Now().Add(time.Minute)
+	}
+	data, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return time.Now().Add(time.Minute)
+	}
+	var c struct {
+		Exp int64 `json:"exp"`
+	}
+	if err := json.Unmarshal(data, &c); err != nil || c.Exp == 0 {
+		return time.Now().Add(time.Minute)
+	}
+	return time.Unix(c.Exp, 0)
+}
+
+func getCachedToken(aud string) (string, time.Time) {
+	tokenCache.Lock()
+	defer tokenCache.Unlock()
+	ct, ok := tokenCache.m[aud]
+	if !ok {
+		return "", time.Time{}
+	}
+	return ct.token, ct.exp
+}
+
+func setCachedToken(aud, tok string, exp time.Time) {
+	tokenCache.Lock()
+	tokenCache.m[aud] = cachedToken{token: tok, exp: exp}
+	tokenCache.Unlock()
 }
 
 func init() { authplugins.RegisterOutgoing(&GoogleOIDC{}) }

--- a/app/authplugins/hmac/incoming.go
+++ b/app/authplugins/hmac/incoming.go
@@ -1,7 +1,6 @@
 package hmacsig
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -9,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash"
-	"io"
 	"net/http"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
@@ -73,11 +71,10 @@ func (h *HMACSignatureAuth) Authenticate(r *http.Request, params interface{}) bo
 	if err != nil {
 		return false
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := authplugins.GetBody(r)
 	if err != nil {
 		return false
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
 	sig := r.Header.Get(cfg.Header)
 	if sig == "" {
 		return false

--- a/app/authplugins/hmac/outgoing.go
+++ b/app/authplugins/hmac/outgoing.go
@@ -1,7 +1,6 @@
 package hmacsig
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -9,7 +8,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"hash"
-	"io"
 	"net/http"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
@@ -73,11 +71,10 @@ func (h *HMACSignature) AddAuth(r *http.Request, params interface{}) {
 	if err != nil {
 		return
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := authplugins.GetBody(r)
 	if err != nil {
 		return
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
 	secret, err := secrets.LoadRandomSecret(cfg.Secrets)
 	if err != nil {
 		return

--- a/app/authplugins/incoming/github_signature.go
+++ b/app/authplugins/incoming/github_signature.go
@@ -1,12 +1,10 @@
 package incoming
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
@@ -50,11 +48,10 @@ func (g *GitHubSignatureAuth) Authenticate(r *http.Request, p interface{}) bool 
 	if !ok {
 		return false
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := authplugins.GetBody(r)
 	if err != nil {
 		return false
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
 	sig := r.Header.Get(cfg.Header)
 	if sig == "" {
 		return false

--- a/app/authplugins/incoming/slack_signature.go
+++ b/app/authplugins/incoming/slack_signature.go
@@ -1,12 +1,10 @@
 package incoming
 
 import (
-	"bytes"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
-	"io"
 	"net/http"
 	"strconv"
 	"time"
@@ -70,11 +68,10 @@ func (s *SlackSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
 	if abs(time.Now().Unix()-ts) > cfg.Tolerance {
 		return false
 	}
-	body, err := io.ReadAll(r.Body)
+	body, err := authplugins.GetBody(r)
 	if err != nil {
 		return false
 	}
-	r.Body = io.NopCloser(bytes.NewReader(body))
 	base := fmt.Sprintf("%s:%s:%s", cfg.Version, tsStr, string(body))
 	sig := r.Header.Get(cfg.SigHeader)
 	if sig == "" {

--- a/app/secrets/plugins/azure/plugin.go
+++ b/app/secrets/plugins/azure/plugin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"time"
 )
 
 // azureKMSPlugin retrieves secrets from Azure Key Vault. It uses the
@@ -18,6 +19,8 @@ import (
 // identifier should be the full URL of the secret without any
 // query parameters (e.g. "https://myvault.vault.azure.net/secrets/foo").
 type azureKMSPlugin struct{}
+
+var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 // Prefix returns the identifier prefix used in configuration strings.
 func (azureKMSPlugin) Prefix() string { return "azure" }
@@ -43,7 +46,7 @@ func (azureKMSPlugin) Load(id string) (string, error) {
 		return "", err
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -75,7 +78,7 @@ func getAzureToken(tenant, client, secret string) (string, error) {
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}

--- a/app/secrets/plugins/azure/plugin_test.go
+++ b/app/secrets/plugins/azure/plugin_test.go
@@ -21,10 +21,16 @@ func (t *azureRewriteTransport) RoundTrip(req *http.Request) (*http.Response, er
 }
 
 func setAzureTestClient(ts *httptest.Server) func() {
-	old := http.DefaultClient
+	oldDef := http.DefaultClient
+	old := HTTPClient
 	u, _ := url.Parse(ts.URL)
-	http.DefaultClient = &http.Client{Transport: &azureRewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
-	return func() { http.DefaultClient = old }
+	c := &http.Client{Transport: &azureRewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
+	http.DefaultClient = c
+	HTTPClient = c
+	return func() {
+		http.DefaultClient = oldDef
+		HTTPClient = old
+	}
 }
 
 func TestAzureKMSLoad(t *testing.T) {

--- a/app/secrets/plugins/gcp/plugin.go
+++ b/app/secrets/plugins/gcp/plugin.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/winhowes/AuthTranslator/app/secrets"
 )
@@ -19,6 +20,8 @@ import (
 // which means it only works when running on GCP with a service account
 // attached.
 type gcpKMSPlugin struct{}
+
+var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 func (gcpKMSPlugin) Prefix() string { return "gcp" }
 
@@ -35,7 +38,7 @@ func (gcpKMSPlugin) Load(id string) (string, error) {
 		return "", err
 	}
 	req.Header.Set("Metadata-Flavor", "Google")
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := HTTPClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -65,7 +68,7 @@ func (gcpKMSPlugin) Load(id string) (string, error) {
 	postReq.Header.Set("Authorization", "Bearer "+tr.AccessToken)
 	postReq.Header.Set("Content-Type", "application/json")
 
-	resp2, err := http.DefaultClient.Do(postReq)
+	resp2, err := HTTPClient.Do(postReq)
 	if err != nil {
 		return "", err
 	}

--- a/app/secrets/plugins/gcp/plugin_test.go
+++ b/app/secrets/plugins/gcp/plugin_test.go
@@ -24,10 +24,16 @@ func (t *gcpRewriteTransport) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 func setGCPTestClient(ts *httptest.Server) func() {
-	old := http.DefaultClient
+	oldDef := http.DefaultClient
+	old := HTTPClient
 	u, _ := url.Parse(ts.URL)
-	http.DefaultClient = &http.Client{Transport: &gcpRewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
-	return func() { http.DefaultClient = old }
+	c := &http.Client{Transport: &gcpRewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
+	http.DefaultClient = c
+	HTTPClient = c
+	return func() {
+		http.DefaultClient = oldDef
+		HTTPClient = old
+	}
 }
 
 func TestGCPKMSLoad(t *testing.T) {


### PR DESCRIPTION
## Summary
- cache request bodies for incoming auth and allowlist checks
- cache outbound Google OIDC tokens
- cache loaded secrets and use HTTP clients with timeouts
- index allowlist lookups by caller ID

## Testing
- `go test ./...`