### PR TITLE
Add Helm chart for Kubernetes deployment

### DIFF
--- a/charts/authtranslator/Chart.yaml
+++ b/charts/authtranslator/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: authtranslator
+version: 0.1.0
+description: A Helm chart for deploying AuthTranslator
+appVersion: "1.0"

--- a/charts/authtranslator/README.md
+++ b/charts/authtranslator/README.md
@@ -1,0 +1,24 @@
+# AuthTranslator Helm Chart
+
+This chart deploys [AuthTranslator](https://github.com/winhowes/AuthTranslator) as a Kubernetes Deployment with an accompanying Service.
+
+## Values
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `image.repository` | Container image repository | `ghcr.io/winhowes/authtranslator` |
+| `image.tag` | Image tag | `latest` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `redisAddress` | Redis connection string passed to `-redis-addr` | `""` |
+| `config` | Contents of `config.yaml` stored in a ConfigMap | sample configuration |
+| `allowlist` | Contents of `allowlist.yaml` stored in a ConfigMap | sample allowlist |
+
+The configuration and allowlist values are written to a ConfigMap that is mounted into the container at `/app/config.yaml` and `/app/allowlist.yaml`.
+
+## Installing
+
+```bash
+helm install my-release ./charts/authtranslator
+```
+
+Override any of the values above using the `--set` flag or a custom values file.

--- a/charts/authtranslator/templates/_helpers.tpl
+++ b/charts/authtranslator/templates/_helpers.tpl
@@ -1,0 +1,24 @@
+{{- define "authtranslator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "authtranslator.fullname" -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- $fullname := printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride }}
+{{- $fullname = .Values.fullnameOverride -}}
+{{- end -}}
+{{- $fullname -}}
+{{- end -}}
+
+{{- define "authtranslator.labels" -}}
+helm.sh/chart: {{ include "authtranslator.chart" . }}
+app.kubernetes.io/name: {{ include "authtranslator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "authtranslator.chart" -}}
+{{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}

--- a/charts/authtranslator/templates/configmap.yaml
+++ b/charts/authtranslator/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "authtranslator.fullname" . }}-config
+  labels:
+    {{- include "authtranslator.labels" . | nindent 4 }}
+data:
+  config.yaml: |-
+{{ .Values.config | indent 4 }}
+  allowlist.yaml: |-
+{{ .Values.allowlist | indent 4 }}

--- a/charts/authtranslator/templates/deployment.yaml
+++ b/charts/authtranslator/templates/deployment.yaml
@@ -1,0 +1,41 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "authtranslator.fullname" . }}
+  labels:
+    {{- include "authtranslator.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "authtranslator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        {{- include "authtranslator.labels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: authtranslator
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["./authtranslator"]
+          args:
+            {{- if .Values.redisAddress }}
+            - "-redis-addr"
+            - {{ .Values.redisAddress | quote }}
+            {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/config.yaml
+              subPath: config.yaml
+            - name: config
+              mountPath: /app/allowlist.yaml
+              subPath: allowlist.yaml
+          ports:
+            - containerPort: 8080
+              name: http
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "authtranslator.fullname" . }}-config

--- a/charts/authtranslator/templates/service.yaml
+++ b/charts/authtranslator/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "authtranslator.fullname" . }}
+  labels:
+    {{- include "authtranslator.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 80
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ include "authtranslator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/authtranslator/values.yaml
+++ b/charts/authtranslator/values.yaml
@@ -1,0 +1,39 @@
+image:
+  repository: ghcr.io/winhowes/authtranslator
+  tag: latest
+  pullPolicy: IfNotPresent
+
+redisAddress: ""
+
+config: |
+  integrations:
+    - name: example
+      destination: http://backend.example.com
+      in_rate_limit: 100
+      out_rate_limit: 1000
+      rate_limit_window: 1m
+      max_idle_conns: 100
+      max_idle_conns_per_host: 20
+      incoming_auth:
+        - type: token
+          params:
+            secrets:
+              - env:IN_TOKEN
+            header: X-Auth
+      outgoing_auth:
+        - type: token
+          params:
+            secrets:
+              - env:OUT_TOKEN
+            header: X-Auth
+
+allowlist: |
+  - integration: example
+    callers:
+      - id: sample
+        rules:
+          - path: /search
+            methods:
+              GET:
+                query:
+                  q: ["example"]


### PR DESCRIPTION
## Summary
- add a simple Helm chart under `charts/authtranslator`
- support custom image tag, Redis address and embedded config/allowlist ConfigMaps

## Testing
- `go vet ./...` *(fails: proxyconnect tcp: no route to host)*
- `go test ./...` *(fails: proxyconnect tcp: no route to host)*