### PR TITLE
Add Confluence integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,9 +196,9 @@ Integration plugins can bundle common allowlist rules into **capabilities**. Ass
 - `github.update_issue` – allow editing or closing issues in a given repository.
 - `ghe.comment`, `ghe.create_issue`, `ghe.update_issue` – GitHub Enterprise equivalents requiring the `repo` parameter.
 - `gitlab.comment`, `gitlab.create_issue`, `gitlab.update_issue` – similar capabilities for GitLab projects (use the `project` parameter).
-- `asana.create_task`, `linear.create_task`, `jira.create_task` – permit creating tasks or issues.
-- `asana.update_status`, `linear.update_status`, `jira.update_status` – allow modifying task or issue status.
-- `asana.add_comment`, `linear.add_comment`, `jira.add_comment` – permit adding comments.
+- `asana.create_task`, `linear.create_task`, `jira.create_task`, `confluence.create_page` – permit creating tasks, issues or pages.
+- `asana.update_status`, `linear.update_status`, `jira.update_status`, `confluence.update_page` – allow editing tasks, issues or pages.
+- `asana.add_comment`, `linear.add_comment`, `jira.add_comment`, `confluence.add_comment` – permit adding comments.
 - `zendesk.open_ticket`, `servicenow.open_ticket` – allow creating support tickets.
 - `zendesk.update_ticket`, `servicenow.update_ticket` – permit updating ticket details.
 - `zendesk.query_status`, `servicenow.query_status` – allow reading ticket status.
@@ -305,7 +305,7 @@ List existing integrations:
 go run ./cmd/integrations list
 ```
 
-A helper CLI is available under `cmd/integrations` to create Slack, GitHub, GitHub Enterprise, GitLab, Jira, Linear, Asana, Zendesk, ServiceNow, SendGrid, Twilio or Stripe integrations with minimal flags.
+A helper CLI is available under `cmd/integrations` to create Slack, GitHub, GitHub Enterprise, GitLab, Jira, Confluence, Linear, Asana, Zendesk, ServiceNow, SendGrid, Twilio or Stripe integrations with minimal flags.
 
 Add Slack:
 ```bash
@@ -331,6 +331,10 @@ go run ./cmd/integrations -server http://localhost:8080/integrations \
 Add Jira:
 ```bash
 go run ./cmd/integrations jira -token env:JIRA_TOKEN
+```
+Add Confluence:
+```bash
+go run ./cmd/integrations confluence -token env:CONFLUENCE_TOKEN
 ```
 Add Linear:
 ```bash

--- a/app/integrationplugins/confluence/capabilities.go
+++ b/app/integrationplugins/confluence/capabilities.go
@@ -1,0 +1,26 @@
+package confluence
+
+import integrationplugins "github.com/winhowes/AuthTranslator/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("confluence", "create_page", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/wiki/api/v2/pages", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("confluence", "update_page", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/wiki/api/v2/pages/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("confluence", "add_comment", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/wiki/api/v2/pages/*/comment", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrationplugins/confluence/confluence_test.go
+++ b/app/integrationplugins/confluence/confluence_test.go
@@ -1,0 +1,46 @@
+package confluence_test
+
+import (
+	"testing"
+
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrationplugins"
+	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/confluence"
+)
+
+func TestConfluenceCapabilities(t *testing.T) {
+	caps := integrationplugins.CapabilitiesFor("confluence")
+	if len(caps) != 3 {
+		t.Fatalf("expected 3 capabilities, got %d", len(caps))
+	}
+
+	tests := []struct {
+		name     string
+		wantPath string
+		method   string
+	}{
+		{"create_page", "/wiki/api/v2/pages", "POST"},
+		{"update_page", "/wiki/api/v2/pages/*", "PUT"},
+		{"add_comment", "/wiki/api/v2/pages/*/comment", "POST"},
+	}
+
+	for _, tt := range tests {
+		spec, ok := caps[tt.name]
+		if !ok {
+			t.Fatalf("capability %s not registered", tt.name)
+		}
+		rules, err := spec.Generate(nil)
+		if err != nil {
+			t.Fatalf("generate failed: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("expected 1 rule for %s", tt.name)
+		}
+		r := rules[0]
+		if r.Path != tt.wantPath {
+			t.Errorf("%s path mismatch: %s", tt.name, r.Path)
+		}
+		if _, ok := r.Methods[tt.method]; !ok {
+			t.Errorf("%s missing method %s", tt.name, tt.method)
+		}
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/google_oidc"
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/token"
 	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/asana"
+	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/confluence"
 	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/ghe"
 	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/github"
 	_ "github.com/winhowes/AuthTranslator/app/integrationplugins/gitlab"

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -16,6 +16,7 @@ func TestBuilders(t *testing.T) {
 		{"ghe", []string{"-name", "ghe1", "-domain", "corp.example.com", "-token", "tok", "-webhook-secret", "sec"}, GitHubEnterprise("ghe1", "corp.example.com", "tok", "sec")},
 		{"gitlab", []string{"-name", "gl", "-token", "tok"}, GitLab("gl", "tok")},
 		{"jira", []string{"-name", "j1", "-token", "tok"}, Jira("j1", "tok")},
+		{"confluence", []string{"-name", "c1", "-token", "tok"}, Confluence("c1", "tok")},
 		{"linear", []string{"-name", "lin", "-token", "tok"}, Linear("lin", "tok")},
 		{"monday", []string{"-name", "mon", "-token", "tok"}, Monday("mon", "tok")},
 		{"okta", []string{"-name", "ok", "-domain", "okta.example.com", "-token", "tok"}, Okta("ok", "okta.example.com", "tok")},

--- a/cmd/integrations/plugins/confluence.go
+++ b/cmd/integrations/plugins/confluence.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Confluence returns an Integration configured for the Confluence API.
+func Confluence(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.atlassian.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}
+
+func init() { Register("confluence", confluenceBuilder) }
+
+func confluenceBuilder(args []string) (Integration, error) {
+	fs := flag.NewFlagSet("confluence", flag.ContinueOnError)
+	name := fs.String("name", "confluence", "integration name")
+	token := fs.String("token", "", "secret reference for API token")
+	if err := fs.Parse(args); err != nil {
+		return Integration{}, err
+	}
+	if *token == "" {
+		return Integration{}, fmt.Errorf("-token is required")
+	}
+	return Confluence(*name, *token), nil
+}


### PR DESCRIPTION
## Summary
- add a Confluence integration plugin with capabilities and tests
- expose the Confluence plugin through main
- add CLI builder for Confluence
- document Confluence integration in README

## Testing
- `go vet ./...`
- `go test ./...`
