### PR TITLE
Add coverage reporting to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,12 @@ jobs:
           fi
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
-      - name: Run tests
-        run: go test ./...
+      - name: Run tests with coverage
+        run: go test -coverprofile=coverage.out ./...
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.out
       - name: Save module cache
         uses: actions/cache/save@v4
         if: ${{ steps.modcache.outputs.cache-hit != 'true' }}


### PR DESCRIPTION
## Summary
- collect test coverage during CI
- upload coverage results to Codecov

## Testing
- `go mod download` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*