### PR TITLE
Fix outdated allowlist CLI docs

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -103,26 +103,7 @@ This lets you allow a bursty webhook while keeping other calls throttled.
 
 ---
 
-## 4  Validating the file
-
-Run the helper:
-
-```bash
-go run ./cmd/allowlist validate --file allowlist.yaml
-```
-
-Fails on unknown fields, bad regexes, or YAML parse errors.
-
-Include it in CI so typos don’t ship:
-
-```yaml
-- name: Lint allowlist
-  run: go run ./cmd/allowlist validate --file allowlist.yaml
-```
-
----
-
-## 5  Tips & conventions
+## 4  Tips & conventions
 
 * **One capability ≈ one business use‑case** (e.g. `slack.chat.write.public`).
 * Prefer **uppercase** HTTP methods (`GET`, `POST`) for consistency.


### PR DESCRIPTION
## Summary
- update CLI docs for the `allowlist` tool
- drop obsolete `validate` command references

## Testing
- `make test`