### PR TITLE
Add JSON schemas for configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,10 @@ The project exists to make it trivial to translate one type of authentication in
    - `max_idle_conns` – total idle connections to keep pooled.
    - `max_idle_conns_per_host` – idle connections per upstream host.
 
-   The allowlist configuration lives in a separate `allowlist.yaml` file:
+   A JSON schema describing this file is available at
+   [`schemas/config.schema.json`](schemas/config.schema.json).
+
+  The allowlist configuration lives in a separate `allowlist.yaml` file:
 
   ```yaml
   - integration: example
@@ -127,6 +130,9 @@ The project exists to make it trivial to translate one type of authentication in
             methods:
               GET: {}
   ```
+
+   A JSON schema describing this file is available at
+   [`schemas/allowlist.schema.json`](schemas/allowlist.schema.json).
 
    Caller IDs are derived by the incoming auth plugins. Plugins that
    implement the `Identifier` interface return a string used to match the

--- a/schemas/allowlist.schema.json
+++ b/schemas/allowlist.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": { "$ref": "#/definitions/entry" },
+  "definitions": {
+    "entry": {
+      "type": "object",
+      "required": ["integration", "callers"],
+      "properties": {
+        "integration": { "type": "string" },
+        "callers": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/caller" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "caller": {
+      "type": "object",
+      "properties": {
+        "id": { "type": "string" },
+        "capabilities": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/capability" }
+        },
+        "rules": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/rule" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "capability": {
+      "type": "object",
+      "required": ["name"],
+      "properties": {
+        "name": { "type": "string" },
+        "params": { "type": "object" }
+      },
+      "additionalProperties": false
+    },
+    "rule": {
+      "type": "object",
+      "required": ["path", "methods"],
+      "properties": {
+        "path": { "type": "string" },
+        "methods": {
+          "type": "object",
+          "additionalProperties": { "$ref": "#/definitions/requestConstraint" }
+        }
+      },
+      "additionalProperties": false
+    },
+    "requestConstraint": {
+      "type": "object",
+      "properties": {
+        "headers": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "query": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        },
+        "body": { "type": "object" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["integrations"],
+  "properties": {
+    "integrations": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/integration" }
+    }
+  },
+  "additionalProperties": false,
+  "definitions": {
+    "integration": {
+      "type": "object",
+      "required": ["name", "destination"],
+      "properties": {
+        "name": { "type": "string", "pattern": "^[a-zA-Z0-9-]+$" },
+        "destination": { "type": "string", "format": "uri" },
+        "in_rate_limit": { "type": "integer" },
+        "out_rate_limit": { "type": "integer" },
+        "rate_limit_window": { "type": "string" },
+        "incoming_auth": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/authPlugin" }
+        },
+        "outgoing_auth": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/authPlugin" }
+        },
+        "idle_conn_timeout": { "type": "string" },
+        "tls_handshake_timeout": { "type": "string" },
+        "response_header_timeout": { "type": "string" },
+        "tls_insecure_skip_verify": { "type": "boolean" },
+        "disable_keep_alives": { "type": "boolean" },
+        "max_idle_conns": { "type": "integer" },
+        "max_idle_conns_per_host": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "authPlugin": {
+      "type": "object",
+      "required": ["type", "params"],
+      "properties": {
+        "type": { "type": "string" },
+        "params": { "type": "object" }
+      },
+      "additionalProperties": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add schema definitions for `config.yaml` and `allowlist.yaml`
- reference schemas from the documentation

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*