### PR TITLE
Add Vault secret plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Integration plugins can bundle common allowlist rules into **capabilities**. Ass
 | `aws`  | `AWS_KMS_KEY` | Base64 encoded 32 byte key used for decrypting `aws:` secrets. |
 | `azure`| `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` | Credentials for fetching `azure:` secrets from Key Vault. |
 | `gcp`  | _none_ | Uses the GCP metadata service for authentication when resolving `gcp:` secrets. |
+| `vault`| `VAULT_ADDR`, `VAULT_TOKEN` | Fetches secrets from HashiCorp Vault via the HTTP API. |
 
 ### Writing Plugins
 

--- a/app/secrets/plugins/plugins.go
+++ b/app/secrets/plugins/plugins.go
@@ -6,4 +6,5 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/env"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/file"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/gcp"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/vault"
 )

--- a/app/secrets/plugins/vault/plugin.go
+++ b/app/secrets/plugins/vault/plugin.go
@@ -1,0 +1,73 @@
+package plugins
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/winhowes/AuthTranslator/app/secrets"
+)
+
+// vaultPlugin fetches secrets from HashiCorp Vault using the HTTP API.
+// The identifier should be the path to the secret within Vault, e.g.
+// "secret/data/myapp" for KVv2.
+// It requires the VAULT_ADDR and VAULT_TOKEN environment variables.
+type vaultPlugin struct{}
+
+// HTTPClient is used for requests to Vault and can be overridden in tests.
+var HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+func (vaultPlugin) Prefix() string { return "vault" }
+
+func (vaultPlugin) Load(id string) (string, error) {
+	addr := os.Getenv("VAULT_ADDR")
+	token := os.Getenv("VAULT_TOKEN")
+	if addr == "" || token == "" {
+		return "", errors.New("missing vault configuration")
+	}
+
+	base, err := url.Parse(addr)
+	if err != nil {
+		return "", fmt.Errorf("invalid VAULT_ADDR: %w", err)
+	}
+	path := strings.TrimLeft(id, "/")
+	base.Path = "/v1/" + path
+	req, err := http.NewRequest("GET", base.String(), nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("X-Vault-Token", token)
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("vault request failed: %s", resp.Status)
+	}
+
+	var out struct {
+		Data struct {
+			Value string            `json:"value"`
+			Data  map[string]string `json:"data"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+
+	if out.Data.Value != "" {
+		return out.Data.Value, nil
+	}
+	if val, ok := out.Data.Data["value"]; ok {
+		return val, nil
+	}
+	return "", errors.New("secret value missing")
+}
+
+func init() { secrets.Register(vaultPlugin{}) }

--- a/app/secrets/plugins/vault/plugin_test.go
+++ b/app/secrets/plugins/vault/plugin_test.go
@@ -1,0 +1,82 @@
+package plugins
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+type vaultRewriteTransport struct {
+	rt     http.RoundTripper
+	scheme string
+	host   string
+}
+
+func (t *vaultRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = t.scheme
+	req.URL.Host = t.host
+	return t.rt.RoundTrip(req)
+}
+
+func setVaultTestClient(ts *httptest.Server) func() {
+	oldDef := http.DefaultClient
+	old := HTTPClient
+	u, _ := url.Parse(ts.URL)
+	c := &http.Client{Transport: &vaultRewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
+	http.DefaultClient = c
+	HTTPClient = c
+	return func() {
+		http.DefaultClient = oldDef
+		HTTPClient = old
+	}
+}
+
+func TestVaultLoad(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Vault-Token") != "tok" {
+			t.Errorf("missing auth header")
+		}
+		fmt.Fprint(w, `{"data":{"data":{"value":"secret"}}}`)
+	}))
+	defer ts.Close()
+	restore := setVaultTestClient(ts)
+	defer restore()
+
+	t.Setenv("VAULT_ADDR", "https://vault.example.com")
+	t.Setenv("VAULT_TOKEN", "tok")
+
+	p := vaultPlugin{}
+	got, err := p.Load("secret/data/foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "secret" {
+		t.Fatalf("expected secret, got %s", got)
+	}
+}
+
+func TestVaultLoadError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "fail", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+	restore := setVaultTestClient(ts)
+	defer restore()
+
+	t.Setenv("VAULT_ADDR", "https://vault.example.com")
+	t.Setenv("VAULT_TOKEN", "tok")
+
+	p := vaultPlugin{}
+	if _, err := p.Load("secret/data/foo"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestVaultLoadMissingConfig(t *testing.T) {
+	p := vaultPlugin{}
+	if _, err := p.Load("secret/data/foo"); err == nil {
+		t.Fatal("expected error when config missing")
+	}
+}


### PR DESCRIPTION
## Summary
- add new `vault` secret plugin for HashiCorp Vault
- register plugin
- document required environment variables
- tests for the vault plugin

## Testing
- `go test ./...`