### PR TITLE
Enforce TLS flag pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The project exists to make it trivial to translate one type of authentication in
    ```
 
    Run `go run ./app --help` to see all available flags.
-   Provide `-tls-cert` and `-tls-key` to serve HTTPS using the specified
-   certificate and key.
+   Provide `-tls-cert` and `-tls-key` together to serve HTTPS using the
+   specified certificate and key. Supplying only one of these options
+   results in an error.
    
    Or build an executable:
    

--- a/app/main.go
+++ b/app/main.go
@@ -287,10 +287,14 @@ type server interface {
 }
 
 func serve(s server, cert, key string) error {
-	if cert != "" && key != "" {
+	switch {
+	case cert != "" && key != "":
 		return s.ListenAndServeTLS(cert, key)
+	case cert == "" && key == "":
+		return s.ListenAndServe()
+	default:
+		return fmt.Errorf("both cert and key must be provided")
 	}
-	return s.ListenAndServe()
 }
 
 func main() {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -55,3 +55,22 @@ func TestServeUsesTLS(t *testing.T) {
 		t.Fatal("expected ListenAndServeTLS to be called")
 	}
 }
+
+func TestServeMissingTLSArgs(t *testing.T) {
+	cases := []struct {
+		cert string
+		key  string
+	}{
+		{cert: "c", key: ""},
+		{cert: "", key: "k"},
+	}
+	for i, tc := range cases {
+		srv := &stubServer{}
+		if err := serve(srv, tc.cert, tc.key); err == nil {
+			t.Fatalf("case %d: expected error", i)
+		}
+		if srv.tls {
+			t.Fatalf("case %d: unexpected TLS start", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- error if only one of `-tls-cert` or `-tls-key` is provided
- document that the TLS certificate and key must be provided together
- test missing TLS flag combinations

## Testing
- `go test ./...`