### PR TITLE
Improve HTTP transport tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ The project exists to make it trivial to translate one type of authentication in
       "in_rate_limit": 100,
       "out_rate_limit": 1000,
       "rate_limit_window": "1m",
+      "max_idle_conns": 100,
+      "max_idle_conns_per_host": 20,
       "incoming_auth": [
            {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
          ],
@@ -104,6 +106,8 @@ The project exists to make it trivial to translate one type of authentication in
    - `response_header_timeout` – how long to wait for upstream headers.
    - `tls_insecure_skip_verify` – skip TLS certificate verification.
    - `disable_keep_alives` – disable HTTP keep-alive connections.
+   - `max_idle_conns` – total idle connections to keep pooled.
+   - `max_idle_conns_per_host` – idle connections per upstream host.
 
    The allowlist configuration lives in a separate `allowlist.json` file:
 

--- a/app/config.json
+++ b/app/config.json
@@ -6,6 +6,8 @@
         "in_rate_limit": 100,
         "out_rate_limit": 1000,
         "rate_limit_window": "1m",
+        "max_idle_conns": 100,
+        "max_idle_conns_per_host": 20,
         "incoming_auth": [
                 {"type": "token", "params": {"secrets": ["env:IN_TOKEN"], "header": "X-Auth"}}
             ],

--- a/app/config_validate.go
+++ b/app/config_validate.go
@@ -58,6 +58,12 @@ func validateConfig(c *Config) error {
 				return fmt.Errorf("integration %s has invalid response_header_timeout", i.Name)
 			}
 		}
+		if i.MaxIdleConns < 0 {
+			return fmt.Errorf("integration %s has invalid max_idle_conns", i.Name)
+		}
+		if i.MaxIdleConnsPerHost < 0 {
+			return fmt.Errorf("integration %s has invalid max_idle_conns_per_host", i.Name)
+		}
 	}
 	return nil
 }

--- a/app/config_validate_test.go
+++ b/app/config_validate_test.go
@@ -55,3 +55,15 @@ func TestValidateConfigBadDestination(t *testing.T) {
 		t.Fatalf("expected error for invalid destination")
 	}
 }
+
+func TestValidateConfigBadIdleConns(t *testing.T) {
+	c := Config{Integrations: []Integration{{Name: "a", Destination: "http://ex", MaxIdleConns: -1}}}
+	if err := validateConfig(&c); err == nil {
+		t.Fatalf("expected error for invalid max idle conns")
+	}
+
+	c = Config{Integrations: []Integration{{Name: "b", Destination: "http://ex", MaxIdleConnsPerHost: -2}}}
+	if err := validateConfig(&c); err == nil {
+		t.Fatalf("expected error for invalid max idle conns per host")
+	}
+}

--- a/app/integration.go
+++ b/app/integration.go
@@ -139,6 +139,8 @@ type Integration struct {
 	ResponseHeaderTimeout string `json:"response_header_timeout,omitempty"`
 	TLSInsecureSkipVerify bool   `json:"tls_insecure_skip_verify,omitempty"`
 	DisableKeepAlives     bool   `json:"disable_keep_alives,omitempty"`
+	MaxIdleConns          int    `json:"max_idle_conns,omitempty"`
+	MaxIdleConnsPerHost   int    `json:"max_idle_conns_per_host,omitempty"`
 
 	inLimiter  *RateLimiter
 	outLimiter *RateLimiter
@@ -265,6 +267,12 @@ func prepareIntegration(i *Integration) error {
 	}
 	if i.DisableKeepAlives {
 		tr.DisableKeepAlives = true
+	}
+	if i.MaxIdleConns > 0 {
+		tr.MaxIdleConns = i.MaxIdleConns
+	}
+	if i.MaxIdleConnsPerHost > 0 {
+		tr.MaxIdleConnsPerHost = i.MaxIdleConnsPerHost
 	}
 
 	i.proxy.Transport = tr

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -224,6 +224,8 @@ func TestIntegrationTransportSettings(t *testing.T) {
 		TLSHandshakeTimeout:   "1s",
 		ResponseHeaderTimeout: "3s",
 		TLSInsecureSkipVerify: true,
+		MaxIdleConns:          5,
+		MaxIdleConnsPerHost:   3,
 	}
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("add: %v", err)
@@ -239,6 +241,9 @@ func TestIntegrationTransportSettings(t *testing.T) {
 	}
 	if tr.IdleConnTimeout != 2*time.Second || tr.TLSHandshakeTimeout != 1*time.Second || tr.ResponseHeaderTimeout != 3*time.Second {
 		t.Fatalf("transport timeouts not applied")
+	}
+	if tr.MaxIdleConns != 5 || tr.MaxIdleConnsPerHost != 3 {
+		t.Fatalf("idle connection limits not applied")
 	}
 	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
 		t.Fatalf("TLS settings not applied")


### PR DESCRIPTION
## Summary
- add optional max idle connection settings for integrations
- validate new fields and show them in sample config
- document transport settings
- test new settings

## Testing
- `go test ./...`