### PR TITLE
Add Redis CA option

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls`, `url_path`, `github_signature` and `slack_signature` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window (default `1m` but configurable per integration via `rate_limit_window`). A value of `0` disables limiting.
-- **Redis Support**: Provide `-redis-addr` as a Redis URL (e.g. `redis://host:6379` or `rediss://:password@host:6379`) to use Redis for rate limit counters instead of in-memory tracking. Use the `rediss` scheme to enable TLS. Include the password in the URL (`:password@`) to authenticate with Redis; the username portion is ignored. If Redis is unavailable the limiter falls back to memory and logs an error.
+- **Redis Support**: Provide `-redis-addr` as a Redis URL (e.g. `redis://host:6379` or `rediss://:password@host:6379`) to use Redis for rate limit counters instead of in-memory tracking. Use the `rediss` scheme to enable TLS. Include the password in the URL (`:password@`) to authenticate with Redis; the username portion is ignored. Certificate verification is skipped unless a CA file is supplied with `-redis-ca`. If Redis is unavailable the limiter falls back to memory and logs an error.
 - **Request Body Limit**: The maximum buffered request body can be adjusted with `-max_body_size` (default 10MB). Set the flag to `0` to disable the limit entirely.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a YAML configuration file.
@@ -171,6 +171,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-x_at_int_host` – only respect `X-AT-Int` when this host is requested
    - `-tls-cert` and `-tls-key` – TLS certificate and key to serve HTTPS
    - `-redis-addr` – Redis URL for rate limit counters. Use `rediss://` for TLS and include `:password@` before the host to authenticate.
