### PR TITLE
Add extra tests for allowlist CLI

### DIFF
--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -186,3 +186,166 @@ func TestRemoveEntryDeletesCaller(t *testing.T) {
 		t.Fatalf("entries mismatch:\n%v\nwant\n%v", entries, want)
 	}
 }
+
+func TestAddEntryNewCaller(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	initial := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers: []plugins.CallerConfig{
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: map[string]interface{}{}}}},
+			},
+		},
+	}
+	data, _ := yaml.Marshal(initial)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	addEntry([]string{"-integration", "foo", "-caller", "u2", "-capability", "cap2"})
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := yaml.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	want := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers: []plugins.CallerConfig{
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: map[string]interface{}{}}}},
+				{ID: "u2", Capabilities: []plugins.CapabilityConfig{{Name: "cap2", Params: map[string]interface{}{}}}},
+			},
+		},
+	}
+	if !reflect.DeepEqual(entries, want) {
+		t.Logf("entries=%#v", entries)
+		t.Logf("want=%#v", want)
+		t.Fatalf("entries mismatch")
+	}
+}
+
+func TestAddEntryMissingArgs(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	out := captureOutput(func() { addEntry([]string{}) })
+	if !strings.Contains(out, "-integration, -caller and -capability required") {
+		t.Fatalf("missing error message: %s", out)
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("file should not be created")
+	}
+}
+
+func TestRemoveEntryIntegrationNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	initial := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers:     []plugins.CallerConfig{{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1"}}}},
+		},
+	}
+	data, _ := yaml.Marshal(initial)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	removeEntry([]string{"-integration", "bar", "-caller", "u1", "-capability", "cap1"})
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := yaml.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(entries, initial) {
+		t.Fatalf("entries changed unexpectedly")
+	}
+}
+
+func TestRemoveEntryCapabilityNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	initial := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers:     []plugins.CallerConfig{{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1"}}}},
+		},
+	}
+	data, _ := yaml.Marshal(initial)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	removeEntry([]string{"-integration", "foo", "-caller", "u1", "-capability", "capX"})
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := yaml.Unmarshal(out, &entries); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(entries, initial) {
+		t.Fatalf("entries changed unexpectedly")
+	}
+}
+
+func TestRemoveEntryFormatsParamsNull(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	initial := []plugins.AllowlistEntry{
+		{
+			Integration: "foo",
+			Callers:     []plugins.CallerConfig{{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: map[string]interface{}{}}}}},
+		},
+	}
+	data, _ := yaml.Marshal(initial)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	removeEntry([]string{"-integration", "foo", "-caller", "u1", "-capability", "missing"})
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	dataStr := string(out)
+	if !strings.Contains(dataStr, "params: null") {
+		t.Fatalf("expected params to be null, got: %s", dataStr)
+	}
+}


### PR DESCRIPTION
## Summary
- increase test coverage of `cmd/allowlist/main.go`
- add cases for missing args, new caller creation and params formatting
- combine new tests with existing `main_test.go`

## Testing
- `go test ./cmd/allowlist -v`
- `go test ./...`
