### PR TITLE
Add redis dial timeout flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls`, `url_path`, `github_signature` and `slack_signature` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window (default `1m` but configurable per integration via `rate_limit_window`). A value of `0` disables limiting.
-- **Redis Support**: Provide `-redis-addr` to use Redis for rate limit counters instead of in-memory tracking. If Redis is unavailable the limiter falls back to memory and logs an error.
+- **Redis Support**: Provide `-redis-addr` to use Redis for rate limit counters instead of in-memory tracking. If Redis is unavailable the limiter falls back to memory and logs an error. Use `-redis-timeout` to control the dial timeout (default `5s`).
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
 - **Validated Startup**: The configuration is checked at startup and errors are reported before serving traffic.
@@ -162,7 +162,7 @@ The project exists to make it trivial to translate one type of authentication in
 
 3. **Running**
 
-   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`. Set `-redis-addr` to persist rate limits in Redis; failures fall back to memory with an error log.
+   The listen address can be configured with the `-addr` flag. By default the server listens on `:8080`. Incoming requests are matched against the `X-AT-Int` header, if present, or otherwise the host header to determine the route and associated authentication plugin. Use `-disable_x_at_int` to ignore the header entirely or `-x_at_int_host` to only respect the header when a specific host is requested. The configuration file is chosen with `-config` (default `config.json`). The allowlist file can be specified with `-allowlist`; it defaults to `allowlist.json`. Set `-redis-addr` to persist rate limits in Redis; failures fall back to memory with an error log. Use `-redis-timeout` to control how long dialing Redis can take.
    Send `SIGHUP` or run with `-watch` to reload these files automatically without
    restarting. If the allowlist fails to load during reload, the previously loaded
    entries remain in effect.
@@ -176,6 +176,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-x_at_int_host` – only respect `X-AT-Int` when this host is requested
    - `-tls-cert` and `-tls-key` – TLS certificate and key to serve HTTPS
    - `-redis-addr` – Redis address for rate limit counters
+   - `-redis-timeout` – timeout for dialing Redis (default `5s`)
    - `-log-level` – log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)
    - `-log-format` – log output format (`text` or `json`)
    - `-debug` – expose the `/integrations` endpoint for the CLI
@@ -564,7 +565,7 @@ Example Terraform files are provided in the `terraform` directory for AWS, GCP a
 - [`terraform/azure`](terraform/azure/README.md) contains a configuration for deploying to Azure Container Instances.
 
 Set the required variables for your environment and run `terraform apply` inside the desired folder to create the service.
-All modules accept an optional `redis_address` variable to pass the `-redis-addr` flag to the container if you have a Redis instance. Each README lists the required variables along with example commands for initialization and deployment.
+All modules accept optional `redis_address` and `redis_timeout` variables to pass the `-redis-addr` and `-redis-timeout` flags to the container if you have a Redis instance. Each README lists the required variables along with example commands for initialization and deployment.
 
 ## Contributing
 

--- a/app/main.go
+++ b/app/main.go
@@ -70,6 +70,7 @@ var tlsKey = flag.String("tls-key", "", "path to TLS key")
 var logLevel = flag.String("log-level", "INFO", "log level: DEBUG, INFO, WARN, ERROR")
 var logFormat = flag.String("log-format", "text", "log output format: text or json")
 var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (host:port)")
+var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout for redis")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
 var logger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo}))
@@ -282,7 +283,7 @@ func (rl *RateLimiter) allowRedis(key string) (bool, error) {
 	}
 	var err error
 	if conn == nil {
-		conn, err = net.Dial("tcp", *redisAddr)
+		conn, err = net.DialTimeout("tcp", *redisAddr, *redisTimeout)
 		if err != nil {
 			return false, err
 		}

--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -68,10 +68,13 @@ func TestRateLimiterUnlimitedNegative(t *testing.T) {
 func TestRateLimiterRedisFallback(t *testing.T) {
 	old := *redisAddr
 	*redisAddr = "127.0.0.1:0" // unreachable
+	oldTimeout := *redisTimeout
+	*redisTimeout = time.Millisecond
 	rl := NewRateLimiter(1, time.Millisecond)
 	t.Cleanup(func() {
 		rl.Stop()
 		*redisAddr = old
+		*redisTimeout = oldTimeout
 	})
 
 	if !rl.Allow("k") {


### PR DESCRIPTION
## Summary
- add `-redis-timeout` flag and use it when connecting to Redis
- document the new flag in README
- set the timeout in rate limiter fallback test

## Testing
- `go test ./...`