+   - `-redis-ca` – CA certificate for verifying Redis TLS
    - `-redis-timeout` – timeout for dialing Redis (default `5s`)
   - `-max_body_size` – maximum bytes buffered from request bodies; use `0` to disable
    - `-log-level` – log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`)
@@ -602,7 +603,7 @@ Example Terraform files are provided in the `terraform` directory for AWS, GCP a
 - [`terraform/azure`](terraform/azure/README.md) contains a configuration for deploying to Azure Container Instances.
 
 Set the required variables for your environment and run `terraform apply` inside the desired folder to create the service.
-All modules accept optional `redis_address` and `redis_timeout` variables to pass the `-redis-addr` and `-redis-timeout` flags to the container if you have a Redis instance. Each README lists the required variables along with example commands for initialization and deployment.
+All modules accept optional `redis_address`, `redis_timeout` and `redis_ca` variables to pass the `-redis-addr`, `-redis-timeout` and `-redis-ca` flags to the container if you have a Redis instance. Each README lists the required variables along with example commands for initialization and deployment.
 
 ## Development
 

--- a/app/main.go
+++ b/app/main.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -74,6 +75,7 @@ var logLevel = flag.String("log-level", "INFO", "log level: DEBUG, INFO, WARN, E
 var logFormat = flag.String("log-format", "text", "log output format: text or json")
 var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (host:port)")
 var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout for redis")
+var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS; disables InsecureSkipVerify")
 var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies (0 to disable)")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
@@ -314,7 +316,21 @@ func (rl *RateLimiter) allowRedis(key string) (bool, error) {
 		}
 		d := net.Dialer{Timeout: *redisTimeout}
 		if useTLS {
-			conn, err = tls.DialWithDialer(&d, "tcp", addr, &tls.Config{InsecureSkipVerify: true})
+			tlsConf := &tls.Config{}
+			if *redisCA != "" {
+				caData, err := os.ReadFile(*redisCA)
+				if err != nil {
+					return false, err
+				}
+				pool := x509.NewCertPool()
+				if !pool.AppendCertsFromPEM(caData) {
+					return false, fmt.Errorf("failed to load CA file")
+				}
+				tlsConf.RootCAs = pool
+			} else {
+				tlsConf.InsecureSkipVerify = true
+			}
+			conn, err = tls.DialWithDialer(&d, "tcp", addr, tlsConf)
 		} else {
 			conn, err = d.Dial("tcp", addr)
 		}

--- a/app/redis_tls_auth_test.go
+++ b/app/redis_tls_auth_test.go
@@ -10,6 +10,8 @@ import (
 	"encoding/pem"
 	"math/big"
 	"net"
+	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -147,6 +149,83 @@ func TestRateLimiterRedisTLSAuth(t *testing.T) {
 		rl.Stop()
 		*redisAddr = oldAddr
 		*redisTimeout = oldTimeout
+	}()
+	if !rl.Allow("k") {
+		t.Fatal("allow failed")
+	}
+	<-done
+}
+
+func TestRateLimiterRedisTLSVerify(t *testing.T) {
+	caKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	caTmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTmpl, caTmpl, &caKey.PublicKey, caKey)
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+
+	srvKey, _ := rsa.GenerateKey(rand.Reader, 1024)
+	srvTmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "srv"},
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	srvDER, _ := x509.CreateCertificate(rand.Reader, srvTmpl, caTmpl, &srvKey.PublicKey, caKey)
+	srvCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: srvDER})
+	srvKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(srvKey)})
+	cert, _ := tls.X509KeyPair(srvCertPEM, srvKeyPEM)
+
+	ln, err := tls.Listen("tcp", "127.0.0.1:0", &tls.Config{Certificates: []tls.Certificate{cert}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		defer c.Close()
+		br := bufio.NewReader(c)
+		if cmd := readCommand(t, br); cmd != "AUTH" {
+			t.Errorf("cmd %s, want AUTH", cmd)
+			return
+		}
+		c.Write([]byte("+OK\r\n"))
+		if cmd := readCommand(t, br); cmd != "INCR" {
+			t.Errorf("cmd %s, want INCR", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+		if cmd := readCommand(t, br); cmd != "EXPIRE" {
+			t.Errorf("cmd %s, want EXPIRE", cmd)
+		}
+		c.Write([]byte(":1\r\n"))
+	}()
+	caFile := filepath.Join(t.TempDir(), "ca.pem")
+	os.WriteFile(caFile, caPEM, 0600)
+	oldAddr := *redisAddr
+	oldTimeout := *redisTimeout
+	oldCA := *redisCA
+	*redisAddr = "rediss://:pw@" + ln.Addr().String()
+	*redisTimeout = time.Second
+	*redisCA = caFile
+	rl := NewRateLimiter(1, time.Second)
+	defer func() {
+		rl.Stop()
+		*redisAddr = oldAddr
+		*redisTimeout = oldTimeout
+		*redisCA = oldCA
 	}()
 	if !rl.Allow("k") {
 		t.Fatal("allow failed")

--- a/charts/authtranslator/README.md
+++ b/charts/authtranslator/README.md
@@ -10,6 +10,7 @@ This chart deploys [AuthTranslator](https://github.com/winhowes/AuthTranslator) 
 | `image.tag` | Image tag | `latest` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `redisAddress` | Redis connection string passed to `-redis-addr` | `""` |
+| `redisCA` | CA file for verifying Redis TLS passed to `-redis-ca` | `""` |
 | `config` | Contents of `config.yaml` stored in a ConfigMap | sample configuration |
 | `allowlist` | Contents of `allowlist.yaml` stored in a ConfigMap | sample allowlist |
 

--- a/charts/authtranslator/templates/deployment.yaml
+++ b/charts/authtranslator/templates/deployment.yaml
@@ -25,6 +25,10 @@ spec:
             - "-redis-addr"
             - {{ .Values.redisAddress | quote }}
             {{- end }}
+            {{- if .Values.redisCA }}
+            - "-redis-ca"
+            - {{ .Values.redisCA | quote }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /app/config.yaml

--- a/charts/authtranslator/values.yaml
+++ b/charts/authtranslator/values.yaml
@@ -4,6 +4,7 @@ image:
   pullPolicy: IfNotPresent
 
 redisAddress: ""
+redisCA: ""
 
 config: |
   integrations:

--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -15,6 +15,7 @@ Required:
 Optional:
 
 - `redis_address` – address for distributed rate limiting
+- `redis_ca` – CA file for verifying Redis TLS
 
 ## Example
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -35,9 +35,10 @@ resource "aws_ecs_task_definition" "this" {
         hostPort      = 8080
         protocol      = "tcp"
       }]
-      command = var.redis_address != "" ? [
-        "./authtranslator", "-redis-addr", var.redis_address
-      ] : ["./authtranslator"]
+      command = concat([
+        "./authtranslator"
+        ], var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
+        var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : [])
     }
   ])
 }

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -29,3 +29,9 @@ variable "redis_address" {
   default     = ""
 }
 
+variable "redis_ca" {
+  description = "Optional CA certificate for Redis TLS"
+  type        = string
+  default     = ""
+}
+

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -15,6 +15,7 @@ Required:
 Optional:
 
 - `redis_address` – address for distributed rate limiting
+- `redis_ca` – CA file for verifying Redis TLS
 
 ## Example
 

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -30,7 +30,10 @@ resource "azurerm_container_group" "this" {
     cpu    = "0.5"
     memory = "1.0"
 
-    command = var.redis_address != "" ? ["./authtranslator", "-redis-addr", var.redis_address] : ["./authtranslator"]
+    command = concat([
+      "./authtranslator"
+      ], var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
+      var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : [])
 
     ports {
       port     = 8080

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -29,3 +29,9 @@ variable "redis_address" {
   default     = ""
 }
 
+variable "redis_ca" {
+  description = "Optional CA certificate for Redis TLS"
+  type        = string
+  default     = ""
+}
+

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -13,6 +13,7 @@ Required:
 Optional:
 
 - `redis_address` – address for distributed rate limiting
+- `redis_ca` – CA file for verifying Redis TLS
 
 ## Example
 

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -26,7 +26,10 @@ resource "google_cloud_run_service" "this" {
             name          = "http1"
             container_port = 8080
           }]
-          args = var.redis_address != "" ? ["-redis-addr", var.redis_address] : []
+          args = concat(
+            var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
+            var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : []
+          )
         }
       ]
     }

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -19,3 +19,9 @@ variable "redis_address" {
   default     = ""
 }
 
+variable "redis_ca" {
+  description = "Optional CA certificate for Redis TLS"
+  type        = string
+  default     = ""
+}
+


### PR DESCRIPTION
## Summary
- add `-redis-ca` CLI flag to verify TLS connections to Redis
- implement certificate pool loading in Redis limiter
- document new option in READMEs and charts
- expose `redis_ca` variable in Terraform modules
- add test covering TLS verification using a CA

## Testing
- `go test ./...`
