### PR TITLE
Fix README getting started order

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,53 @@ The project exists to make it trivial to translate one type of authentication in
    ]
    ```
 
+3. **Running**
+
+   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`.
+
+4. **Run Locally**
+
+   Start a simple backend and point an integration at it to test the proxy:
+
+   ```bash
+   # terminal 1 - dummy backend
+   python3 -m http.server 9000
+   ```
+
+   Edit `app/config.json` so the integration forwards to the local backend:
+
+   ```json
+   {
+       "integrations": [
+           {
+               "name": "example",
+               "destination": "http://localhost:9000",
+               "in_rate_limit": 100,
+               "out_rate_limit": 1000,
+               "incoming_auth": [
+                   {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
+               ],
+               "outgoing_auth": [
+                   {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
+               ]
+           }
+       ]
+   }
+   ```
+
+   Provide the environment variables referenced by the auth configuration and start the proxy:
+
+   ```bash
+   export IN_TOKEN=secret-in
+   export OUT_TOKEN=secret-out
+   go run ./app -config app/config.json -allowlist app/allowlist.json
+   ```
+
+   In another terminal, call the proxy using the integration name as the Host header:
+
+   ```bash
+   curl -H "Host: example" -H "X-Auth: $IN_TOKEN" http://localhost:8080/
+   ```
 ### Allowlist Rules
 
 Each caller entry lists path patterns and method constraints. `*` matches a
@@ -242,54 +289,6 @@ Integration plugins live under `cmd/integrations/plugins`. Each plugin registers
 itself in an `init()` block using `plugins.Register`. The `Register` call
 associates the plugin name with a function that parses CLI flags and returns an
 `Integration` struct, so the CLI automatically recognizes new plugins.
-
-3. **Running**
-
-   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`.
-
-4. **Run Locally**
-
-   Start a simple backend and point an integration at it to test the proxy:
-
-   ```bash
-   # terminal 1 - dummy backend
-   python3 -m http.server 9000
-   ```
-
-   Edit `app/config.json` so the integration forwards to the local backend:
-
-   ```json
-   {
-       "integrations": [
-           {
-               "name": "example",
-               "destination": "http://localhost:9000",
-               "in_rate_limit": 100,
-               "out_rate_limit": 1000,
-               "incoming_auth": [
-                   {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
-               ],
-               "outgoing_auth": [
-                   {"type": "token", "params": {"secrets": ["env:OUT_TOKEN"], "header": "X-Auth"}}
-               ]
-           }
-       ]
-   }
-   ```
-
-   Provide the environment variables referenced by the auth configuration and start the proxy:
-
-   ```bash
-   export IN_TOKEN=secret-in
-   export OUT_TOKEN=secret-out
-   go run ./app -config app/config.json -allowlist app/allowlist.json
-   ```
-
-   In another terminal, call the proxy using the integration name as the Host header:
-
-   ```bash
-   curl -H "Host: example" -H "X-Auth: $IN_TOKEN" http://localhost:8080/
-   ```
 
 ## Integration CLI
 


### PR DESCRIPTION
## Summary
- keep the numbered instructions together in the Getting Started section
- move the "Running" and "Run Locally" steps before the allowlist details

## Testing
- `go vet ./...`
- `go test ./...`
