### PR TITLE
Improve allowlist validation

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -143,7 +143,9 @@ func reload() error {
 	allowlists.Unlock()
 
 	for _, al := range entries {
-		SetAllowlist(al.Integration, al.Callers)
+		if err := SetAllowlist(al.Integration, al.Callers); err != nil {
+			return fmt.Errorf("failed to load allowlist for %s: %w", al.Integration, err)
+		}
 	}
 
 	lastReloadTime.Set(time.Now().Format(time.RFC3339))


### PR DESCRIPTION
## Summary
- enforce uniqueness rules when registering allowlists
- return errors from `SetAllowlist`
- handle allowlist load errors during reload
- test duplicate detection

## Testing
- `go test ./...`