### PR TITLE
Add missing tests

### DIFF
--- a/app/integrationplugins/capabilities_test.go
+++ b/app/integrationplugins/capabilities_test.go
@@ -1,0 +1,27 @@
+package integrationplugins
+
+import "testing"
+
+func TestCapabilityGenerate(t *testing.T) {
+	caps := AllCapabilities()
+	for integ, m := range caps {
+		if len(m) == 0 {
+			t.Errorf("no capabilities for %s", integ)
+			continue
+		}
+		for name, spec := range m {
+			params := map[string]interface{}{}
+			for _, p := range spec.Params {
+				params[p] = "x"
+			}
+			rules, err := spec.Generate(params)
+			if err != nil {
+				t.Errorf("%s %s generate error: %v", integ, name, err)
+				continue
+			}
+			if len(rules) == 0 {
+				t.Errorf("%s %s returned no rules", integ, name)
+			}
+		}
+	}
+}

--- a/app/redis_test.go
+++ b/app/redis_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"bufio"
+	"net"
+	"testing"
+)
+
+func TestRedisCmdInt(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer srv.Close()
+	defer cli.Close()
+
+	go func() {
+		br := bufio.NewReader(srv)
+		// read request
+		if _, err := br.ReadBytes('\n'); err != nil {
+			return
+		}
+		if _, err := br.ReadBytes('\n'); err != nil {
+			return
+		}
+		srv.Write([]byte(":5\r\n"))
+	}()
+
+	n, err := redisCmdInt(cli, "INCR", "key")
+	if err != nil {
+		t.Fatalf("redisCmdInt error: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("redisCmdInt returned %d, want 5", n)
+	}
+}
+
+func TestRedisCmdIntError(t *testing.T) {
+	srv, cli := net.Pipe()
+	defer srv.Close()
+	defer cli.Close()
+
+	go func() {
+		br := bufio.NewReader(srv)
+		br.ReadBytes('\n')
+		br.ReadBytes('\n')
+		srv.Write([]byte("-ERR fail\r\n"))
+	}()
+
+	_, err := redisCmdInt(cli, "INCR", "key")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/app/watch_files_test.go
+++ b/app/watch_files_test.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWatchFiles(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watch*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := tmp.Name()
+	tmp.Close()
+	defer os.Remove(name)
+
+	ch := make(chan struct{}, 1)
+	go watchFiles([]string{name}, ch)
+
+	// give watcher time to start
+	time.Sleep(20 * time.Millisecond)
+
+	if err := os.WriteFile(name, []byte("1"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-ch:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for event")
+	}
+}

--- a/cmd/integrations/cli_test.go
+++ b/cmd/integrations/cli_test.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestCLIListDeleteUpdate(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/integrations", func(w http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case http.MethodGet:
+			json.NewEncoder(w).Encode([]struct {
+				Name string `json:"name"`
+			}{{"cli"}})
+		case http.MethodDelete:
+			w.WriteHeader(http.StatusNoContent)
+		case http.MethodPut:
+			w.WriteHeader(http.StatusOK)
+		case http.MethodPost:
+			w.WriteHeader(http.StatusCreated)
+		}
+	})
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	// list
+	out, err := exec.Command("go", "run", "./cmd/integrations", "-server", srv.URL, "list").CombinedOutput()
+	if err != nil {
+		t.Fatalf("list failed: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "cli") {
+		t.Fatalf("list output unexpected: %s", out)
+	}
+
+	// update
+	out, err = exec.Command("go", "run", "./cmd/integrations", "-server", srv.URL, "update", "slack", "-name", "cli", "-token", "t", "-signing-secret", "s").CombinedOutput()
+	if err != nil {
+		t.Fatalf("update failed: %v\n%s", err, out)
+	}
+
+	// delete
+	out, err = exec.Command("go", "run", "./cmd/integrations", "-server", srv.URL, "delete", "cli").CombinedOutput()
+	if err != nil {
+		t.Fatalf("delete failed: %v\n%s", err, out)
+	}
+}

--- a/fsnotify/fsnotify_test.go
+++ b/fsnotify/fsnotify_test.go
@@ -1,0 +1,56 @@
+package fsnotify
+
+import (
+	"os"
+	"testing"
+	"time"
+)
+
+func TestWatcherWriteRename(t *testing.T) {
+	tmp, err := os.CreateTemp("", "watch*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := tmp.Name()
+	tmp.Close()
+	defer os.Remove(name)
+
+	w, err := NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	w.ticker.Stop()
+	w.ticker = time.NewTicker(10 * time.Millisecond)
+
+	if err := w.Add(name); err != nil {
+		t.Fatal(err)
+	}
+
+	// modify
+	if err := os.WriteFile(name, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case ev := <-w.Events:
+		if ev.Name != name || ev.Op != Write {
+			t.Fatalf("unexpected event: %#v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for write event")
+	}
+
+	// remove triggers rename
+	if err := os.Remove(name); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case ev := <-w.Events:
+		if ev.Name != name || ev.Op != Rename {
+			t.Fatalf("unexpected event: %#v", ev)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for rename event")
+	}
+}


### PR DESCRIPTION
## Summary
- add polling watcher test
- test watchFiles event propagation
- cover redisCmdInt success and error cases
- exercise integrations CLI with an httptest server
- verify integration capabilities generate rules

## Testing
- `go vet ./...` *(fails: go.mod requires go >= 1.24.3)*
- `go test ./...` *(fails: go.mod requires go >= 1.24.3)*