### PR TITLE
Support unlimited rate limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Reverse Proxy**: Forwards incoming HTTP requests to a target backend based on the requested host or `X-AT-Int` header. The header can be disabled or restricted to a specific host using command-line flags.
 - **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls`, `url_path`, `github_signature` and `slack_signature` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
-- **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window.
+- **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window. A value of `0` disables limiting.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 - **Clean Shutdown**: On SIGINT or SIGTERM the server and rate limiters are gracefully stopped.
@@ -67,6 +67,8 @@ The project exists to make it trivial to translate one type of authentication in
      ]
    }
    ```
+
+   Use `0` (or a negative number) for `in_rate_limit` or `out_rate_limit` to disable rate limiting for that direction.
 
    The allowlist configuration lives in a separate `allowlist.json` file:
 

--- a/app/main.go
+++ b/app/main.go
@@ -124,36 +124,45 @@ type RateLimiter struct {
 
 func NewRateLimiter(limit int, duration time.Duration) *RateLimiter {
 	rl := &RateLimiter{
-		limit:       limit,
-		duration:    duration,
-		requests:    make(map[string]int),
-		resetTicker: time.NewTicker(duration),
-		done:        make(chan struct{}),
+		limit:    limit,
+		duration: duration,
+		requests: make(map[string]int),
+		done:     make(chan struct{}),
 	}
 
-	go func() {
-		for {
-			select {
-			case <-rl.resetTicker.C:
-				rl.mu.Lock()
-				rl.requests = make(map[string]int)
-				rl.mu.Unlock()
-			case <-rl.done:
-				return
+	if limit > 0 {
+		rl.resetTicker = time.NewTicker(duration)
+
+		go func() {
+			for {
+				select {
+				case <-rl.resetTicker.C:
+					rl.mu.Lock()
+					rl.requests = make(map[string]int)
+					rl.mu.Unlock()
+				case <-rl.done:
+					return
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	return rl
 }
 
 // Stop stops the rate limiter's reset goroutine and ticker.
 func (rl *RateLimiter) Stop() {
-	rl.resetTicker.Stop()
+	if rl.resetTicker != nil {
+		rl.resetTicker.Stop()
+	}
 	close(rl.done)
 }
 
 func (rl *RateLimiter) Allow(key string) bool {
+	if rl.limit <= 0 {
+		return true
+	}
+
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
 

--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -40,3 +40,27 @@ func TestRateLimiterReset(t *testing.T) {
 		t.Fatal("rate limiter should reset after duration")
 	}
 }
+
+func TestRateLimiterUnlimited(t *testing.T) {
+	rl := NewRateLimiter(0, time.Hour)
+	t.Cleanup(rl.Stop)
+	key := "caller"
+
+	for i := 0; i < 100; i++ {
+		if !rl.Allow(key) {
+			t.Fatalf("call %d should be allowed", i)
+		}
+	}
+}
+
+func TestRateLimiterUnlimitedNegative(t *testing.T) {
+	rl := NewRateLimiter(-1, time.Hour)
+	t.Cleanup(rl.Stop)
+	key := "caller"
+
+	for i := 0; i < 100; i++ {
+		if !rl.Allow(key) {
+			t.Fatalf("call %d should be allowed", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- allow rate limits of 0 or negative to mean "unlimited"
- test unlimited rate limiter behaviour
- document how to disable limits in README

## Testing
- `go test ./...`