### PR TITLE
Fix splitPath handling of empty paths

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -19,7 +19,11 @@ var allowlists = struct {
 }{m: make(map[string]map[string]CallerConfig)}
 
 func splitPath(p string) []string {
-	clean := strings.Trim(path.Clean(p), "/")
+	clean := path.Clean(p)
+	if clean == "." {
+		return []string{}
+	}
+	clean = strings.Trim(clean, "/")
 	if clean == "" {
 		return []string{}
 	}

--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -78,3 +78,10 @@ func TestValidateRequestBodyMismatch(t *testing.T) {
 		t.Fatal("expected body mismatch to fail")
 	}
 }
+
+func TestSplitPathEmpty(t *testing.T) {
+	got := splitPath("")
+	if len(got) != 0 {
+		t.Fatalf("expected empty slice, got %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- fix `splitPath` when called with an empty string
- add a test verifying the corrected behavior

## Testing
- `go vet ./...`
- `go test ./...`
