### PR TITLE
Support Redis username auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The project exists to make it trivial to translate one type of authentication in
 - **Pluggable Authentication**: Supports "basic", "token", `hmac_signature`, `jwt`, `mtls`, `url_path`, `github_signature` and `slack_signature` authentication types for both incoming and outgoing requests including Google OIDC with room for extension.
 - **Extensible Plugins**: Add new auth, secret and integration plugins to cover different systems.
 - **Rate Limiting**: Limits the number of requests per caller and per host within a rolling window (default `1m` but configurable per integration via `rate_limit_window`). A value of `0` disables limiting.
-- **Redis Support**: Provide `-redis-addr` as a Redis URL (e.g. `redis://host:6379` or `rediss://:password@host:6379`) to use Redis for rate limit counters instead of in-memory tracking. Use the `rediss` scheme to enable TLS. Include the password in the URL (`:password@`) to authenticate with Redis; the username portion is ignored. Certificate verification is skipped unless a CA file is supplied with `-redis-ca`. If Redis is unavailable the limiter falls back to memory and logs an error.
+- **Redis Support**: Provide `-redis-addr` as a Redis URL (e.g. `redis://user:pass@host:6379` or `rediss://user:pass@host:6379`) to use Redis for rate limit counters instead of in-memory tracking. Use the `rediss` scheme to enable TLS. Include the credentials in the URL to authenticate with Redis. Certificate verification is skipped unless a CA file is supplied with `-redis-ca`. If Redis is unavailable the limiter falls back to memory and logs an error.
 - **Request Body Limit**: The maximum buffered request body can be adjusted with `-max_body_size` (default 10MB). Set the flag to `0` to disable the limit entirely.
 - **Allowlist**: Integrations can restrict specific callers to particular paths, methods and required parameters.
 - **Configuration Driven**: Behavior is controlled via a YAML configuration file.
@@ -171,7 +171,7 @@ The project exists to make it trivial to translate one type of authentication in
    - `-disable_x_at_int` – ignore the `X-AT-Int` header
    - `-x_at_int_host` – only respect `X-AT-Int` when this host is requested
    - `-tls-cert` and `-tls-key` – TLS certificate and key to serve HTTPS
-   - `-redis-addr` – Redis URL for rate limit counters. Use `rediss://` for TLS and include `:password@` before the host to authenticate.
+   - `-redis-addr` – Redis URL for rate limit counters. Use `rediss://` for TLS and include credentials (`user:pass@`) before the host to authenticate.
    - `-redis-ca` – CA certificate for verifying Redis TLS
    - `-redis-timeout` – timeout for dialing Redis (default `5s`)
   - `-max_body_size` – maximum bytes buffered from request bodies; use `0` to disable


### PR DESCRIPTION
## Summary
- parse Redis username/password from URL
- send `AUTH` with username when provided
- document Redis URLs that include usernames
- test `AUTH username password` handling

## Testing
- `go vet ./...` *(fails: no route to host)*
- `go test ./...` *(fails: no route to host)*