### PR TITLE
Add integration transport settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ The project exists to make it trivial to translate one type of authentication in
 
    Use `0` (or a negative number) for `in_rate_limit` or `out_rate_limit` to disable rate limiting for that direction.
    The optional `rate_limit_window` sets the rolling window duration using Go's duration syntax; it defaults to `1m`.
+   Optional transport settings adjust the proxy's HTTP client:
+
+   - `idle_conn_timeout` – close idle connections after this duration.
+   - `tls_handshake_timeout` – maximum time for TLS handshakes.
+   - `response_header_timeout` – how long to wait for upstream headers.
+   - `tls_insecure_skip_verify` – skip TLS certificate verification.
+   - `disable_keep_alives` – disable HTTP keep-alive connections.
 
    The allowlist configuration lives in a separate `allowlist.json` file:
 

--- a/app/config_validate.go
+++ b/app/config_validate.go
@@ -21,6 +21,24 @@ func validateConfig(c *Config) error {
 				return fmt.Errorf("integration %s has invalid rate_limit_window", i.Name)
 			}
 		}
+		if i.IdleConnTimeout != "" {
+			d, err := time.ParseDuration(i.IdleConnTimeout)
+			if err != nil || d < 0 {
+				return fmt.Errorf("integration %s has invalid idle_conn_timeout", i.Name)
+			}
+		}
+		if i.TLSHandshakeTimeout != "" {
+			d, err := time.ParseDuration(i.TLSHandshakeTimeout)
+			if err != nil || d < 0 {
+				return fmt.Errorf("integration %s has invalid tls_handshake_timeout", i.Name)
+			}
+		}
+		if i.ResponseHeaderTimeout != "" {
+			d, err := time.ParseDuration(i.ResponseHeaderTimeout)
+			if err != nil || d < 0 {
+				return fmt.Errorf("integration %s has invalid response_header_timeout", i.Name)
+			}
+		}
 	}
 	return nil
 }

--- a/app/config_validate_test.go
+++ b/app/config_validate_test.go
@@ -13,3 +13,10 @@ func TestValidateConfig(t *testing.T) {
 		t.Fatalf("expected error for missing name")
 	}
 }
+
+func TestValidateConfigBadTimeout(t *testing.T) {
+	c := Config{Integrations: []Integration{{Name: "a", Destination: "http://ex", IdleConnTimeout: "not"}}}
+	if err := validateConfig(&c); err == nil {
+		t.Fatalf("expected error for invalid timeout")
+	}
+}

--- a/app/integration.go
+++ b/app/integration.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -131,6 +132,12 @@ type Integration struct {
 	OutgoingAuth    []AuthPluginConfig `json:"outgoing_auth"`
 	RateLimitWindow string             `json:"rate_limit_window"`
 
+	IdleConnTimeout       string `json:"idle_conn_timeout,omitempty"`
+	TLSHandshakeTimeout   string `json:"tls_handshake_timeout,omitempty"`
+	ResponseHeaderTimeout string `json:"response_header_timeout,omitempty"`
+	TLSInsecureSkipVerify bool   `json:"tls_insecure_skip_verify,omitempty"`
+	DisableKeepAlives     bool   `json:"disable_keep_alives,omitempty"`
+
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter
 
@@ -218,6 +225,44 @@ func prepareIntegration(i *Integration) error {
 			}
 		}
 	}
+
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if existing, ok := i.proxy.Transport.(*http.Transport); ok {
+		tr = existing.Clone()
+	}
+
+	if i.IdleConnTimeout != "" {
+		d, err := time.ParseDuration(i.IdleConnTimeout)
+		if err != nil || d < 0 {
+			return fmt.Errorf("invalid idle_conn_timeout: %w", err)
+		}
+		tr.IdleConnTimeout = d
+	}
+	if i.TLSHandshakeTimeout != "" {
+		d, err := time.ParseDuration(i.TLSHandshakeTimeout)
+		if err != nil || d < 0 {
+			return fmt.Errorf("invalid tls_handshake_timeout: %w", err)
+		}
+		tr.TLSHandshakeTimeout = d
+	}
+	if i.ResponseHeaderTimeout != "" {
+		d, err := time.ParseDuration(i.ResponseHeaderTimeout)
+		if err != nil || d < 0 {
+			return fmt.Errorf("invalid response_header_timeout: %w", err)
+		}
+		tr.ResponseHeaderTimeout = d
+	}
+	if i.TLSInsecureSkipVerify {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{}
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+	if i.DisableKeepAlives {
+		tr.DisableKeepAlives = true
+	}
+
+	i.proxy.Transport = tr
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- extend `Integration` with timeouts & TLS options
- validate and apply these options when building the reverse proxy
- document new configuration fields
- add unit tests
- remove local replace directive for fsnotify in `go.mod`

## Testing
- `go test ./...` *(fails: github.com/fsnotify/fsnotify@v1.9.0 download blocked)*