### PR TITLE
Fix go vet unused variable

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -181,7 +181,6 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 	callers := allowlists.m[i.Name]
 	wildcard, hasWildcard := callers["*"]
 	c, ok := callers[callerID]
-	wildcard, wOK := callers["*"]
 	allowlists.RUnlock()
 
 	if ok {


### PR DESCRIPTION
## Summary
- remove an unused variable `wOK` in `findConstraint`
- ensure go vet and gofmt clean

## Testing
- `go vet ./...`
- `go test ./...`
