### PR TITLE
Add additional allowlist validation tests

### DIFF
--- a/app/allowlist_validate_test.go
+++ b/app/allowlist_validate_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"strings"
 	"testing"
 
 	integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
@@ -41,5 +42,73 @@ func TestValidateAllowlistEntriesDuplicateCaller(t *testing.T) {
 	}}
 	if err := validateAllowlistEntries(entries); err == nil {
 		t.Fatal("expected error for duplicate caller")
+	}
+}
+
+func TestValidateAllowlistEntriesMissingIntegration(t *testing.T) {
+	entries := []AllowlistEntry{{Integration: ""}}
+	err := validateAllowlistEntries(entries)
+	if err == nil || !strings.Contains(err.Error(), "missing integration") {
+		t.Fatalf("expected missing integration error, got %v", err)
+	}
+}
+
+func TestValidateAllowlistEntriesNoRulesOrCapabilities(t *testing.T) {
+	entries := []AllowlistEntry{{
+		Integration: "test",
+		Callers:     []CallerConfig{{ID: "c"}},
+	}}
+	if err := validateAllowlistEntries(entries); err == nil {
+		t.Fatal("expected error for caller with no rules or capabilities")
+	}
+}
+
+func TestValidateAllowlistEntriesMissingPath(t *testing.T) {
+	entries := []AllowlistEntry{{
+		Integration: "test",
+		Callers:     []CallerConfig{{ID: "c", Rules: []CallRule{{Path: " ", Methods: map[string]RequestConstraint{"GET": {}}}}}},
+	}}
+	if err := validateAllowlistEntries(entries); err == nil {
+		t.Fatal("expected error for missing path")
+	}
+}
+
+func TestValidateAllowlistEntriesInvalidMethodCase(t *testing.T) {
+	entries := []AllowlistEntry{{
+		Integration: "test",
+		Callers:     []CallerConfig{{ID: "c", Rules: []CallRule{{Path: "/x", Methods: map[string]RequestConstraint{"get": {}}}}}},
+	}}
+	if err := validateAllowlistEntries(entries); err == nil {
+		t.Fatal("expected error for invalid method case")
+	}
+}
+
+func TestValidateAllowlistEntriesCapabilityParamErrors(t *testing.T) {
+	entries := []AllowlistEntry{{
+		Integration: "slack",
+		Callers: []CallerConfig{{
+			ID: "c",
+			Capabilities: []integrationplugins.CapabilityConfig{{
+				Name:   "post_public_as",
+				Params: map[string]interface{}{"username": "u", "extra": "bad"},
+			}},
+		}},
+	}}
+	if err := validateAllowlistEntries(entries); err == nil {
+		t.Fatal("expected error for unknown capability param")
+	}
+
+	entries = []AllowlistEntry{{
+		Integration: "slack",
+		Callers: []CallerConfig{{
+			ID: "c",
+			Capabilities: []integrationplugins.CapabilityConfig{{
+				Name:   "post_public_as",
+				Params: map[string]interface{}{"username": ""},
+			}},
+		}},
+	}}
+	if err := validateAllowlistEntries(entries); err == nil {
+		t.Fatal("expected error for invalid capability params")
 	}
 }


### PR DESCRIPTION
## Summary
- increase coverage of allowlist validation logic with new unit tests

## Testing
- `go test ./app -run TestValidateAllowlistEntries -count=1` *(fails: no route to host)*