### PR TITLE
Add validation, metrics and docs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,25 @@
+name: Docker Image
+
+on:
+  push:
+    tags: [ 'v*.*.*' ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t ghcr.io/winhowes/authtranslator:$GITHUB_REF_NAME .
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Push
+        run: docker push ghcr.io/winhowes/authtranslator:$GITHUB_REF_NAME

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Redis Support**: Provide `-redis-addr` to use Redis for rate limit counters instead of in-memory tracking. If Redis is unavailable the limiter falls back to memory and logs an error.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
+- **Validated Startup**: The configuration is checked at startup and errors are reported before serving traffic.
 - **Clean Shutdown**: On SIGINT or SIGTERM the server and rate limiters are gracefully stopped.
 - **Hot Reload**: Send `SIGHUP` to reload the configuration and allowlist without restarting.
 
@@ -284,6 +285,7 @@ New functionality can be added without modifying the core server. There are thre
 `IncomingAuthPlugin` or `OutgoingAuthPlugin` interface and call the appropriate
 `authplugins.RegisterIncoming` or `authplugins.RegisterOutgoing` function in an
 `init()` block.
+See `app/authplugins/example` for a minimal template.
 
 **Secret plugins** implement the `secrets.Plugin` interface in
 subdirectories of `app/secrets/plugins` and register themselves with
@@ -446,6 +448,12 @@ Build the container image:
 docker build -t authtranslator .
 ```
 
+Prebuilt images are also published to GitHub Container Registry:
+
+```bash
+docker pull ghcr.io/winhowes/authtranslator:latest
+```
+
 Run the image exposing port 8080:
 
 ```bash
@@ -459,6 +467,7 @@ AuthTranslator writes log messages to standard output using Go's `log/slog` pack
 ## Health Checks and Metrics
 
 AuthTranslator exposes a readiness endpoint at `/healthz` which returns HTTP `200` when the server is running.
+The response includes an `X-Last-Reload` header indicating the last time configuration was reloaded.
 
 Metrics are available at `/metrics` using the Prometheus text format. The following metrics are exported:
 
@@ -478,6 +487,8 @@ scrape_configs:
 ## Deploying with Terraform
 
 Example Terraform files are provided in the `terraform` directory for AWS, GCP and Azure.
+
+- `terraform/quickstart` provides a minimal example using the Docker provider to run a local container.
 
 - `terraform/aws` contains the AWS configuration for ECS Fargate.
 - `terraform/gcp` contains a configuration for deploying to Google Cloud Run.

--- a/app/authplugins/example/README.md
+++ b/app/authplugins/example/README.md
@@ -1,0 +1,5 @@
+# Example Plugin
+
+This directory contains a minimal authentication plugin illustrating how to
+implement the interfaces required by AuthTranslator. It is excluded from normal
+builds with a `//go:build example` tag so it can serve purely as a reference.

--- a/app/authplugins/example/example.go
+++ b/app/authplugins/example/example.go
@@ -1,0 +1,18 @@
+//go:build example
+
+package example
+
+import (
+	"github.com/winhowes/AuthTranslator/app/authplugins"
+	"net/http"
+)
+
+// Incoming example plugin that allows all requests.
+type incoming struct{}
+
+func (incoming) RequiredParams() []string                                    { return nil }
+func (incoming) OptionalParams() []string                                    { return nil }
+func (incoming) ParseParams(map[string]interface{}) (interface{}, error)     { return struct{}{}, nil }
+func (incoming) Authenticate(_ interface{}, _ *http.Request) (string, error) { return "", nil }
+
+func init() { authplugins.RegisterIncoming("example", incoming{}) }

--- a/app/config_validate.go
+++ b/app/config_validate.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"time"
+)
+
+// validateConfig ensures the Config contains sane values before use.
+func validateConfig(c *Config) error {
+	for idx := range c.Integrations {
+		i := &c.Integrations[idx]
+		if i.Name == "" {
+			return fmt.Errorf("integration at index %d missing name", idx)
+		}
+		if i.Destination == "" {
+			return fmt.Errorf("integration %s missing destination", i.Name)
+		}
+		if i.RateLimitWindow != "" {
+			d, err := time.ParseDuration(i.RateLimitWindow)
+			if err != nil || d <= 0 {
+				return fmt.Errorf("integration %s has invalid rate_limit_window", i.Name)
+			}
+		}
+	}
+	return nil
+}

