### PR TITLE
Add unit tests for secret helpers

### DIFF
--- a/app/integration_utils_test.go
+++ b/app/integration_utils_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+type secretCfg struct {
+	Secrets   []string
+	Extra     []string `json:"SeCrEtS"`
+	NotSlice  string   `json:"secrets"`
+	NotString []int    `json:"secrets"`
+}
+
+func TestCollectSecretRefs(t *testing.T) {
+	cfg := &secretCfg{
+		Secrets:   []string{"a", "b"},
+		Extra:     []string{"c", "d"},
+		NotSlice:  "x",
+		NotString: []int{1, 2},
+	}
+	refs := collectSecretRefs(cfg)
+	want := []string{"a", "b", "c", "d"}
+	if !reflect.DeepEqual(refs, want) {
+		t.Fatalf("expected %v, got %v", want, refs)
+	}
+}
+
+func TestCollectSecretRefsNonStruct(t *testing.T) {
+	if refs := collectSecretRefs(42); refs != nil {
+		t.Fatalf("expected nil, got %v", refs)
+	}
+}

--- a/app/secrets/registry_validate_test.go
+++ b/app/secrets/registry_validate_test.go
@@ -1,0 +1,26 @@
+package secrets_test
+
+import (
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/secrets"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
+)
+
+func TestValidateSecretOK(t *testing.T) {
+	if err := secrets.ValidateSecret("env:FOO"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateSecretUnknown(t *testing.T) {
+	if err := secrets.ValidateSecret("bogus:FOO"); err == nil {
+		t.Fatal("expected error for unknown prefix")
+	}
+}
+
+func TestValidateSecretBadFormat(t *testing.T) {
+	if err := secrets.ValidateSecret("missingcolon"); err == nil {
+		t.Fatal("expected error for invalid reference")
+	}
+}


### PR DESCRIPTION
## Summary
- cover collectSecretRefs helper in integration tests
- add tests for ValidateSecret checking valid, unknown and malformed references

## Testing
- `go test ./...`