### PR TITLE
feat: add Redis TLS and auth support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls`, `url_path`, `github_signature` and `slack_signature` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window (default `1m` but configurable per integration via `rate_limit_window`). A value of `0` disables limiting.
-- **Redis Support**: Provide `-redis-addr` to use Redis for rate limit counters instead of in-memory tracking. If Redis is unavailable the limiter falls back to memory and logs an error.
+- **Redis Support**: Provide `-redis-addr` as a Redis URL (e.g. `redis://host:6379` or `rediss://:password@host:6379`) to use Redis for rate limit counters instead of in-memory tracking. Use the `rediss` scheme to enable TLS. Include the password in the URL (`:password@`) to authenticate with Redis; the username portion is ignored. If Redis is unavailable the limiter falls back to memory and logs an error.
 - **Request Body Limit**: The maximum buffered request body can be adjusted with `-max_body_size` (default 10MB). Set the flag to `0` to disable the limit entirely.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a JSON configuration file.
@@ -161,7 +161,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-disable_x_at_int` – ignore the `X-AT-Int` header
    - `-x_at_int_host` – only respect `X-AT-Int` when this host is requested
    - `-tls-cert` and `-tls-key` – TLS certificate and key to serve HTTPS
-   - `-redis-addr` – Redis address for rate limit counters
+   - `-redis-addr` – Redis URL for rate limit counters. Use `rediss://` for TLS and include `:password@` before the host to authenticate.
    - `-redis-timeout` – timeout for dialing Redis (default `5s`)
   - `-max_body_size` – maximum bytes buffered from request bodies; use `0` to disable
    - `-log-level` – log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)

--- a/app/main.go
+++ b/app/main.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -12,6 +13,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/signal"
 	"strconv"
@@ -284,10 +286,43 @@ func (rl *RateLimiter) allowRedis(key string) (bool, error) {
 		}
 	}
 	var err error
+	var password string
 	if conn == nil {
-		conn, err = net.DialTimeout("tcp", *redisAddr, *redisTimeout)
+		addr := *redisAddr
+		useTLS := false
+		if strings.Contains(addr, "://") {
+			u, err := url.Parse(addr)
+			if err != nil {
+				return false, err
+			}
+			if u.Host != "" {
+				addr = u.Host
+			}
+			switch u.Scheme {
+			case "rediss":
+				useTLS = true
+			case "", "redis":
+			default:
+				return false, fmt.Errorf("unsupported redis scheme %q", u.Scheme)
+			}
+			if u.User != nil {
+				password, _ = u.User.Password()
+			}
+		}
+		d := net.Dialer{Timeout: *redisTimeout}
+		if useTLS {
+			conn, err = tls.DialWithDialer(&d, "tcp", addr, &tls.Config{InsecureSkipVerify: true})
+		} else {
+			conn, err = d.Dial("tcp", addr)
+		}
 		if err != nil {
 			return false, err
+		}
+		if password != "" {
+			if err := redisCmd(conn, "AUTH", password); err != nil {
+				conn.Close()
+				return false, err
+			}
 		}
 	}
 	bad := false
@@ -346,6 +381,34 @@ func redisCmdInt(conn net.Conn, args ...string) (int, error) {
 		return 0, fmt.Errorf("redis error: %s", strings.TrimSpace(line))
 	default:
 		return 0, fmt.Errorf("unexpected reply: %q", prefix)
+	}
+}
+
+func redisCmd(conn net.Conn, args ...string) error {
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "*%d\r\n", len(args))
+	for _, a := range args {
+		fmt.Fprintf(&buf, "$%d\r\n%s\r\n", len(a), a)
+	}
+	if _, err := conn.Write(buf.Bytes()); err != nil {
+		return err
+	}
+	br := bufio.NewReader(conn)
+	prefix, err := br.ReadByte()
+	if err != nil {
+		return err
+	}
+	line, err := br.ReadString('\n')
+	if err != nil {
+		return err
+	}
+	switch prefix {
+	case '+', ':':
+		return nil
+	case '-':
+		return fmt.Errorf("redis error: %s", strings.TrimSpace(line))
+	default:
+		return fmt.Errorf("unexpected reply: %q", prefix)
 	}
 }
 

--- a/app/redis_tls_auth_test.go
+++ b/app/redis_tls_auth_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"bufio"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func readCommand(t *testing.T, br *bufio.Reader) string {
+	t.Helper()
+	line, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(line) == 0 || line[0] != '*' {
+		t.Fatalf("bad prefix %q", line)
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(line[1:]))
+	if err != nil {
+		t.Fatal(err)
+	}
+	line, err = br.ReadString('\n') // $len
+	if err != nil {
+		t.Fatal(err)
+	}
+	line, err = br.ReadString('\n') // command
+	if err != nil {
+		t.Fatal(err)
+	}
+	cmd := strings.ToUpper(strings.TrimSpace(line))
+	for i := 1; i < count; i++ {
+		if _, err := br.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := br.ReadString('\n'); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return cmd
+}
+
+func TestRateLimiterRedisAuth(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		if cmd := readCommand(t, br); cmd != "AUTH" {
+			t.Errorf("cmd %s, want AUTH", cmd)
+			return
+		}
+		c.Write([]byte("+OK\r\n"))
+		if cmd := readCommand(t, br); cmd != "INCR" {
+			t.Errorf("cmd %s, want INCR", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+		if cmd := readCommand(t, br); cmd != "EXPIRE" {
+			t.Errorf("cmd %s, want EXPIRE", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+	}()
+	oldAddr := *redisAddr
+	oldTimeout := *redisTimeout
+	*redisAddr = "redis://:pw@" + ln.Addr().String()
+	*redisTimeout = time.Second
+	rl := NewRateLimiter(1, time.Second)
+	defer func() {
+		rl.Stop()
+		*redisAddr = oldAddr
+		*redisTimeout = oldTimeout
+	}()
+	if !rl.Allow("k") {
+		t.Fatal("allow failed")
+	}
+	<-done
+}
+
+func TestRateLimiterRedisTLSAuth(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "srv"},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	cert, _ := tls.X509KeyPair(certPEM, keyPEM)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		if cmd := readCommand(t, br); cmd != "AUTH" {
+			t.Errorf("cmd %s, want AUTH", cmd)
+			return
+		}
+		c.Write([]byte("+OK\r\n"))
+		if cmd := readCommand(t, br); cmd != "INCR" {
+			t.Errorf("cmd %s, want INCR", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+		if cmd := readCommand(t, br); cmd != "EXPIRE" {
+			t.Errorf("cmd %s, want EXPIRE", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+	}()
+	oldAddr := *redisAddr
+	oldTimeout := *redisTimeout
+	*redisAddr = "rediss://:pw@" + ln.Addr().String()
+	*redisTimeout = time.Second
+	rl := NewRateLimiter(1, time.Second)
+	defer func() {
+		rl.Stop()
+		*redisAddr = oldAddr
+		*redisTimeout = oldTimeout
+	}()
+	if !rl.Allow("k") {
+		t.Fatal("allow failed")
+	}
+	<-done
+}


### PR DESCRIPTION
## Summary
- support `redis-addr` URL parsing in rate limiter
- dial TLS when scheme is `rediss`
- authenticate with Redis when URL includes password
- document new flag behaviour
- test TLS and AUTH flows against mock Redis servers
- clarify how to specify Redis passwords

## Testing
- `go test ./...`