### PR TITLE
Fix allowlist wildcard logic

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -22,7 +22,11 @@ func SetAllowlist(name string, callers []CallerConfig) {
 	callers = integrationplugins.ExpandCapabilities(name, callers)
 	m := make(map[string]CallerConfig, len(callers))
 	for _, c := range callers {
-		m[c.ID] = c
+		id := c.ID
+		if id == "" {
+			id = "*"
+		}
+		m[id] = c
 	}
 	allowlists.Lock()
 	allowlists.m[name] = m
@@ -176,18 +180,19 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 	allowlists.RLock()
 	callers := allowlists.m[i.Name]
 	c, ok := callers[callerID]
+	wildcard, wOK := callers["*"]
 	allowlists.RUnlock()
-	if !ok {
-		return RequestConstraint{}, false
-	}
-	for _, r := range c.Rules {
-		if matchPath(r.Path, pth) {
-			if m, ok := r.Methods[method]; ok {
-				return m, true
+
+	if ok {
+		for _, r := range c.Rules {
+			if matchPath(r.Path, pth) {
+				if m, ok := r.Methods[method]; ok {
+					return m, true
+				}
 			}
 		}
 	}
-	if wildcard != nil {
+	if wOK {
 		for _, r := range wildcard.Rules {
 			if matchPath(r.Path, pth) {
 				if m, ok := r.Methods[method]; ok {


### PR DESCRIPTION
## Summary
- index allowlists by integration and caller id
- fallback to `"*"` if caller id missing
- handle wildcard lookups in findConstraint
- add tests for indexing and wildcard logic

## Testing
- `go test ./...`