### PR TITLE
Add tests for parse utilities and auth plugin registry

### DIFF
--- a/app/authplugins/parseutil_test.go
+++ b/app/authplugins/parseutil_test.go
@@ -1,0 +1,34 @@
+package authplugins
+
+import "testing"
+
+// sample struct for parsing
+type sampleParams struct {
+	A string `json:"a"`
+	B int    `json:"b"`
+}
+
+func TestParseParamsSuccess(t *testing.T) {
+	m := map[string]interface{}{"a": "foo", "b": 2}
+	cfg, err := ParseParams[sampleParams](m)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.A != "foo" || cfg.B != 2 {
+		t.Fatalf("unexpected result: %#v", cfg)
+	}
+}
+
+func TestParseParamsUnknownField(t *testing.T) {
+	m := map[string]interface{}{"a": "foo", "b": 2, "c": true}
+	if _, err := ParseParams[sampleParams](m); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestParseParamsTypeMismatch(t *testing.T) {
+	m := map[string]interface{}{"a": "foo", "b": "bad"}
+	if _, err := ParseParams[sampleParams](m); err == nil {
+		t.Fatal("expected type error")
+	}
+}

--- a/app/authplugins/registry_test.go
+++ b/app/authplugins/registry_test.go
@@ -1,0 +1,55 @@
+package authplugins
+
+import "testing"
+import "net/http"
+
+// minimal incoming plugin
+type testIncoming struct{ name string }
+
+func (p testIncoming) Name() string                                          { return p.name }
+func (testIncoming) ParseParams(map[string]interface{}) (interface{}, error) { return nil, nil }
+func (testIncoming) Authenticate(*http.Request, interface{}) bool            { return true }
+func (testIncoming) RequiredParams() []string                                { return nil }
+func (testIncoming) OptionalParams() []string                                { return nil }
+
+// minimal outgoing plugin
+type testOutgoing struct{ name string }
+
+func (p testOutgoing) Name() string                                          { return p.name }
+func (testOutgoing) ParseParams(map[string]interface{}) (interface{}, error) { return nil, nil }
+func (testOutgoing) AddAuth(*http.Request, interface{})                      {}
+func (testOutgoing) RequiredParams() []string                                { return nil }
+func (testOutgoing) OptionalParams() []string                                { return nil }
+
+func TestRegistryIncomingOutgoing(t *testing.T) {
+	// Save original registries and restore after test
+	inOrig := incomingRegistry
+	outOrig := outgoingRegistry
+	t.Cleanup(func() {
+		incomingRegistry = inOrig
+		outgoingRegistry = outOrig
+	})
+
+	// reset registries
+	incomingRegistry = map[string]IncomingAuthPlugin{}
+	outgoingRegistry = map[string]OutgoingAuthPlugin{}
+
+	in := testIncoming{name: "in"}
+	out := testOutgoing{name: "out"}
+
+	RegisterIncoming(in)
+	RegisterOutgoing(out)
+
+	if got := GetIncoming("in"); got == nil {
+		t.Fatal("expected incoming plugin returned")
+	}
+	if got := GetOutgoing("out"); got == nil {
+		t.Fatal("expected outgoing plugin returned")
+	}
+	if GetIncoming("missing") != nil {
+		t.Fatal("expected nil for unknown incoming plugin")
+	}
+	if GetOutgoing("missing") != nil {
+		t.Fatal("expected nil for unknown outgoing plugin")
+	}
+}


### PR DESCRIPTION
## Summary
- add coverage for ParseParams utility
- test registration and lookup in auth plugin registry

## Testing
- `go vet ./...`
- `test -z "$(gofmt -l .)"`
- `go test ./...`
