### PR TITLE
Fix allowlist docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,19 +98,21 @@ The project exists to make it trivial to translate one type of authentication in
 
    The allowlist configuration lives in a separate `allowlist.json` file:
 
-   ```json
-   {
-     "integration": "example",
-     "callers": [
-       {
-         "id": "user-token",
-         "rules": [
-           {"path": "/allowed", "methods": {"GET": {}}}
-         ]
-       }
-     ]
-   }
-   ```
+  ```json
+  [
+    {
+      "integration": "example",
+      "callers": [
+        {
+          "id": "user-token",
+          "rules": [
+            {"path": "/allowed", "methods": {"GET": {}}}
+          ]
+        }
+      ]
+    }
+  ]
+  ```
 
    Caller IDs are derived by the incoming auth plugins. Plugins that
    implement the `Identifier` interface return a string used to match the
@@ -128,19 +130,21 @@ The project exists to make it trivial to translate one type of authentication in
    Capabilities can be listed instead of explicit rules. Each capability expands
    to one or more rules when loaded, making it easy to audit access by name:
 
-   ```json
-   {
-     "integration": "slack",
-     "callers": [
-       {
-         "id": "ci-bot-token",
+  ```json
+  [
+    {
+      "integration": "slack",
+      "callers": [
+        {
+          "id": "ci-bot-token",
           "capabilities": [
             {"name": "post_public_as", "params": {"username": "ci-bot"}}
           ]
-       }
-     ]
-   }
-   ```
+        }
+      ]
+    }
+  ]
+  ```
 
 3. **Running**
 
@@ -456,6 +460,13 @@ To grant a caller a capability use `allowlist add`:
 go run ./cmd/allowlist add -integration slack \
     -caller user-token -capability post_public_as \
     -params username=ci-bot
+```
+
+To revoke a capability use `allowlist remove`:
+
+```bash
+go run ./cmd/allowlist remove -integration slack \
+    -caller user-token -capability post_public_as
 ```
 
 The CLI updates the file in place (default `allowlist.json`, overridable with `-file`).


### PR DESCRIPTION
## Summary
- fix allowlist examples to show array structure
- document the `allowlist remove` command

## Testing
- `go vet ./...`
- `go test ./...`
