### PR TITLE
Fix tests under race detector

### DIFF
--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -181,7 +181,7 @@ func TestIntegrationRateLimitWindow(t *testing.T) {
 		Destination:     "http://example.com",
 		InRateLimit:     1,
 		OutRateLimit:    1,
-		RateLimitWindow: "10ms",
+		RateLimitWindow: "30ms",
 	}
 	if err := AddIntegration(i); err != nil {
 		t.Fatalf("add: %v", err)
@@ -197,7 +197,7 @@ func TestIntegrationRateLimitWindow(t *testing.T) {
 	if i.inLimiter.Allow("a") {
 		t.Fatal("limit should be enforced")
 	}
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(40 * time.Millisecond)
 	if !i.inLimiter.Allow("a") {
 		t.Fatal("limit did not reset after window")
 	}

--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -22,7 +22,7 @@ func TestRateLimiterExceedLimit(t *testing.T) {
 }
 
 func TestRateLimiterReset(t *testing.T) {
-	rl := NewRateLimiter(1, 10*time.Millisecond)
+	rl := NewRateLimiter(1, 20*time.Millisecond)
 	t.Cleanup(rl.Stop)
 	key := "caller"
 
@@ -34,7 +34,7 @@ func TestRateLimiterReset(t *testing.T) {
 	}
 
 	// wait for reset
-	time.Sleep(15 * time.Millisecond)
+	time.Sleep(25 * time.Millisecond)
 
 	if !rl.Allow(key) {
 		t.Fatal("rate limiter should reset after duration")
@@ -70,7 +70,7 @@ func TestRateLimiterRedisFallback(t *testing.T) {
 	*redisAddr = "127.0.0.1:0" // unreachable
 	oldTimeout := *redisTimeout
 	*redisTimeout = time.Millisecond
-	rl := NewRateLimiter(1, time.Millisecond)
+	rl := NewRateLimiter(1, 10*time.Millisecond)
 	t.Cleanup(func() {
 		rl.Stop()
 		*redisAddr = old

--- a/app/watch_files_test.go
+++ b/app/watch_files_test.go
@@ -22,7 +22,7 @@ func TestWatchFiles(t *testing.T) {
 	go watchFiles(ctx, []string{name}, ch)
 
 	// give watcher time to start
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	if err := os.WriteFile(name, []byte("1"), 0o644); err != nil {
 		t.Fatal(err)
@@ -51,7 +51,7 @@ func TestWatchFilesRename(t *testing.T) {
 	go watchFiles(ctx, []string{name}, ch)
 
 	// allow watcher to start
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 
 	// rename the file to trigger an event and remove the watch
 	newName := name + ".old"
@@ -71,7 +71,7 @@ func TestWatchFilesRename(t *testing.T) {
 		t.Fatal(err)
 	}
 	// give watcher time to re-add
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(50 * time.Millisecond)
 	if err := os.WriteFile(name, []byte("y"), 0o644); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- extend timing windows in rate limiter and watch file tests
- adjust integration rate limit window for race detector

## Testing
- `go test ./... -race`
