### PR TITLE
Implement mTLS outgoing transport

### DIFF
--- a/app/authplugins/mtls/mtls_test.go
+++ b/app/authplugins/mtls/mtls_test.go
@@ -1,11 +1,18 @@
 package mtls
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
 	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
@@ -40,7 +47,18 @@ func TestMTLSAuthFail(t *testing.T) {
 }
 
 func TestMTLSOutgoingParse(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
 	p := MTLSAuthOut{}
+	t.Setenv("CERT", string(certPEM))
+	t.Setenv("KEY", string(keyPEM))
 	cfg, err := p.ParseParams(map[string]interface{}{"cert": "env:CERT", "key": "env:KEY"})
 	if err != nil {
 		t.Fatal(err)
@@ -53,5 +71,96 @@ func TestMTLSOutgoingParse(t *testing.T) {
 	p.AddAuth(r, cfg)
 	if len(r.Header) != 0 {
 		t.Fatalf("expected no headers set, got %v", r.Header)
+	}
+}
+
+func TestMTLSOutgoingTransport(t *testing.T) {
+	// Generate CA, server, and client certificates.
+	caKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "ca"},
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caDER)
+
+	srvKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "srv"},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	srvDER, _ := x509.CreateCertificate(rand.Reader, srvTmpl, caCert, &srvKey.PublicKey, caKey)
+	srvCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvDER})
+	srvKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(srvKey)})
+	srvTLS, _ := tls.X509KeyPair(srvCertPEM, srvKeyPEM)
+
+	cliKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	cliTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "client"},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	cliDER, _ := x509.CreateCertificate(rand.Reader, cliTmpl, caCert, &cliKey.PublicKey, caKey)
+	cliCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cliDER})
+	cliKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(cliKey)})
+
+	pool := x509.NewCertPool()
+	pool.AddCert(caCert)
+
+	hit := false
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if r.TLS == nil || len(r.TLS.PeerCertificates) == 0 {
+			w.WriteHeader(http.StatusTeapot)
+			return
+		}
+		if r.TLS.PeerCertificates[0].Subject.CommonName != "client" {
+			w.WriteHeader(http.StatusForbidden)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	ts.TLS = &tls.Config{Certificates: []tls.Certificate{srvTLS}, ClientAuth: tls.RequireAndVerifyClientCert, ClientCAs: pool}
+	ts.StartTLS()
+	defer ts.Close()
+
+	t.Setenv("CCERT", string(cliCertPEM))
+	t.Setenv("CKEY", string(cliKeyPEM))
+
+	p := MTLSAuthOut{}
+	cfgIntf, err := p.ParseParams(map[string]interface{}{"cert": "env:CCERT", "key": "env:CKEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tr := p.Transport(cfgIntf)
+	if tr == nil {
+		t.Fatal("missing transport")
+	}
+	tr.TLSClientConfig.RootCAs = pool
+
+	c := http.Client{Transport: tr}
+	resp, err := c.Get(ts.URL)
+	if err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	resp.Body.Close()
+	if !hit {
+		t.Fatal("server not hit")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
 }

--- a/app/authplugins/mtls/outgoing.go
+++ b/app/authplugins/mtls/outgoing.go
@@ -1,16 +1,19 @@
 package mtls
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
+	"github.com/winhowes/AuthTranslator/app/secrets"
 )
 
 // outParams holds outbound mTLS configuration. Currently unused beyond validation.
 type outParams struct {
-	Cert string `json:"cert"`
-	Key  string `json:"key"`
+	Cert      string          `json:"cert"`
+	Key       string          `json:"key"`
+	transport *http.Transport `json:"-"`
 }
 
 type MTLSAuthOut struct{}
@@ -27,10 +30,32 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 	if p.Cert == "" || p.Key == "" {
 		return nil, fmt.Errorf("missing cert or key")
 	}
+	certPEM, err := secrets.LoadSecret(p.Cert)
+	if err != nil {
+		return nil, fmt.Errorf("load cert: %w", err)
+	}
+	keyPEM, err := secrets.LoadSecret(p.Key)
+	if err != nil {
+		return nil, fmt.Errorf("load key: %w", err)
+	}
+	tlsCert, err := tls.X509KeyPair([]byte(certPEM), []byte(keyPEM))
+	if err != nil {
+		return nil, fmt.Errorf("tls pair: %w", err)
+	}
+	p.transport = &http.Transport{TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{tlsCert}}}
 	return p, nil
 }
 
 // AddAuth currently performs no per-request actions for mTLS.
 func (m *MTLSAuthOut) AddAuth(r *http.Request, p interface{}) {}
+
+// Transport exposes the configured mTLS transport for integration usage.
+func (m *MTLSAuthOut) Transport(p interface{}) *http.Transport {
+	cfg, ok := p.(*outParams)
+	if !ok {
+		return nil
+	}
+	return cfg.transport
+}
 
 func init() { authplugins.RegisterOutgoing(&MTLSAuthOut{}) }

--- a/app/integration.go
+++ b/app/integration.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"reflect"
@@ -208,6 +209,14 @@ func prepareIntegration(i *Integration) error {
 			}
 		}
 		i.OutgoingAuth[idx].parsed = cfg
+
+		if tp, ok := p.(interface {
+			Transport(interface{}) *http.Transport
+		}); ok {
+			if t := tp.Transport(cfg); t != nil {
+				i.proxy.Transport = t
+			}
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- load certificate and key for mTLS outgoing auth
- create a custom `http.Transport` with TLS config and expose it
- apply outgoing auth transport to reverse proxy
- test mTLS outgoing transport

## Testing
- `go vet ./...`
- `go test ./...`
