### PR TITLE
Fix DoS via unbounded body read

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window (default `1m` but configurable per integration via `rate_limit_window`). A value of `0` disables limiting.
 - **Redis Support**: Provide `-redis-addr` to use Redis for rate limit counters instead of in-memory tracking. If Redis is unavailable the limiter falls back to memory and logs an error.
+- **Request Body Limit**: The maximum buffered request body can be adjusted with `-max_body_size` (default 10MB).
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 - **Validated Startup**: The configuration is checked at startup and errors are reported before serving traffic.
@@ -176,6 +177,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-x_at_int_host` – only respect `X-AT-Int` when this host is requested
    - `-tls-cert` and `-tls-key` – TLS certificate and key to serve HTTPS
    - `-redis-addr` – Redis address for rate limit counters
+   - `-max_body_size` – maximum bytes buffered from request bodies
    - `-log-level` – log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)
    - `-log-format` – log output format (`text` or `json`)
    - `-debug` – expose the `/integrations` endpoint for the CLI

--- a/app/auth/body.go
+++ b/app/auth/body.go
@@ -3,9 +3,17 @@ package authplugins
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"net/http"
 )
+
+// MaxBodySize limits how many bytes GetBody will read. It can be overridden
+// by applications to enforce a custom limit.
+var MaxBodySize int64 = 10 << 20 // 10MB
+
+// ErrBodyTooLarge is returned when a request body exceeds MaxBodySize.
+var ErrBodyTooLarge = errors.New("body too large")
 
 type bodyKey struct{}
 
@@ -15,9 +23,13 @@ func GetBody(r *http.Request) ([]byte, error) {
 	if b, ok := r.Context().Value(bodyKey{}).([]byte); ok {
 		return b, nil
 	}
-	b, err := io.ReadAll(r.Body)
+	lr := io.LimitReader(r.Body, MaxBodySize+1)
+	b, err := io.ReadAll(lr)
 	if err != nil {
 		return nil, err
+	}
+	if int64(len(b)) > MaxBodySize {
+		return nil, ErrBodyTooLarge
 	}
 	r.Body = io.NopCloser(bytes.NewReader(b))
 	ctx := context.WithValue(r.Context(), bodyKey{}, b)

--- a/app/auth/body_test.go
+++ b/app/auth/body_test.go
@@ -57,3 +57,22 @@ func TestGetBodyReadError(t *testing.T) {
 		t.Fatal("expected error reading body")
 	}
 }
+
+func TestGetBodyTooLarge(t *testing.T) {
+	large := make([]byte, MaxBodySize+1)
+	r := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBuffer(large))
+	if _, err := GetBody(r); err == nil {
+		t.Fatal("expected error for large body")
+	}
+}
+
+func TestGetBodyCustomLimit(t *testing.T) {
+	old := MaxBodySize
+	MaxBodySize = 5
+	defer func() { MaxBodySize = old }()
+
+	r := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString("abcdef"))
+	if _, err := GetBody(r); !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("expected ErrBodyTooLarge, got %v", err)
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -70,6 +70,7 @@ var tlsKey = flag.String("tls-key", "", "path to TLS key")
 var logLevel = flag.String("log-level", "INFO", "log level: DEBUG, INFO, WARN, ERROR")
 var logFormat = flag.String("log-format", "text", "log output format: text or json")
 var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (host:port)")
+var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
 var logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -544,6 +545,8 @@ func serve(s server, cert, key string) error {
 func main() {
 	flag.Usage = usage
 	flag.Parse()
+
+	authplugins.MaxBodySize = *maxBodySizeFlag
 
 	if *showVersion {
 		fmt.Println(version)


### PR DESCRIPTION
## Summary
- limit GetBody to 10MB and error when exceeded
- add regression test for large body

## Testing
- `go vet ./...`
- `go test ./...`
