### PR TITLE
Add context parameter to plugin interfaces

### DIFF
--- a/app/authplugins/basic/basic_test.go
+++ b/app/authplugins/basic/basic_test.go
@@ -1,6 +1,7 @@
 package basic
 
 import (
+	"context"
 	"encoding/base64"
 	"net/http"
 	"testing"
@@ -16,7 +17,7 @@ func TestBasicOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
 	if got := r.Header.Get("Authorization"); got != expected {
 		t.Fatalf("expected %q, got %s", expected, got)
@@ -32,7 +33,7 @@ func TestBasicIncomingAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 
@@ -50,7 +51,7 @@ func TestBasicIncomingAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }
@@ -64,7 +65,7 @@ func TestBasicIdentify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 	id, ok := p.Identify(r, cfg)

--- a/app/authplugins/basic/incoming.go
+++ b/app/authplugins/basic/incoming.go
@@ -1,6 +1,7 @@
 package basic
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/base64"
 	"fmt"
@@ -41,7 +42,7 @@ func (b *BasicAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
 	return p, nil
 }
 
-func (b *BasicAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (b *BasicAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
@@ -57,7 +58,7 @@ func (b *BasicAuth) Authenticate(r *http.Request, p interface{}) bool {
 	}
 	creds := dec
 	for _, ref := range cfg.Secrets {
-		sec, err := secrets.LoadSecret(ref)
+		sec, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/basic/outgoing.go
+++ b/app/authplugins/basic/outgoing.go
@@ -1,6 +1,7 @@
 package basic
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"net/http"
@@ -39,12 +40,12 @@ func (b *BasicAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 	return p, nil
 }
 
-func (b *BasicAuthOut) AddAuth(r *http.Request, p interface{}) {
+func (b *BasicAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}
-	cred, err := secrets.LoadRandomSecret(cfg.Secrets)
+	cred, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
 		return
 	}

--- a/app/authplugins/github_signature/github_signature_test.go
+++ b/app/authplugins/github_signature/github_signature_test.go
@@ -1,6 +1,7 @@
 package githubsignature
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -28,7 +29,7 @@ func TestGitHubSignatureAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 }
@@ -49,7 +50,7 @@ func TestGitHubSignatureAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }

--- a/app/authplugins/github_signature/incoming.go
+++ b/app/authplugins/github_signature/incoming.go
@@ -1,6 +1,7 @@
 package githubsignature
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -43,7 +44,7 @@ func (g *GitHubSignatureAuth) ParseParams(m map[string]interface{}) (interface{}
 	return p, nil
 }
 
-func (g *GitHubSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (g *GitHubSignatureAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*githubSigParams)
 	if !ok {
 		return false
@@ -57,7 +58,7 @@ func (g *GitHubSignatureAuth) Authenticate(r *http.Request, p interface{}) bool 
 		return false
 	}
 	for _, ref := range cfg.Secrets {
-		secret, err := secrets.LoadSecret(ref)
+		secret, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/google_oidc/google_oidc_test.go
+++ b/app/authplugins/google_oidc/google_oidc_test.go
@@ -1,6 +1,7 @@
 package googleoidc
 
 import (
+	"context"
 	"crypto"
 	"crypto/rand"
 	"crypto/rsa"
@@ -42,7 +43,7 @@ func TestGoogleOIDCAddAuth(t *testing.T) {
 	}
 
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
 		t.Fatalf("expected 'Bearer tok123', got %s", got)
 	}
@@ -67,7 +68,7 @@ func TestGoogleOIDCDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if got := r.Header.Get("Authorization"); got != "Bearer tok" {
 		t.Fatalf("unexpected header %s", got)
 	}
@@ -119,7 +120,7 @@ func TestGoogleOIDCIncomingAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 	if id, ok := p.Identify(r, cfg); !ok || id != "user1" {
@@ -150,7 +151,7 @@ func TestGoogleOIDCIncomingAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }

--- a/app/authplugins/google_oidc/incoming.go
+++ b/app/authplugins/google_oidc/incoming.go
@@ -1,6 +1,7 @@
 package googleoidc
 
 import (
+        "context"
 	"crypto"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -200,7 +201,7 @@ func parseAndVerify(tok string) (map[string]interface{}, bool) {
 	return claims, true
 }
 
-func (g *GoogleOIDCAuth) Authenticate(r *http.Request, params interface{}) bool {
+func (g *GoogleOIDCAuth) Authenticate(ctx context.Context, r *http.Request, params interface{}) bool {
 	cfg, ok := params.(*inParams)
 	if !ok {
 		return false

--- a/app/authplugins/google_oidc/outgoing.go
+++ b/app/authplugins/google_oidc/outgoing.go
@@ -1,6 +1,7 @@
 package googleoidc
 
 import (
+        "context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -66,7 +67,7 @@ func (g *GoogleOIDC) ParseParams(m map[string]interface{}) (interface{}, error) 
 	return p, nil
 }
 
-func (g *GoogleOIDC) AddAuth(r *http.Request, params interface{}) {
+func (g *GoogleOIDC) AddAuth(ctx context.Context, r *http.Request, params interface{}) {
 	cfg, ok := params.(*googleOIDCParams)
 	if !ok {
 		return

--- a/app/authplugins/hmac/hmac_test.go
+++ b/app/authplugins/hmac/hmac_test.go
@@ -1,6 +1,7 @@
 package hmacsig
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -20,7 +21,7 @@ func TestHMACOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	mac := hmac.New(sha256.New, []byte("key"))
 	mac.Write([]byte("hello"))
 	expected := hex.EncodeToString(mac.Sum(nil))
@@ -41,7 +42,7 @@ func TestHMACIncomingAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 }
@@ -58,7 +59,7 @@ func TestHMACIncomingAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }

--- a/app/authplugins/hmac/incoming.go
+++ b/app/authplugins/hmac/incoming.go
@@ -1,6 +1,7 @@
 package hmacsig
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -62,7 +63,7 @@ func (h *HMACSignatureAuth) ParseParams(m map[string]interface{}) (interface{}, 
 	return p, nil
 }
 
-func (h *HMACSignatureAuth) Authenticate(r *http.Request, params interface{}) bool {
+func (h *HMACSignatureAuth) Authenticate(ctx context.Context, r *http.Request, params interface{}) bool {
 	cfg, ok := params.(*inParams)
 	if !ok {
 		return false
@@ -80,7 +81,7 @@ func (h *HMACSignatureAuth) Authenticate(r *http.Request, params interface{}) bo
 		return false
 	}
 	for _, ref := range cfg.Secrets {
-		secret, err := secrets.LoadSecret(ref)
+		secret, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/hmac/outgoing.go
+++ b/app/authplugins/hmac/outgoing.go
@@ -1,6 +1,7 @@
 package hmacsig
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha1"
 	"crypto/sha256"
@@ -62,7 +63,7 @@ func (h *HMACSignature) ParseParams(m map[string]interface{}) (interface{}, erro
 	return p, nil
 }
 
-func (h *HMACSignature) AddAuth(r *http.Request, params interface{}) {
+func (h *HMACSignature) AddAuth(ctx context.Context, r *http.Request, params interface{}) {
 	cfg, ok := params.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
@@ -75,7 +76,7 @@ func (h *HMACSignature) AddAuth(r *http.Request, params interface{}) {
 	if err != nil {
 		return
 	}
-	secret, err := secrets.LoadRandomSecret(cfg.Secrets)
+	secret, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
 		return
 	}

--- a/app/authplugins/jwt/incoming.go
+++ b/app/authplugins/jwt/incoming.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto"
 	"crypto/hmac"
 	"crypto/rsa"
@@ -117,7 +118,7 @@ func matchAudience(claim interface{}, want string) bool {
 	return false
 }
 
-func (j *JWTAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (j *JWTAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
@@ -134,7 +135,7 @@ func (j *JWTAuth) Authenticate(r *http.Request, p interface{}) bool {
 	alg, _ := header["alg"].(string)
 	verified := false
 	for _, ref := range cfg.Secrets {
-		key, err := secrets.LoadSecret(ref)
+		key, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/jwt/jwt_test.go
+++ b/app/authplugins/jwt/jwt_test.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/base64"
@@ -34,7 +35,7 @@ func TestJWTAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 	id, ok := p.Identify(r, cfg)
@@ -53,7 +54,7 @@ func TestJWTAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }
@@ -66,7 +67,7 @@ func TestJWTOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
 		t.Fatalf("expected 'Bearer tok123', got %s", got)
 	}

--- a/app/authplugins/jwt/outgoing.go
+++ b/app/authplugins/jwt/outgoing.go
@@ -1,6 +1,7 @@
 package jwt
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -38,12 +39,12 @@ func (j *JWTAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) 
 	return p, nil
 }
 
-func (j *JWTAuthOut) AddAuth(r *http.Request, p interface{}) {
+func (j *JWTAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}
-	tok, err := secrets.LoadRandomSecret(cfg.Secrets)
+	tok, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
 		return
 	}

--- a/app/authplugins/mtls/incoming.go
+++ b/app/authplugins/mtls/incoming.go
@@ -1,6 +1,7 @@
 package mtls
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/winhowes/AuthTranslator/app/authplugins"
@@ -21,7 +22,7 @@ func (m *MTLSAuth) ParseParams(data map[string]interface{}) (interface{}, error)
 	return authplugins.ParseParams[mtlsParams](data)
 }
 
-func (m *MTLSAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (m *MTLSAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*mtlsParams)
 	if !ok {
 		return false

--- a/app/authplugins/mtls/mtls_test.go
+++ b/app/authplugins/mtls/mtls_test.go
@@ -1,6 +1,7 @@
 package mtls
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -25,7 +26,7 @@ func TestMTLSAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 	id, ok := p.Identify(r, cfg)
@@ -41,7 +42,7 @@ func TestMTLSAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected failure without TLS")
 	}
 }
@@ -68,7 +69,7 @@ func TestMTLSOutgoingParse(t *testing.T) {
 		t.Fatalf("unexpected config %+v", cfg)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if len(r.Header) != 0 {
 		t.Fatalf("expected no headers set, got %v", r.Header)
 	}

--- a/app/authplugins/mtls/outgoing.go
+++ b/app/authplugins/mtls/outgoing.go
@@ -1,6 +1,7 @@
 package mtls
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net/http"
@@ -30,11 +31,11 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 	if p.Cert == "" || p.Key == "" {
 		return nil, fmt.Errorf("missing cert or key")
 	}
-	certPEM, err := secrets.LoadSecret(p.Cert)
+	certPEM, err := secrets.LoadSecret(context.Background(), p.Cert)
 	if err != nil {
 		return nil, fmt.Errorf("load cert: %w", err)
 	}
-	keyPEM, err := secrets.LoadSecret(p.Key)
+	keyPEM, err := secrets.LoadSecret(context.Background(), p.Key)
 	if err != nil {
 		return nil, fmt.Errorf("load key: %w", err)
 	}
@@ -47,7 +48,7 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 }
 
 // AddAuth currently performs no per-request actions for mTLS.
-func (m *MTLSAuthOut) AddAuth(r *http.Request, p interface{}) {}
+func (m *MTLSAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {}
 
 // Transport exposes the configured mTLS transport for integration usage.
 func (m *MTLSAuthOut) Transport(p interface{}) *http.Transport {

--- a/app/authplugins/registry.go
+++ b/app/authplugins/registry.go
@@ -1,6 +1,9 @@
 package authplugins
 
-import "net/http"
+import (
+	"context"
+	"net/http"
+)
 
 // IncomingAuthPlugin processes authentication from incoming callers.
 // ParseParams should validate and convert the raw parameter map into a
@@ -8,7 +11,7 @@ import "net/http"
 type IncomingAuthPlugin interface {
 	Name() string
 	ParseParams(map[string]interface{}) (interface{}, error)
-	Authenticate(r *http.Request, params interface{}) bool
+	Authenticate(ctx context.Context, r *http.Request, params interface{}) bool
 	RequiredParams() []string
 	OptionalParams() []string
 }
@@ -23,7 +26,7 @@ type Identifier interface {
 type OutgoingAuthPlugin interface {
 	Name() string
 	ParseParams(map[string]interface{}) (interface{}, error)
-	AddAuth(r *http.Request, params interface{})
+	AddAuth(ctx context.Context, r *http.Request, params interface{})
 	RequiredParams() []string
 	OptionalParams() []string
 }

--- a/app/authplugins/registry_test.go
+++ b/app/authplugins/registry_test.go
@@ -1,23 +1,26 @@
 package authplugins
 
-import "testing"
-import "net/http"
+import (
+	"context"
+	"net/http"
+	"testing"
+)
 
 // minimal incoming plugin
 type testIncoming struct{ name string }
 
-func (p testIncoming) Name() string                                          { return p.name }
-func (testIncoming) ParseParams(map[string]interface{}) (interface{}, error) { return nil, nil }
-func (testIncoming) Authenticate(*http.Request, interface{}) bool            { return true }
-func (testIncoming) RequiredParams() []string                                { return nil }
-func (testIncoming) OptionalParams() []string                                { return nil }
+func (p testIncoming) Name() string                                                { return p.name }
+func (testIncoming) ParseParams(map[string]interface{}) (interface{}, error)       { return nil, nil }
+func (testIncoming) Authenticate(context.Context, *http.Request, interface{}) bool { return true }
+func (testIncoming) RequiredParams() []string                                      { return nil }
+func (testIncoming) OptionalParams() []string                                      { return nil }
 
 // minimal outgoing plugin
 type testOutgoing struct{ name string }
 
 func (p testOutgoing) Name() string                                          { return p.name }
 func (testOutgoing) ParseParams(map[string]interface{}) (interface{}, error) { return nil, nil }
-func (testOutgoing) AddAuth(*http.Request, interface{})                      {}
+func (testOutgoing) AddAuth(context.Context, *http.Request, interface{})     {}
 func (testOutgoing) RequiredParams() []string                                { return nil }
 func (testOutgoing) OptionalParams() []string                                { return nil }
 

--- a/app/authplugins/slack_signature/incoming.go
+++ b/app/authplugins/slack_signature/incoming.go
@@ -1,6 +1,7 @@
 package slacksignature
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -55,7 +56,7 @@ func (s *SlackSignatureAuth) ParseParams(m map[string]interface{}) (interface{},
 	return p, nil
 }
 
-func (s *SlackSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (s *SlackSignatureAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*slackSigParams)
 	if !ok {
 		return false
@@ -78,7 +79,7 @@ func (s *SlackSignatureAuth) Authenticate(r *http.Request, p interface{}) bool {
 		return false
 	}
 	for _, ref := range cfg.Secrets {
-		secret, err := secrets.LoadSecret(ref)
+		secret, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/slack_signature/slack_signature_test.go
+++ b/app/authplugins/slack_signature/slack_signature_test.go
@@ -1,6 +1,7 @@
 package slacksignature
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -34,7 +35,7 @@ func TestSlackSignatureAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 }
@@ -58,7 +59,7 @@ func TestSlackSignatureAuthOldTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }

--- a/app/authplugins/token/incoming.go
+++ b/app/authplugins/token/incoming.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"crypto/subtle"
 	"fmt"
 	"net/http"
@@ -36,14 +37,14 @@ func (t *TokenAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
 	return p, nil
 }
 
-func (t *TokenAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (t *TokenAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
 	}
 	tokenValue := strings.TrimPrefix(r.Header.Get(cfg.Header), cfg.Prefix)
 	for _, ref := range cfg.Secrets {
-		token, err := secrets.LoadSecret(ref)
+		token, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/token/outgoing.go
+++ b/app/authplugins/token/outgoing.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -34,12 +35,12 @@ func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 	return p, nil
 }
 
-func (t *TokenAuthOut) AddAuth(r *http.Request, p interface{}) {
+func (t *TokenAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}
-	token, err := secrets.LoadRandomSecret(cfg.Secrets)
+	token, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
 		return
 	}

--- a/app/authplugins/token/token_test.go
+++ b/app/authplugins/token/token_test.go
@@ -1,6 +1,7 @@
 package token
 
 import (
+	"context"
 	"net/http"
 	"testing"
 
@@ -15,7 +16,7 @@ func TestTokenOutgoingPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if got := r.Header.Get("Authorization"); got != "Bearer secret" {
 		t.Fatalf("expected 'Bearer secret', got %s", got)
 	}
@@ -29,7 +30,7 @@ func TestTokenIncomingPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed with prefix")
 	}
 }
@@ -42,7 +43,7 @@ func TestTokenIncomingPrefixMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail when prefix not configured")
 	}
 }

--- a/app/authplugins/urlpath/incoming.go
+++ b/app/authplugins/urlpath/incoming.go
@@ -1,6 +1,7 @@
 package urlpath
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,13 +32,13 @@ func (u *URLPathAuth) ParseParams(m map[string]interface{}) (interface{}, error)
 	return p, nil
 }
 
-func (u *URLPathAuth) Authenticate(r *http.Request, p interface{}) bool {
+func (u *URLPathAuth) Authenticate(ctx context.Context, r *http.Request, p interface{}) bool {
 	cfg, ok := p.(*inParams)
 	if !ok {
 		return false
 	}
 	for _, ref := range cfg.Secrets {
-		sec, err := secrets.LoadSecret(ref)
+		sec, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {
 			continue
 		}

--- a/app/authplugins/urlpath/outgoing.go
+++ b/app/authplugins/urlpath/outgoing.go
@@ -1,6 +1,7 @@
 package urlpath
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -31,12 +32,12 @@ func (u *URLPathAuthOut) ParseParams(m map[string]interface{}) (interface{}, err
 	return p, nil
 }
 
-func (u *URLPathAuthOut) AddAuth(r *http.Request, p interface{}) {
+func (u *URLPathAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
 		return
 	}
-	sec, err := secrets.LoadRandomSecret(cfg.Secrets)
+	sec, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
 		return
 	}

--- a/app/authplugins/urlpath/urlpath_test.go
+++ b/app/authplugins/urlpath/urlpath_test.go
@@ -1,6 +1,7 @@
 package urlpath
 
 import (
+	"context"
 	"net/http"
 	"net/url"
 	"testing"
@@ -16,7 +17,7 @@ func TestURLPathOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(r, cfg)
+	p.AddAuth(context.Background(), r, cfg)
 	if got := r.URL.Path; got != "/api/secret" {
 		t.Fatalf("expected '/api/secret', got %s", got)
 	}
@@ -30,7 +31,7 @@ func TestURLPathIncomingAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !p.Authenticate(r, cfg) {
+	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
 	if got := r.URL.Path; got != "/api" {
@@ -46,7 +47,7 @@ func TestURLPathIncomingAuthFail(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if p.Authenticate(r, cfg) {
+	if p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to fail")
 	}
 }

--- a/app/main.go
+++ b/app/main.go
@@ -414,7 +414,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	for _, cfg := range integ.IncomingAuth {
 		p := authplugins.GetIncoming(cfg.Type)
 		if p != nil {
-			if !p.Authenticate(r, cfg.parsed) {
+			if !p.Authenticate(r.Context(), r, cfg.parsed) {
 				logger.Warn("authentication failed", "host", host, "remote", r.RemoteAddr)
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
@@ -457,7 +457,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	for _, cfg := range integ.OutgoingAuth {
 		p := authplugins.GetOutgoing(cfg.Type)
 		if p != nil {
-			p.AddAuth(r, cfg.parsed)
+			p.AddAuth(r.Context(), r, cfg.parsed)
 		}
 	}
 

--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"os"
 	"testing"
@@ -112,11 +113,11 @@ func TestReloadClearsSecretCache(t *testing.T) {
 	}
 
 	t.Setenv("CACHE_RELOAD_SECRET", "first")
-	if _, err := secrets.LoadSecret("env:CACHE_RELOAD_SECRET"); err != nil {
+	if _, err := secrets.LoadSecret(context.Background(), "env:CACHE_RELOAD_SECRET"); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("CACHE_RELOAD_SECRET", "second")
-	if val, err := secrets.LoadSecret("env:CACHE_RELOAD_SECRET"); err != nil {
+	if val, err := secrets.LoadSecret(context.Background(), "env:CACHE_RELOAD_SECRET"); err != nil {
 		t.Fatal(err)
 	} else if val != "first" {
 		t.Fatalf("expected cached 'first', got %s", val)
@@ -126,7 +127,7 @@ func TestReloadClearsSecretCache(t *testing.T) {
 		t.Fatalf("reload failed: %v", err)
 	}
 
-	val, err := secrets.LoadSecret("env:CACHE_RELOAD_SECRET")
+	val, err := secrets.LoadSecret(context.Background(), "env:CACHE_RELOAD_SECRET")
 	if err != nil {
 		t.Fatalf("unexpected error after reload: %v", err)
 	}

--- a/app/secrets/file_plugin_test.go
+++ b/app/secrets/file_plugin_test.go
@@ -1,6 +1,7 @@
 package secrets_test
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -15,7 +16,7 @@ func TestLoadSecretFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte("top-secret"), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	val, err := secrets.LoadSecret("file:" + path)
+	val, err := secrets.LoadSecret(context.Background(), "file:"+path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -30,7 +31,7 @@ func TestLoadSecretFileTrailingNewline(t *testing.T) {
 	if err := os.WriteFile(path, []byte("top-secret\n"), 0600); err != nil {
 		t.Fatalf("write: %v", err)
 	}
-	val, err := secrets.LoadSecret("file:" + path)
+	val, err := secrets.LoadSecret(context.Background(), "file:"+path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -41,7 +42,7 @@ func TestLoadSecretFileTrailingNewline(t *testing.T) {
 
 func TestLoadSecretFileMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing.txt")
-	if _, err := secrets.LoadSecret("file:" + path); err == nil {
+	if _, err := secrets.LoadSecret(context.Background(), "file:"+path); err == nil {
 		t.Fatal("expected error for missing file")
 	}
 }

--- a/app/secrets/plugins/aws/plugin.go
+++ b/app/secrets/plugins/aws/plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
@@ -41,7 +42,7 @@ func (p *awsKMSPlugin) init() {
 
 func (p *awsKMSPlugin) Prefix() string { return "aws" }
 
-func (p *awsKMSPlugin) Load(id string) (string, error) {
+func (p *awsKMSPlugin) Load(ctx context.Context, id string) (string, error) {
 	p.once.Do(p.init)
 	if p.err != nil {
 		return "", p.err

--- a/app/secrets/plugins/aws/plugin_test.go
+++ b/app/secrets/plugins/aws/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
@@ -35,7 +36,7 @@ func TestAWSKMSPluginLoad(t *testing.T) {
 
 	id := encryptAWS(t, key, "secret")
 	p := &awsKMSPlugin{}
-	got, err := p.Load(id)
+	got, err := p.Load(context.Background(), id)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -46,7 +47,7 @@ func TestAWSKMSPluginLoad(t *testing.T) {
 
 func TestAWSKMSPluginLoadMissingKey(t *testing.T) {
 	p := &awsKMSPlugin{}
-	if _, err := p.Load("deadbeef"); err == nil {
+	if _, err := p.Load(context.Background(), "deadbeef"); err == nil {
 		t.Fatal("expected error when key missing")
 	}
 }
@@ -58,7 +59,7 @@ func TestAWSKMSPluginInvalidCiphertext(t *testing.T) {
 	}
 	t.Setenv("AWS_KMS_KEY", base64.StdEncoding.EncodeToString(key))
 	p := &awsKMSPlugin{}
-	if _, err := p.Load("!!notbase64!!"); err == nil {
+	if _, err := p.Load(context.Background(), "!!notbase64!!"); err == nil {
 		t.Fatal("expected error for invalid ciphertext")
 	}
 }

--- a/app/secrets/plugins/azure/plugin.go
+++ b/app/secrets/plugins/azure/plugin.go
@@ -4,6 +4,7 @@ import "github.com/winhowes/AuthTranslator/app/secrets"
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -28,7 +29,7 @@ func (azureKMSPlugin) Prefix() string { return "azure" }
 // Load resolves the secret identified by id using Azure Key Vault. The
 // plugin expects a service principal to be configured via the environment
 // variables AZURE_TENANT_ID, AZURE_CLIENT_ID and AZURE_CLIENT_SECRET.
-func (azureKMSPlugin) Load(id string) (string, error) {
+func (azureKMSPlugin) Load(ctx context.Context, id string) (string, error) {
 	tenantID := os.Getenv("AZURE_TENANT_ID")
 	clientID := os.Getenv("AZURE_CLIENT_ID")
 	clientSecret := os.Getenv("AZURE_CLIENT_SECRET")

--- a/app/secrets/plugins/azure/plugin_test.go
+++ b/app/secrets/plugins/azure/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -61,7 +62,7 @@ func TestAzureKMSLoad(t *testing.T) {
 	t.Setenv("AZURE_CLIENT_SECRET", "sec")
 
 	p := azureKMSPlugin{}
-	got, err := p.Load("https://vault.example.com/secrets/foo")
+	got, err := p.Load(context.Background(), "https://vault.example.com/secrets/foo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -83,7 +84,7 @@ func TestAzureKMSLoadError(t *testing.T) {
 	t.Setenv("AZURE_CLIENT_SECRET", "sec")
 
 	p := azureKMSPlugin{}
-	if _, err := p.Load("https://vault.example.com/secrets/foo"); err == nil {
+	if _, err := p.Load(context.Background(), "https://vault.example.com/secrets/foo"); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/app/secrets/plugins/env/plugin.go
+++ b/app/secrets/plugins/env/plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -12,7 +13,7 @@ type envPlugin struct{}
 
 func (envPlugin) Prefix() string { return "env" }
 
-func (envPlugin) Load(id string) (string, error) {
+func (envPlugin) Load(ctx context.Context, id string) (string, error) {
 	val, ok := os.LookupEnv(id)
 	if !ok {
 		return "", fmt.Errorf("%s not set", id)

--- a/app/secrets/plugins/env/plugin_test.go
+++ b/app/secrets/plugins/env/plugin_test.go
@@ -1,11 +1,14 @@
 package plugins
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 func TestEnvPluginLoad(t *testing.T) {
 	t.Setenv("FOO", "bar")
 	p := envPlugin{}
-	got, err := p.Load("FOO")
+	got, err := p.Load(context.Background(), "FOO")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -16,7 +19,7 @@ func TestEnvPluginLoad(t *testing.T) {
 
 func TestEnvPluginLoadMissing(t *testing.T) {
 	p := envPlugin{}
-	if _, err := p.Load("MISSING"); err == nil {
+	if _, err := p.Load(context.Background(), "MISSING"); err == nil {
 		t.Fatal("expected error for missing variable")
 	}
 }

--- a/app/secrets/plugins/file/plugin.go
+++ b/app/secrets/plugins/file/plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -12,7 +13,7 @@ type filePlugin struct{}
 
 func (filePlugin) Prefix() string { return "file" }
 
-func (filePlugin) Load(id string) (string, error) {
+func (filePlugin) Load(ctx context.Context, id string) (string, error) {
 	b, err := os.ReadFile(id)
 	if err != nil {
 		return "", err

--- a/app/secrets/plugins/file/plugin_test.go
+++ b/app/secrets/plugins/file/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,7 +14,7 @@ func TestFilePluginLoad(t *testing.T) {
 		t.Fatalf("write: %v", err)
 	}
 	p := filePlugin{}
-	got, err := p.Load(path)
+	got, err := p.Load(context.Background(), path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -25,7 +26,7 @@ func TestFilePluginLoad(t *testing.T) {
 func TestFilePluginLoadMissing(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing.txt")
 	p := filePlugin{}
-	if _, err := p.Load(path); err == nil {
+	if _, err := p.Load(context.Background(), path); err == nil {
 		t.Fatal("expected error for missing file")
 	}
 }

--- a/app/secrets/plugins/gcp/plugin.go
+++ b/app/secrets/plugins/gcp/plugin.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -25,7 +26,7 @@ var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 func (gcpKMSPlugin) Prefix() string { return "gcp" }
 
-func (gcpKMSPlugin) Load(id string) (string, error) {
+func (gcpKMSPlugin) Load(ctx context.Context, id string) (string, error) {
 	parts := strings.SplitN(id, ":", 2)
 	if len(parts) != 2 {
 		return "", fmt.Errorf("invalid gcp kms id: %s", id)

--- a/app/secrets/plugins/gcp/plugin_test.go
+++ b/app/secrets/plugins/gcp/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"io"
@@ -63,7 +64,7 @@ func TestGCPKMSLoad(t *testing.T) {
 	defer restore()
 
 	p := gcpKMSPlugin{}
-	got, err := p.Load("projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher")
+	got, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,7 +82,7 @@ func TestGCPKMSLoadError(t *testing.T) {
 	defer restore()
 
 	p := gcpKMSPlugin{}
-	if _, err := p.Load("projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
+	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
 		t.Fatal("expected error")
 	}
 }

--- a/app/secrets/plugins/vault/plugin.go
+++ b/app/secrets/plugins/vault/plugin.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -24,7 +25,7 @@ var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
 func (vaultPlugin) Prefix() string { return "vault" }
 
-func (vaultPlugin) Load(id string) (string, error) {
+func (vaultPlugin) Load(ctx context.Context, id string) (string, error) {
 	addr := os.Getenv("VAULT_ADDR")
 	token := os.Getenv("VAULT_TOKEN")
 	if addr == "" || token == "" {

--- a/app/secrets/plugins/vault/plugin_test.go
+++ b/app/secrets/plugins/vault/plugin_test.go
@@ -1,6 +1,7 @@
 package plugins
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -48,7 +49,7 @@ func TestVaultLoad(t *testing.T) {
 	t.Setenv("VAULT_TOKEN", "tok")
 
 	p := vaultPlugin{}
-	got, err := p.Load("secret/data/foo")
+	got, err := p.Load(context.Background(), "secret/data/foo")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -69,14 +70,14 @@ func TestVaultLoadError(t *testing.T) {
 	t.Setenv("VAULT_TOKEN", "tok")
 
 	p := vaultPlugin{}
-	if _, err := p.Load("secret/data/foo"); err == nil {
+	if _, err := p.Load(context.Background(), "secret/data/foo"); err == nil {
 		t.Fatal("expected error")
 	}
 }
 
 func TestVaultLoadMissingConfig(t *testing.T) {
 	p := vaultPlugin{}
-	if _, err := p.Load("secret/data/foo"); err == nil {
+	if _, err := p.Load(context.Background(), "secret/data/foo"); err == nil {
 		t.Fatal("expected error when config missing")
 	}
 }

--- a/app/secrets/registry_cache_test.go
+++ b/app/secrets/registry_cache_test.go
@@ -1,6 +1,7 @@
 package secrets_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/winhowes/AuthTranslator/app/secrets"
@@ -9,7 +10,7 @@ import (
 
 func TestClearCache(t *testing.T) {
 	t.Setenv("CACHE_SECRET", "first")
-	val, err := secrets.LoadSecret("env:CACHE_SECRET")
+	val, err := secrets.LoadSecret(context.Background(), "env:CACHE_SECRET")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -19,7 +20,7 @@ func TestClearCache(t *testing.T) {
 
 	// Change the underlying secret; cache should still return old value.
 	t.Setenv("CACHE_SECRET", "second")
-	if val, err := secrets.LoadSecret("env:CACHE_SECRET"); err != nil {
+	if val, err := secrets.LoadSecret(context.Background(), "env:CACHE_SECRET"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	} else if val != "first" {
 		t.Fatalf("expected cached 'first', got %s", val)
@@ -27,7 +28,7 @@ func TestClearCache(t *testing.T) {
 
 	secrets.ClearCache()
 
-	val, err = secrets.LoadSecret("env:CACHE_SECRET")
+	val, err = secrets.LoadSecret(context.Background(), "env:CACHE_SECRET")
 	if err != nil {
 		t.Fatalf("unexpected error after clear: %v", err)
 	}

--- a/app/secrets/secret_test.go
+++ b/app/secrets/secret_test.go
@@ -1,6 +1,7 @@
 package secrets_test
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"encoding/base64"
@@ -13,7 +14,7 @@ import (
 
 func TestLoadSecretEnv(t *testing.T) {
 	t.Setenv("MY_SECRET", "val")
-	s, err := secrets.LoadSecret("env:MY_SECRET")
+	s, err := secrets.LoadSecret(context.Background(), "env:MY_SECRET")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -23,13 +24,13 @@ func TestLoadSecretEnv(t *testing.T) {
 }
 
 func TestLoadSecretEnvMissing(t *testing.T) {
-	if _, err := secrets.LoadSecret("env:UNSET_VAR"); err == nil {
+	if _, err := secrets.LoadSecret(context.Background(), "env:UNSET_VAR"); err == nil {
 		t.Fatal("expected error when variable is missing")
 	}
 }
 
 func TestLoadSecretUnknown(t *testing.T) {
-	if _, err := secrets.LoadSecret("unknown:id"); err == nil {
+	if _, err := secrets.LoadSecret(context.Background(), "unknown:id"); err == nil {
 		t.Fatal("expected error for unknown secret source")
 	}
 }
@@ -39,7 +40,7 @@ func TestLoadRandomSecret(t *testing.T) {
 	t.Setenv("B", "second")
 
 	// Single reference
-	val, err := secrets.LoadRandomSecret([]string{"env:A"})
+	val, err := secrets.LoadRandomSecret(context.Background(), []string{"env:A"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -48,7 +49,7 @@ func TestLoadRandomSecret(t *testing.T) {
 	}
 
 	// Multiple references - result should be one of the provided values
-	val, err = secrets.LoadRandomSecret([]string{"env:A", "env:B"})
+	val, err = secrets.LoadRandomSecret(context.Background(), []string{"env:A", "env:B"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -67,7 +68,7 @@ func TestLoadRandomSecretConcurrent(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			val, err := secrets.LoadRandomSecret(refs)
+			val, err := secrets.LoadRandomSecret(context.Background(), refs)
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 				return
@@ -105,7 +106,7 @@ func TestLoadSecretAWSKMS(t *testing.T) {
 	ct = append(nonce, ct...)
 	ref := "aws:" + base64.StdEncoding.EncodeToString(ct)
 
-	val, err := secrets.LoadSecret(ref)
+	val, err := secrets.LoadSecret(context.Background(), ref)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}


### PR DESCRIPTION
## Summary
- update auth and secret plugin interfaces to take `context.Context`
- adjust all plugin implementations and update registry usage
- pass request context in `proxyHandler`
- fix tests for new context-aware APIs

## Testing
- `go vet ./...`
- `go test ./...`
