### PR TITLE
Add goreleaser workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: '1.24.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v5
+        uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
           args: release --clean

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*.*.*']
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.3'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GORELEASER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,30 @@
+project_name: authtranslator
+release:
+  github:
+    owner: winhowes
+    name: AuthTranslator
+builds:
+  - id: authtranslator
+    main: ./app
+    binary: authtranslator
+    ldflags: -s -w -X main.version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+archives:
+  - id: default
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+      - app/config.yaml
+      - app/allowlist.yaml

--- a/README.md
+++ b/README.md
@@ -50,19 +50,28 @@ The project exists to make it trivial to translate one type of authentication in
 
 ## Getting Started
 
-1. **Build or Run**
-   
+1. **Download or Build**
+
+   Grab a pre-built binary from the latest release:
+
+   ```bash
+   curl -L https://github.com/winhowes/AuthTranslator/releases/latest/download/authtranslator_$(uname -s)_$(uname -m).tar.gz | tar -xz
+   ./authtranslator -config app/config.yaml
+   ```
+
+   Or run from source:
+
    ```bash
    go run ./app -config app/config.yaml
    ```
 
-   Run `go run ./app --help` to see all available flags.
-   Provide `-tls-cert` and `-tls-key` together to serve HTTPS using the
+   Run `go run ./app --help` to see all available flags. Provide
+   `-tls-cert` and `-tls-key` together to serve HTTPS using the
    specified certificate and key. Supplying only one of these options
    results in an error.
-   
+
    Or build an executable:
-   
+
    ```bash
    go build -o authtranslator ./app
    ./authtranslator -config app/config.yaml


### PR DESCRIPTION
## Summary
- create goreleaser config to build cross-platform binaries
- add workflow to run GoReleaser on tag pushes
- document how to download release binaries

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*