--- a/app/config_validate_test.go
+++ b/app/config_validate_test.go
@@ -1,0 +1,15 @@
+package main
+
+import "testing"
+
+func TestValidateConfig(t *testing.T) {
+	good := Config{Integrations: []Integration{{Name: "a", Destination: "http://ex"}}}
+	if err := validateConfig(&good); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	bad := Config{Integrations: []Integration{{Destination: "http://ex"}}}
+	if err := validateConfig(&bad); err == nil {
+		t.Fatalf("expected error for missing name")
+	}
+}

--- a/app/healthz_test.go
+++ b/app/healthz_test.go
@@ -13,4 +13,7 @@ func TestHealthz(t *testing.T) {
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
+	if rr.Header().Get("X-Last-Reload") == "" {
+		t.Fatal("missing X-Last-Reload header")
+	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -85,6 +85,10 @@ func loadConfig(filename string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := validateConfig(&config); err != nil {
+		return nil, err
+	}
+
 	return &config, nil
 }
 
@@ -141,6 +145,8 @@ func reload() error {
 	for _, al := range entries {
 		SetAllowlist(al.Integration, al.Callers)
 	}
+
+	lastReloadTime.Set(time.Now().Format(time.RFC3339))
 
 	return nil
 }
@@ -313,6 +319,7 @@ func integrationsHandler(w http.ResponseWriter, r *http.Request) {
 
 // healthzHandler reports server readiness.
 func healthzHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Last-Reload", lastReloadTime.Value())
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/app/metrics.go
+++ b/app/metrics.go
@@ -15,6 +15,7 @@ var (
 	requestCounts    = expvar.NewMap("authtranslator_requests_total")
 	rateLimitCounts  = expvar.NewMap("authtranslator_rate_limit_events_total")
 	requestDurations = expvar.NewMap("authtranslator_request_duration_seconds")
+	lastReloadTime   = expvar.NewString("authtranslator_last_reload")
 	durationHistsMu  sync.Mutex
 	durationHists    = make(map[string]*histogram)
 	durationBuckets  = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10}
@@ -32,6 +33,10 @@ func newHistogram() *histogram {
 		buckets: durationBuckets,
 		counts:  make([]uint64, len(durationBuckets)+1),
 	}
+}
+
+func init() {
+	lastReloadTime.Set(time.Now().Format(time.RFC3339))
 }
 
 func (h *histogram) Observe(v float64) {

--- a/cmd/integrations/plugins/slack_test.go
+++ b/cmd/integrations/plugins/slack_test.go
@@ -1,0 +1,13 @@
+package plugins
+
+import "testing"
+
+func TestSlackIntegration(t *testing.T) {
+	i := Slack("s", "tok", "sign")
+	if i.Name != "s" || i.Destination == "" {
+		t.Fatalf("unexpected integration: %+v", i)
+	}
+	if len(i.IncomingAuth) != 1 || len(i.OutgoingAuth) != 1 {
+		t.Fatalf("auth config missing")
+	}
+}

--- a/terraform/quickstart/README.md
+++ b/terraform/quickstart/README.md
@@ -1,0 +1,9 @@
+This example uses the Docker provider to quickly run AuthTranslator on a single
+machine. Ensure Docker is installed then run:
+
+```bash
+terraform init
+terraform apply
+```
+
+The container will listen on port 8080.

--- a/terraform/quickstart/main.tf
+++ b/terraform/quickstart/main.tf
@@ -1,0 +1,26 @@
+# Quick start using the Docker provider to run AuthTranslator locally
+
+terraform {
+  required_providers {
+    docker = {
+      source  = "kreuzwerker/docker"
+      version = "~> 2.0"
+    }
+  }
+  required_version = ">= 1.0"
+}
+
+provider "docker" {}
+
+resource "docker_image" "authtranslator" {
+  name         = "ghcr.io/winhowes/authtranslator:latest"
+}
+
+resource "docker_container" "authtranslator" {
+  image = docker_image.authtranslator.name
+  name  = "authtranslator"
+  ports {
+    internal = 8080
+    external = 8080
+  }
+}


### PR DESCRIPTION
## Summary
- validate JSON config on startup
- expose last reload time in metrics and `/healthz`
- add Slack integration tests
- provide example auth plugin and Terraform quickstart
- publish container images via GitHub Actions
- document new features

## Testing
- `go vet ./...`
- `go test ./...`
