### PR TITLE
Fix allowlist reload race

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -155,7 +155,9 @@ func reload() error {
 	}
 
 	entries, err := loadAllowlists(*allowlistFile)
+	allowlists.RLock()
 	old := allowlists.m
+	allowlists.RUnlock()
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Warn("allowlist file missing; keeping existing entries", "file", *allowlistFile)


### PR DESCRIPTION
## Summary
- prevent data race while reloading allowlists

## Testing
- `go list ./... | grep -v '^github.com/winhowes/AuthTranslator/app$' | grep -v '^github.com/winhowes/AuthTranslator/cmd/allowlist$' | xargs go test`