### PR TITLE
Fix go vet duplicate JSON tag

### DIFF
--- a/app/integration_utils_test.go
+++ b/app/integration_utils_test.go
@@ -9,7 +9,7 @@ type secretCfg struct {
 	Secrets   []string
 	Extra     []string `json:"SeCrEtS"`
 	NotSlice  string   `json:"secrets"`
-	NotString []int    `json:"secrets"`
+	NotString []int    `json:"sEcReTs"`
 }
 
 func TestCollectSecretRefs(t *testing.T) {


### PR DESCRIPTION
## Summary
- fix go vet issue about duplicate json tag in tests

## Testing
- `go vet ./...`
- `go test ./...`
