### PR TITLE
Fix allowlist integration name case mismatch

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -52,6 +52,7 @@ func validateAllowlist(name string, callers []CallerConfig) error {
 // SetAllowlist registers the caller allowlist for an integration. It returns an
 // error if duplicate caller IDs or rules are detected.
 func SetAllowlist(name string, callers []CallerConfig) error {
+	name = strings.ToLower(name)
 	callers = integrationplugins.ExpandCapabilities(name, callers)
 	if err := validateAllowlist(name, callers); err != nil {
 		return err

--- a/app/allowlist_case_test.go
+++ b/app/allowlist_case_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	_ "github.com/winhowes/AuthTranslator/app/authplugins/token"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
+)
+
+func TestAllowlistCaseInsensitive(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	t.Setenv("TOK", "secret")
+	integ := Integration{
+		Name:         "foo",
+		Destination:  backend.URL,
+		InRateLimit:  1,
+		OutRateLimit: 1,
+		IncomingAuth: []AuthPluginConfig{{Type: "token", Params: map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "X-Auth"}}},
+	}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("failed to add integration: %v", err)
+	}
+	// allow only /ok path; integration name uses different case
+	if err := SetAllowlist("FOO", []CallerConfig{{ID: "*", Rules: []CallRule{{Path: "/ok", Methods: map[string]RequestConstraint{"GET": {}}}}}}); err != nil {
+		t.Fatalf("failed to set allowlist: %v", err)
+	}
+	t.Cleanup(func() {
+		integ.inLimiter.Stop()
+		integ.outLimiter.Stop()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://foo/deny", nil)
+	req.Host = "foo"
+	req.Header.Set("X-Auth", "secret")
+	rr := httptest.NewRecorder()
+	proxyHandler(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure SetAllowlist stores integration names in lowercase
- add regression test demonstrating case-insensitive allowlist lookup

## Testing
- `go test -count=1 ./app -run TestAllowlistCaseInsensitive -v`
- `go test ./...`