### PR TITLE
Optimize allowlist path matching

### DIFF
--- a/app/integrations/types.go
+++ b/app/integrations/types.go
@@ -2,8 +2,9 @@ package integrationplugins
 
 // CallRule ties a path pattern to method-specific constraints.
 type CallRule struct {
-	Path    string                       `json:"path"`
-	Methods map[string]RequestConstraint `json:"methods"`
+	Path     string                       `json:"path"`
+	Methods  map[string]RequestConstraint `json:"methods"`
+	Segments []string                     `json:"-"`
 }
 
 // RequestConstraint lists required headers and body parameters.


### PR DESCRIPTION
## Summary
- pre-parse allowlist rule paths into segments
- avoid splitting request paths repeatedly when matching rules
- return empty slice from `splitPath` instead of nil

## Testing
- `go test ./...`
