### PR TITLE
Add precommit make target

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,26 +4,16 @@ Thank you for your interest in contributing! This project uses the standard Go t
 
 ## Development workflow
 
-1. Format your code before committing:
+1. Run the precommit checks to format, vet and lint your code:
    ```bash
-gofmt -w <files>
-```
-   Run `gofmt -w` on any files you changed so the style stays consistent.
-
-2. Run vet and tests:
-   ```bash
-go vet ./...
-go test ./...
+make precommit
 ```
 
-3. Optional linting
-
-   If you have [`golangci-lint`](https://github.com/golangci/golangci-lint) installed you can run:
+2. Run the tests:
    ```bash
-golangci-lint run
+make test
 ```
-   Linting is not required but helps catch issues early.
 
-4. Commit your changes and open a pull request on GitHub targeting the `main` branch.
+3. Commit your changes and open a pull request on GitHub targeting the `main` branch.
 
 We appreciate bug fixes, new features and improvements to the documentation. Thanks for contributing!

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fmt vet test docker
+.PHONY: fmt vet lint test docker precommit
 
 GOFILES := $(shell find . -name '*.go')
 
@@ -6,10 +6,19 @@ fmt:
 	gofmt -w $(GOFILES)
 
 vet:
-	go vet ./...
+        go vet ./...
+
+lint:
+@if command -v golangci-lint >/dev/null 2>&1; then \
+golangci-lint run; \
+else \
+echo "golangci-lint not installed, skipping"; \
+fi
 
 test:
 	go test ./...
 
 docker:
-	docker build -t authtranslator .
+        docker build -t authtranslator .
+
+precommit: fmt vet lint

--- a/README.md
+++ b/README.md
@@ -526,20 +526,14 @@ The CLI updates the file in place (default `allowlist.yaml`, overridable with `-
 
 ## Running Tests
 
-Use the Makefile or the Go toolchain to vet and test the code:
+Use the Makefile to format, vet and lint the code before running tests:
 
 ```bash
-make vet
+make precommit
 make test
 ```
 
-These run `go vet ./...` and `go test ./...` respectively.
-
-If you have [`golangci-lint`](https://github.com/golangci/golangci-lint) installed you can also run:
-
-```bash
-golangci-lint run
-```
+`make precommit` runs `gofmt -w`, `go vet ./...` and `golangci-lint run` if available.
 
 The CI workflow caches the Go modules directory using `actions/cache` to speed
 up dependency installation.
@@ -615,8 +609,10 @@ A Makefile is provided to simplify formatting, vetting, testing and building the
 ```bash
 make fmt    # run gofmt on all Go files
 make vet    # run go vet ./...
+make lint   # run golangci-lint if installed
 make test   # run go test ./...
 make docker # build the container image
+make precommit # run fmt, vet and lint
 ```
 
 ## Contributing


### PR DESCRIPTION
## Summary
- add a `precommit` target to run fmt, vet and lint
- document new workflow in README and CONTRIBUTING

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*