### PR TITLE
feat: add query parameter constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,23 @@ methods:
       tag: ["a", "b"]
 ```
 
+Query parameters may also be constrained. Each parameter listed under
+`query` must appear in the request. If the value list is empty the parameter
+only needs to exist. Otherwise every value must be present, though additional
+values are allowed:
+
+```yaml
+path: /search
+methods:
+  GET:
+    query:
+      q: ["example", "foo"]
+      lang: []
+```
+
+The above rule requires that `q` include both `example` and `foo` among its
+values and that a `lang` parameter is present with any value.
+
 #### Body Matching
 
 Body rules are checked against only the fields listed in the rule. Additional

--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -136,6 +136,11 @@ func validateRequest(r *http.Request, c RequestConstraint) bool {
 			return false
 		}
 	}
+	if len(c.Query) > 0 {
+		if !matchQuery(r.URL.Query(), c.Query) {
+			return false
+		}
+	}
 	if len(c.Body) == 0 {
 		return true
 	}
@@ -184,6 +189,28 @@ func matchForm(vals url.Values, rule map[string]interface{}) bool {
 				if !found {
 					return false
 				}
+			}
+		}
+	}
+	return true
+}
+
+func matchQuery(vals url.Values, rule map[string][]string) bool {
+	for k, wantVals := range rule {
+		present, ok := vals[k]
+		if !ok {
+			return false
+		}
+		for _, want := range wantVals {
+			found := false
+			for _, got := range present {
+				if got == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
 			}
 		}
 	}

--- a/app/allowlist.json
+++ b/app/allowlist.json
@@ -1,6 +1,22 @@
 [
     {
         "integration": "example",
-        "callers": []
+        "callers": [
+            {
+                "id": "sample",
+                "rules": [
+                    {
+                        "path": "/search",
+                        "methods": {
+                            "GET": {
+                                "query": {
+                                    "q": ["example"]
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        ]
     }
 ]

--- a/app/allowlist.yaml
+++ b/app/allowlist.yaml
@@ -1,2 +1,9 @@
 - integration: example
-  callers: []
+  callers:
+    - id: sample
+      rules:
+        - path: /search
+          methods:
+            GET:
+              query:
+                q: ["example"]

--- a/app/allowlist_helpers_test.go
+++ b/app/allowlist_helpers_test.go
@@ -85,6 +85,18 @@ func TestValidateRequestTable(t *testing.T) {
 			cons:   RequestConstraint{Body: map[string]interface{}{"a": []interface{}{"1", "3"}, "b": "2"}},
 			wantOK: true,
 		},
+		{
+			name:   "query match",
+			r:      httptest.NewRequest(http.MethodGet, "http://x?a=1&b=2", nil),
+			cons:   RequestConstraint{Query: map[string][]string{"a": {"1"}, "b": {"2"}}},
+			wantOK: true,
+		},
+		{
+			name:   "query missing",
+			r:      httptest.NewRequest(http.MethodGet, "http://x?a=1", nil),
+			cons:   RequestConstraint{Query: map[string][]string{"a": {"1"}, "b": {"2"}}},
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -70,6 +70,18 @@ func TestValidateRequestFormBody(t *testing.T) {
 	}
 }
 
+func TestValidateRequestQuery(t *testing.T) {
+	r := httptest.NewRequest(http.MethodGet, "http://x?a=1&a=2&b=3", nil)
+	cons := RequestConstraint{Query: map[string][]string{"a": {"1"}, "b": {"3"}}}
+	if !validateRequest(r, cons) {
+		t.Fatal("expected query match")
+	}
+	r2 := httptest.NewRequest(http.MethodGet, "http://x?a=1", nil)
+	if validateRequest(r2, cons) {
+		t.Fatal("expected missing query to fail")
+	}
+}
+
 func TestValidateRequestBodyMismatch(t *testing.T) {
 	body := []byte(`{"a":"x"}`)
 	r := newRequest(http.MethodPost, "http://x", "application/json", body)

--- a/app/integrations/types.go
+++ b/app/integrations/types.go
@@ -10,6 +10,7 @@ type CallRule struct {
 // RequestConstraint lists required headers and body parameters.
 type RequestConstraint struct {
 	Headers []string               `json:"headers"`
+	Query   map[string][]string    `json:"query"`
 	Body    map[string]interface{} `json:"body"`
 }
 


### PR DESCRIPTION
## Notes
- Adds query matching support to allowlist rules and updates examples.
- Clarify query constraint semantics in README.

## Summary
- support `query` field in request constraints
- check query params when validating requests
- document query rules in README
- extend example allowlist files with query params
- add tests for query matching

## Testing
- `go test ./...`
