### PR TITLE
Add transport timeout validation and keepalive option

### DIFF
--- a/app/config_validate.go
+++ b/app/config_validate.go
@@ -21,6 +21,18 @@ func validateConfig(c *Config) error {
 				return fmt.Errorf("integration %s has invalid rate_limit_window", i.Name)
 			}
 		}
+		if i.TLSHandshakeTimeout != "" {
+			d, err := time.ParseDuration(i.TLSHandshakeTimeout)
+			if err != nil || d <= 0 {
+				return fmt.Errorf("integration %s has invalid tls_handshake_timeout", i.Name)
+			}
+		}
+		if i.ResponseHeaderTimeout != "" {
+			d, err := time.ParseDuration(i.ResponseHeaderTimeout)
+			if err != nil || d <= 0 {
+				return fmt.Errorf("integration %s has invalid response_header_timeout", i.Name)
+			}
+		}
 	}
 	return nil
 }

--- a/app/config_validate_test.go
+++ b/app/config_validate_test.go
@@ -13,3 +13,16 @@ func TestValidateConfig(t *testing.T) {
 		t.Fatalf("expected error for missing name")
 	}
 }
+
+func TestValidateConfigBadTimeout(t *testing.T) {
+	cases := []Integration{
+		{Name: "a", Destination: "http://ex", TLSHandshakeTimeout: "bogus"},
+		{Name: "a", Destination: "http://ex", ResponseHeaderTimeout: "bogus"},
+	}
+	for _, in := range cases {
+		cfg := Config{Integrations: []Integration{in}}
+		if err := validateConfig(&cfg); err == nil {
+			t.Fatalf("expected error for bad timeout: %+v", in)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- expand `Integration` config to support disable keep-alives and timeout settings
- validate new timeout fields
- ensure proxy transport respects the settings
- test invalid timeout values
- test that `DisableKeepAlives` is applied

## Testing
- `go test ./...` *(fails: proxyconnect tcp: dial tcp 172.25.0.3:8080: connect: no route to host)*