### PR TITLE
Add CLI unit tests

### DIFF
--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -1,0 +1,109 @@
+package main
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/cmd/allowlist/plugins"
+)
+
+// helper to capture stdout from f
+func captureOutput(f func()) string {
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	old := os.Stdout
+	os.Stdout = w
+	f()
+	w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out)
+}
+
+func TestAddEntryNewFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.json")
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	addEntry([]string{"-integration", "foo", "-caller", "u1", "-capability", "cap"})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := json.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("failed to parse json: %v", err)
+	}
+	want := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers: []plugins.CallerConfig{
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap", Params: map[string]interface{}{}}}},
+			},
+		},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries mismatch:\n%v\nwant\n%v", entries, want)
+	}
+}
+
+func TestAddEntryUpdateExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.json")
+
+	initial := []plugins.AllowlistEntry{
+		{Integration: "foo", Callers: []plugins.CallerConfig{{ID: "u1"}}},
+	}
+	data, _ := json.MarshalIndent(initial, "", "    ")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	addEntry([]string{"-integration", "foo", "-caller", "u1", "-capability", "cap2", "-params", "k=v"})
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := json.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	want := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers:     []plugins.CallerConfig{{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap2", Params: map[string]interface{}{"k": "v"}}}}},
+		},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Fatalf("entries mismatch:\n%v\nwant\n%v", entries, want)
+	}
+}
+
+func TestListCapsOutput(t *testing.T) {
+	out := captureOutput(listCaps)
+	if !strings.Contains(out, "slack:") {
+		t.Fatalf("missing slack integration in output: %s", out)
+	}
+	if !strings.Contains(out, "post_public_as (params: username)") {
+		t.Fatalf("missing capability info: %s", out)
+	}
+	if !strings.Contains(out, "post_channels_as (params: username,channels)") {
+		t.Fatalf("missing capability info: %s", out)
+	}
+}

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -1,0 +1,46 @@
+package plugins
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuilders(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want Integration
+	}{
+		{"asana", []string{"-name", "a", "-token", "tok"}, Asana("a", "tok")},
+		{"github", []string{"-name", "gh", "-token", "tok", "-webhook-secret", "sec"}, GitHub("gh", "tok", "sec")},
+		{"ghe", []string{"-name", "ghe1", "-domain", "corp.example.com", "-token", "tok", "-webhook-secret", "sec"}, GitHubEnterprise("ghe1", "corp.example.com", "tok", "sec")},
+		{"gitlab", []string{"-name", "gl", "-token", "tok"}, GitLab("gl", "tok")},
+		{"jira", []string{"-name", "j1", "-token", "tok"}, Jira("j1", "tok")},
+		{"linear", []string{"-name", "lin", "-token", "tok"}, Linear("lin", "tok")},
+		{"monday", []string{"-name", "mon", "-token", "tok"}, Monday("mon", "tok")},
+		{"okta", []string{"-name", "ok", "-domain", "okta.example.com", "-token", "tok"}, Okta("ok", "okta.example.com", "tok")},
+		{"sendgrid", []string{"-name", "sg", "-token", "tok"}, SendGrid("sg", "tok")},
+		{"servicenow", []string{"-name", "sn", "-token", "tok"}, ServiceNow("sn", "tok")},
+		{"slack", []string{"-name", "sl", "-token", "tok", "-signing-secret", "sec"}, Slack("sl", "tok", "sec")},
+		{"stripe", []string{"-name", "st", "-token", "tok"}, Stripe("st", "tok")},
+		{"twilio", []string{"-name", "tw", "-token", "tok"}, Twilio("tw", "tok")},
+		{"workday", []string{"-name", "wd", "-domain", "work.example.com", "-token", "tok"}, Workday("wd", "work.example.com", "tok")},
+		{"zendesk", []string{"-name", "zd", "-token", "tok"}, Zendesk("zd", "tok")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := Get(tt.name)
+			if b == nil {
+				t.Fatalf("builder %s not registered", tt.name)
+			}
+			got, err := b(tt.args)
+			if err != nil {
+				t.Fatalf("builder returned error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("builder %s output mismatch\n got: %#v\nwant: %#v", tt.name, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- add `allowlist` command tests for add command updates and capability list
- add tests ensuring integration plugin builders parse flags correctly

## Testing
- `go test ./...`
