### PR TITLE
Fix int64 overflow in slack signature plugin

### DIFF
--- a/app/auth/plugins/slack_signature/incoming.go
+++ b/app/auth/plugins/slack_signature/incoming.go
@@ -6,6 +6,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"time"
@@ -95,6 +96,9 @@ func (s *SlackSignatureAuth) Authenticate(ctx context.Context, r *http.Request, 
 
 func abs(i int64) int64 {
 	if i < 0 {
+		if i == math.MinInt64 {
+			return math.MaxInt64
+		}
 		return -i
 	}
 	return i


### PR DESCRIPTION
## Summary
- guard against overflow in `abs` helper for Slack signature validation

## Testing
- `go vet ./...`
- `go test ./...`
