### PR TITLE
Add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-log-level` – log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)
    - `-log-format` – log output format (`text` or `json`)
    - `-debug` – expose the `/integrations` endpoint for the CLI
+   - `-version` – print the build version and exit
 
 4. **Run Locally**
 

--- a/app/main.go
+++ b/app/main.go
@@ -25,6 +25,10 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
+// version is the application version. It can be overridden at build time using
+// the -ldflags "-X main.version=<version>" option.
+var version = "dev"
+
 type AllowlistEntry struct {
 	Integration string         `json:"integration"`
 	Callers     []CallerConfig `json:"callers"`
@@ -63,6 +67,7 @@ var tlsKey = flag.String("tls-key", "", "path to TLS key")
 var logLevel = flag.String("log-level", "INFO", "log level: DEBUG, INFO, WARN, ERROR")
 var logFormat = flag.String("log-format", "text", "log output format: text or json")
 var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (host:port)")
+var showVersion = flag.Bool("version", false, "print version and exit")
 var logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
 func usage() {
@@ -453,6 +458,11 @@ func serve(s server, cert, key string) error {
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Println(version)
+		return
+	}
 
 	var handler slog.Handler
 	if strings.ToLower(*logFormat) == "json" {


### PR DESCRIPTION
## Summary
- expose a build-time `version` variable in `app/main.go`
- add a `-version` flag that prints the version and exits
- document the new flag in README

## Testing
- `go test ./...`
