### PR TITLE
Improve allowlist validation

### DIFF
--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/basic"
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/google_oidc"
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/token"
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrationplugins"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
@@ -128,5 +129,33 @@ func TestSetAllowlistDuplicateRule(t *testing.T) {
 	err := SetAllowlist("dup", callers)
 	if err == nil {
 		t.Fatal("expected error for duplicate rule")
+	}
+}
+
+func TestSetAllowlistInvalidRule(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	callers := []CallerConfig{{
+		ID:    "a",
+		Rules: []CallRule{{Path: "", Methods: map[string]RequestConstraint{"GET": {}}}},
+	}}
+	if err := SetAllowlist("bad", callers); err == nil {
+		t.Fatal("expected error for invalid rule")
+	}
+}
+
+func TestSetAllowlistUnknownCapability(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	callers := []CallerConfig{{
+		ID:           "a",
+		Capabilities: []integrationplugins.CapabilityConfig{{Name: "bogus"}},
+	}}
+	if err := SetAllowlist("foo", callers); err == nil {
+		t.Fatal("expected error for unknown capability")
 	}
 }

--- a/app/integrationplugins/registry.go
+++ b/app/integrationplugins/registry.go
@@ -1,5 +1,7 @@
 package integrationplugins
 
+import "fmt"
+
 // CapabilityConfig defines a named capability and optional parameters.
 type CapabilityConfig struct {
 	Name   string                 `json:"name"`
@@ -35,22 +37,22 @@ func CapabilitiesFor(integration string) map[string]CapabilitySpec {
 }
 
 // expandCapabilities converts declared capabilities into explicit allow rules.
-func ExpandCapabilities(integration string, callers []CallerConfig) []CallerConfig {
+func ExpandCapabilities(integration string, callers []CallerConfig) ([]CallerConfig, error) {
 	for i := range callers {
 		for _, cap := range callers[i].Capabilities {
 			spec, ok := getCapability(integration, cap.Name)
 			if !ok {
-				continue
+				return nil, fmt.Errorf("unknown capability %s for integration %s", cap.Name, integration)
 			}
 			rules, err := spec.Generate(cap.Params)
 			if err != nil {
-				continue
+				return nil, fmt.Errorf("capability %s: %w", cap.Name, err)
 			}
 			callers[i].Rules = append(callers[i].Rules, rules...)
 		}
 		callers[i].Capabilities = nil
 	}
-	return callers
+	return callers, nil
 }
 
 // ListCapabilities exposes capability names for CLI usage.

--- a/app/integrationplugins/registry_test.go
+++ b/app/integrationplugins/registry_test.go
@@ -20,7 +20,10 @@ func TestExpandCapabilities(t *testing.T) {
 		Capabilities: []CapabilityConfig{{Name: "cap"}},
 	}}
 
-	expanded := ExpandCapabilities("test", callers)
+	expanded, err := ExpandCapabilities("test", callers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	if len(expanded) != 1 {
 		t.Fatalf("expected one caller, got %d", len(expanded))

--- a/app/main.go
+++ b/app/main.go
@@ -142,7 +142,12 @@ func reload() error {
 	allowlists.m = make(map[string]map[string]CallerConfig)
 	allowlists.Unlock()
 
+	seenAllow := make(map[string]struct{})
 	for _, al := range entries {
+		if _, dup := seenAllow[al.Integration]; dup {
+			return fmt.Errorf("duplicate allowlist entry for %s", al.Integration)
+		}
+		seenAllow[al.Integration] = struct{}{}
 		if err := SetAllowlist(al.Integration, al.Callers); err != nil {
 			return fmt.Errorf("failed to load allowlist for %s: %w", al.Integration, err)
 		}


### PR DESCRIPTION
## Summary
- validate allowlist input for malformed rules or capabilities
- return errors for invalid capabilities when expanding
- guard against duplicate allowlist entries on reload
- cover new validation cases in tests

## Testing
- `go vet ./...`
- `go test ./...`
