### PR TITLE
Add metrics for authentication failures and upstream responses

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -416,6 +416,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		if p != nil {
 			if !p.Authenticate(r, cfg.parsed) {
 				logger.Warn("authentication failed", "host", host, "remote", r.RemoteAddr)
+				incAuthFailure(integ.Name)
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -471,6 +472,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if rec.status == 0 {
 		rec.status = http.StatusOK
 	}
+	recordStatus(integ.Name, rec.status)
 	logger.Info("upstream response", "host", host, "status", rec.status)
 }
 


### PR DESCRIPTION
## Summary
- track authentication failures and upstream HTTP status codes
- report new metrics from metrics handler
- increment counters from proxy handler
- test new metrics in metrics handler tests

## Testing
- `go test ./...`