### PR TITLE
Cache Go modules in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,16 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.24.3'
+      - name: Export Go module cache path
+        run: echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
+      - name: Restore module cache
+        id: modcache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
+      - name: Download dependencies
+        run: go mod download
       - name: Vet code
         run: go vet ./...
       - name: Lint (optional)
@@ -27,3 +37,9 @@ jobs:
         run: test -z "$(gofmt -l .)"
       - name: Run tests
         run: go test ./...
+      - name: Save module cache
+        uses: actions/cache/save@v4
+        if: ${{ steps.modcache.outputs.cache-hit != 'true' }}
+        with:
+          path: ${{ env.GOMODCACHE }}
+          key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}

--- a/README.md
+++ b/README.md
@@ -509,6 +509,9 @@ If you have [`golangci-lint`](https://github.com/golangci/golangci-lint) install
 golangci-lint run
 ```
 
+The CI workflow caches the Go modules directory using `actions/cache` to speed
+up dependency installation.
+
 ## Docker
 
 Build the container image:


### PR DESCRIPTION
## Summary
- cache Go module downloads in test workflow
- mention dependency caching in README

## Testing
- `go vet ./...`
- `go test ./...`
