### PR TITLE
Add automatic reload by watching config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Validated Startup**: The configuration is checked at startup and errors are reported before serving traffic.
 - **Clean Shutdown**: On SIGINT or SIGTERM the server and rate limiters are gracefully stopped.
 - **Hot Reload**: Send `SIGHUP` to reload the configuration and allowlist without restarting.
+- **File Watching**: Use `-watch` to automatically reload when configuration or allowlist files change.
 
 ## Development Requirements
 
@@ -150,9 +151,9 @@ The project exists to make it trivial to translate one type of authentication in
 3. **Running**
 
    The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`. Set `-redis-addr` to persist rate limits in Redis; failures fall back to memory with an error log.
-   Send `SIGHUP` to the process to reload these files without restarting. If the
-   allowlist fails to load during reload, the previously loaded entries remain in
-   effect.
+   Send `SIGHUP` or run with `-watch` to reload these files automatically without
+   restarting. If the allowlist fails to load during reload, the previously loaded
+   entries remain in effect.
 
    **Service flags**
 
@@ -167,6 +168,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-log-format` – log output format (`text` or `json`)
    - `-debug` – expose the `/integrations` endpoint for the CLI
    - `-version` – print the build version and exit
+   - `-watch` – automatically reload when config or allowlist files change
 
 4. **Run Locally**
 


### PR DESCRIPTION
## Summary
- support new `-watch` flag in the service
- automatically reload config and allowlist when watched files change
- document file watching option in README

## Testing
- `go test ./...`
