### PR TITLE
Add non-root user to runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,13 @@ RUN go build -o authtranslator ./app
 
 # Runtime stage
 FROM alpine:3.19
+# create non-root group and user for running the application
+RUN addgroup -S app && adduser -S -G app app
 WORKDIR /app
 COPY --from=build /src/authtranslator .
 COPY app/config.json ./config.json
+# ensure the runtime directory is owned by the app user
+RUN chown -R app:app /app
+USER app
 EXPOSE 8080
 CMD ["./authtranslator"]


### PR DESCRIPTION
## Summary
- add a non-root `app` user/group in Docker runtime stage
- ensure `/app` is owned by that user
- switch to `USER app` for execution

## Testing
- `go test ./...`