### PR TITLE
Fix allowlist CLI exit codes

### DIFF
--- a/cmd/allowlist/main.go
+++ b/cmd/allowlist/main.go
@@ -23,6 +23,7 @@ func main() {
 	flag.Parse()
 	if flag.NArg() < 1 {
 		usage()
+		os.Exit(1)
 	}
 	switch flag.Arg(0) {
 	case "list":
@@ -31,6 +32,7 @@ func main() {
 		addEntry(flag.Args()[1:])
 	default:
 		usage()
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
## Summary
- ensure the `allowlist` command exits with a non-zero status on usage errors

## Testing
- `go vet ./...`
- `go test ./...`