### PR TITLE
Normalize host matching

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -145,6 +145,7 @@ var nameRegexp = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
 
 // AddIntegration validates and stores a new integration.
 func AddIntegration(i *Integration) error {
+	i.Name = strings.ToLower(i.Name)
 	if !nameRegexp.MatchString(i.Name) {
 		return errors.New("invalid integration name")
 	}
@@ -218,7 +219,7 @@ func AddIntegration(i *Integration) error {
 // GetIntegration retrieves an integration by name.
 func GetIntegration(name string) (*Integration, bool) {
 	integrations.RLock()
-	i, ok := integrations.m[name]
+	i, ok := integrations.m[strings.ToLower(name)]
 	integrations.RUnlock()
 	return i, ok
 }

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -99,3 +99,26 @@ func TestAddIntegrationDuplicateName(t *testing.T) {
 		t.Fatal("expected error for duplicate name")
 	}
 }
+
+func TestGetIntegrationCaseInsensitive(t *testing.T) {
+	i := &Integration{
+		Name:         "MiXeD",
+		Destination:  "http://example.com",
+		InRateLimit:  1,
+		OutRateLimit: 1,
+	}
+	if err := AddIntegration(i); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	t.Cleanup(func() {
+		i.inLimiter.Stop()
+		i.outLimiter.Stop()
+	})
+
+	if _, ok := GetIntegration("mixed"); !ok {
+		t.Fatal("lookup by lowercase failed")
+	}
+	if _, ok := GetIntegration("MIXED"); !ok {
+		t.Fatal("lookup by uppercase failed")
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -178,8 +178,9 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			host = hdr
 		}
 	}
+	hostLookup := strings.ToLower(host)
 	log.Printf("Incoming %s request for %s%s from %s", r.Method, host, r.URL.Path, r.RemoteAddr)
-	integ, ok := GetIntegration(host)
+	integ, ok := GetIntegration(hostLookup)
 	if !ok {
 		log.Printf("No integration configured for host %s", host)
 		http.Error(w, "Not Found", http.StatusNotFound)


### PR DESCRIPTION
## Summary
- convert integration names to lowercase before storing
- use lowercase lookups in `GetIntegration` and `proxyHandler`
- add tests for case-insensitive host handling

## Testing
- `go test ./...`
