### PR TITLE
Split incoming auth plugins

### DIFF
--- a/app/authplugins/github_signature/incoming.go
+++ b/app/authplugins/github_signature/incoming.go
@@ -1,4 +1,4 @@
-package incoming
+package githubsignature
 
 import (
 	"crypto/hmac"

--- a/app/authplugins/slack_signature/incoming.go
+++ b/app/authplugins/slack_signature/incoming.go
@@ -1,4 +1,4 @@
-package incoming
+package slacksignature
 
 import (
 	"crypto/hmac"


### PR DESCRIPTION
## Summary
- split the `incoming` auth plugin folder into two
- add `github_signature` plugin directory
- add `slack_signature` plugin directory

## Testing
- `go vet ./...`
- `go test ./...`
