### PR TITLE
Add gofmt formatting check to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,5 +23,7 @@ jobs:
           else
             echo "golangci-lint not installed, skipping"
           fi
+      - name: Check formatting
+        run: test -z "$(gofmt -l .)"
       - name: Run tests
         run: go test ./...


### PR DESCRIPTION
## Summary
- verify all Go files are formatted before tests run

## Testing
- `go test ./...`
