### PR TITLE
Add trufflehog integration plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ Integration plugins can bundle common allowlist rules into **capabilities**. Ass
 - `twilio.send_sms`, `twilio.make_call`, `twilio.query_message` – Twilio messaging and voice APIs.
 - `okta.create_user`, `okta.update_user`, `okta.deactivate_user` – manage Okta user accounts.
 - `stripe.create_charge`, `stripe.refund_charge`, `stripe.create_customer` – Stripe payment flows.
+- `trufflehog.start_scan`, `trufflehog.get_results`, `trufflehog.list_scans` – scan management operations.
 
 ### Secret Plugin Environment Variables
 
@@ -308,7 +309,7 @@ List existing integrations:
 go run ./cmd/integrations list
 ```
 
-A helper CLI is available under `cmd/integrations` to create Slack, GitHub, GitHub Enterprise, GitLab, Jira, Confluence, Linear, Asana, Zendesk, ServiceNow, SendGrid, Twilio or Stripe integrations with minimal flags.
+A helper CLI is available under `cmd/integrations` to create Slack, GitHub, GitHub Enterprise, GitLab, Jira, Confluence, Linear, Asana, Zendesk, ServiceNow, SendGrid, TruffleHog, Twilio or Stripe integrations with minimal flags.
 
 Add Slack:
 ```bash
@@ -362,6 +363,10 @@ go run ./cmd/integrations servicenow -token env:SERVICENOW_TOKEN
 Add SendGrid:
 ```bash
 go run ./cmd/integrations sendgrid -token env:SENDGRID_TOKEN
+```
+Add TruffleHog:
+```bash
+go run ./cmd/integrations trufflehog -token env:TRUFFLEHOG_TOKEN
 ```
 Add Twilio:
 ```bash

--- a/app/integrationplugins/trufflehog/capabilities.go
+++ b/app/integrationplugins/trufflehog/capabilities.go
@@ -1,0 +1,26 @@
+package trufflehog
+
+import integrationplugins "github.com/winhowes/AuthTranslator/app/integrationplugins"
+
+func init() {
+	integrationplugins.RegisterCapability("trufflehog", "start_scan", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/scan", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("trufflehog", "get_results", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/results/*", Methods: map[string]integrationplugins.RequestConstraint{"GET": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("trufflehog", "list_scans", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v1/scans", Methods: map[string]integrationplugins.RequestConstraint{"GET": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -21,6 +21,7 @@ func TestBuilders(t *testing.T) {
 		{"monday", []string{"-name", "mon", "-token", "tok"}, Monday("mon", "tok")},
 		{"okta", []string{"-name", "ok", "-domain", "okta.example.com", "-token", "tok"}, Okta("ok", "okta.example.com", "tok")},
 		{"sendgrid", []string{"-name", "sg", "-token", "tok"}, SendGrid("sg", "tok")},
+		{"trufflehog", []string{"-name", "th", "-token", "tok"}, TruffleHog("th", "tok")},
 		{"servicenow", []string{"-name", "sn", "-token", "tok"}, ServiceNow("sn", "tok")},
 		{"slack", []string{"-name", "sl", "-token", "tok", "-signing-secret", "sec"}, Slack("sl", "tok", "sec")},
 		{"stripe", []string{"-name", "st", "-token", "tok"}, Stripe("st", "tok")},

--- a/cmd/integrations/plugins/trufflehog.go
+++ b/cmd/integrations/plugins/trufflehog.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"flag"
+	"fmt"
+)
+
+// TruffleHog returns an Integration configured for the TruffleHog API.
+func TruffleHog(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://trufflehog.cloud/api",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Bearer ",
+			},
+		}},
+	}
+}
+
+func init() { Register("trufflehog", trufflehogBuilder) }
+
+func trufflehogBuilder(args []string) (Integration, error) {
+	fs := flag.NewFlagSet("trufflehog", flag.ContinueOnError)
+	name := fs.String("name", "trufflehog", "integration name")
+	token := fs.String("token", "", "secret reference for API token")
+	if err := fs.Parse(args); err != nil {
+		return Integration{}, err
+	}
+	if *token == "" {
+		return Integration{}, fmt.Errorf("-token is required")
+	}
+	return TruffleHog(*name, *token), nil
+}


### PR DESCRIPTION
## Summary
- add `trufflehog` integration plugin and capabilities
- expose a CLI builder for creating trufflehog integrations
- document trufflehog integration and capability usage
- test plugin builder output

## Testing
- `go vet ./...`
- `go test ./...`
