### PR TITLE
Improve allowlist validation

### DIFF
--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/basic"
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/google_oidc"
 	_ "github.com/winhowes/AuthTranslator/app/authplugins/token"
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrationplugins"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
@@ -128,5 +129,33 @@ func TestSetAllowlistDuplicateRule(t *testing.T) {
 	err := SetAllowlist("dup", callers)
 	if err == nil {
 		t.Fatal("expected error for duplicate rule")
+	}
+}
+
+func TestSetAllowlistInvalidRule(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	callers := []CallerConfig{{
+		ID:    "a",
+		Rules: []CallRule{{Path: "", Methods: map[string]RequestConstraint{"GET": {}}}},
+	}}
+	if err := SetAllowlist("bad", callers); err == nil {
+		t.Fatal("expected error for invalid rule")
+	}
+}
+
+func TestSetAllowlistUnknownCapability(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	callers := []CallerConfig{{
+		ID:           "a",
+		Capabilities: []integrationplugins.CapabilityConfig{{Name: "bogus"}},
+	}}
+	if err := SetAllowlist("foo", callers); err == nil {
+		t.Fatal("expected error for unknown capability")
 	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -142,7 +142,12 @@ func reload() error {
 	allowlists.m = make(map[string]map[string]CallerConfig)
 	allowlists.Unlock()
 
+	seenAllow := make(map[string]struct{})
 	for _, al := range entries {
+		if _, dup := seenAllow[al.Integration]; dup {
+			return fmt.Errorf("duplicate allowlist entry for %s", al.Integration)
+		}
+		seenAllow[al.Integration] = struct{}{}
 		if err := SetAllowlist(al.Integration, al.Callers); err != nil {
 			return fmt.Errorf("failed to load allowlist for %s: %w", al.Integration, err)
 		}


### PR DESCRIPTION
## Summary
- validate allowlist input for malformed rules or capabilities
- return errors for invalid capabilities when expanding
- guard against duplicate allowlist entries on reload
- cover new validation cases in tests
- avoid modifying inputs when expanding capabilities

## Testing
- `go vet ./...`
- `go test ./...`
