### PR TITLE
Add identifier for Basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ array.
    - **jwt**: Validates generic JWTs using provided keys and can attach tokens on outgoing requests.
    - **mtls**: Requires a verified client certificate and optional subject match, and accepts outbound certificate configuration.
    - **token**: Header token comparison for simple shared secrets.
-   - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets.
+  - **basic**: Performs HTTP Basic authentication using credentials loaded from configured secrets. The username becomes the caller ID for allowlist checks.
    - **hmac_signature**: Computes or verifies request HMAC digests with a configurable algorithm.
    - **github_signature**: Validates GitHub webhook signatures against shared secrets.
    - **slack_signature**: Validates Slack request signatures with timestamp tolerance.

--- a/app/authplugins/basic/basic_test.go
+++ b/app/authplugins/basic/basic_test.go
@@ -35,6 +35,10 @@ func TestBasicIncomingAuth(t *testing.T) {
 	if !p.Authenticate(r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
+
+	if id, ok := p.Identify(r, cfg); !ok || id != "user" {
+		t.Fatalf("unexpected identifier %s", id)
+	}
 }
 
 func TestBasicIncomingAuthFail(t *testing.T) {

--- a/app/authplugins/basic/incoming.go
+++ b/app/authplugins/basic/incoming.go
@@ -68,4 +68,26 @@ func (b *BasicAuth) Authenticate(r *http.Request, p interface{}) bool {
 	return false
 }
 
+// Identify returns the username from the Basic auth header when present.
+func (b *BasicAuth) Identify(r *http.Request, p interface{}) (string, bool) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return "", false
+	}
+	header := r.Header.Get(cfg.Header)
+	if !strings.HasPrefix(header, cfg.Prefix) {
+		return "", false
+	}
+	enc := strings.TrimPrefix(header, cfg.Prefix)
+	dec, err := base64.StdEncoding.DecodeString(enc)
+	if err != nil {
+		return "", false
+	}
+	creds := string(dec)
+	if i := strings.IndexByte(creds, ':'); i > 0 {
+		return creds[:i], true
+	}
+	return "", false
+}
+
 func init() { authplugins.RegisterIncoming(&BasicAuth{}) }


### PR DESCRIPTION
## Summary
- derive the username as the caller ID for the basic auth plugin
- document that basic auth uses the username for allowlist checks

## Testing
- `go test ./...`
