### PR TITLE
Support identifier for basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,9 @@ The project exists to make it trivial to translate one type of authentication in
   Caller IDs are derived by the incoming auth plugins. Plugins that
   implement the `Identifier` interface return a string used to match the
   `id` field in the allowlist. `jwt` and `google_oidc` return the token's
-  `sub` claim while `mtls` uses the client certificate's common name. The
-  `token` plugin does not supply an ID. Allowlist entries are grouped first
+  `sub` claim while `mtls` uses the client certificate's common name and
+  `basic` returns the username portion of the credentials. Plugins like the
+  `token` plugin do not supply an ID. Allowlist entries are grouped first
   by integration name and then by caller ID. When no ID is available the
   wildcard `"*"` entry is used so all callers share those rules.
 
@@ -170,7 +171,7 @@ array.
    - **jwt**: Validates generic JWTs using provided keys and can attach tokens on outgoing requests.
    - **mtls**: Requires a verified client certificate and optional subject match, and accepts outbound certificate configuration.
    - **token**: Header token comparison for simple shared secrets.
-   - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets.
+   - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets. The username portion is used as the caller ID.
    - **hmac_signature**: Computes or verifies request HMAC digests with a configurable algorithm.
    - **url_path**: Appends a secret to the request path for outgoing calls and verifies it on incoming requests.
 

--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -175,6 +175,7 @@ func matchValue(data, rule interface{}) bool {
 func findConstraint(i *Integration, callerID, pth, method string) (RequestConstraint, bool) {
 	allowlists.RLock()
 	callers := allowlists.m[i.Name]
+	wildcard, hasWildcard := callers["*"]
 	c, ok := callers[callerID]
 	allowlists.RUnlock()
 	if !ok {
@@ -187,7 +188,7 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 			}
 		}
 	}
-	if wildcard != nil {
+	if hasWildcard {
 		for _, r := range wildcard.Rules {
 			if matchPath(r.Path, pth) {
 				if m, ok := r.Methods[method]; ok {

--- a/app/authplugins/basic/basic_test.go
+++ b/app/authplugins/basic/basic_test.go
@@ -51,6 +51,24 @@ func TestBasicIncomingAuthFail(t *testing.T) {
 	}
 }
 
+func TestBasicIdentify(t *testing.T) {
+	cred := base64.StdEncoding.EncodeToString([]byte("user:pass"))
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Basic " + cred}}}
+	p := BasicAuth{}
+	t.Setenv("CREDS", "user:pass")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:CREDS"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+	id, ok := p.Identify(r, cfg)
+	if !ok || id != "user" {
+		t.Fatalf("unexpected id %s", id)
+	}
+}
+
 func TestBasicPluginOptionalParams(t *testing.T) {
 	in := BasicAuth{}
 	out := BasicAuthOut{}

--- a/app/authplugins/basic/incoming.go
+++ b/app/authplugins/basic/incoming.go
@@ -64,4 +64,25 @@ func (b *BasicAuth) Authenticate(r *http.Request, p interface{}) bool {
 	return false
 }
 
+func (b *BasicAuth) Identify(r *http.Request, p interface{}) (string, bool) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return "", false
+	}
+	header := r.Header.Get(cfg.Header)
+	if !strings.HasPrefix(header, cfg.Prefix) {
+		return "", false
+	}
+	enc := strings.TrimPrefix(header, cfg.Prefix)
+	dec, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return "", false
+	}
+	parts := strings.SplitN(string(dec), ":", 2)
+	if len(parts) != 2 || parts[0] == "" {
+		return "", false
+	}
+	return parts[0], true
+}
+
 func init() { authplugins.RegisterIncoming(&BasicAuth{}) }


### PR DESCRIPTION
## Summary
- parse the username as the caller ID for Basic auth
- document Basic auth identifier behavior
- return wildcard rules if present in allowlists

## Testing
- `go test ./...`
