### PR TITLE
Fix documentation paths and build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ AuthTranslator eats **YAML** (or pure JSON) for two files:
 | `config.yaml`    | Declares **integrations** – upstream URL, outgoing auth plug‑in, transport tweaks, rate‑limit window. |
 | `allowlist.yaml` | Grants each **caller ID** specific HTTP paths/methods **or** named **capabilities**.                  |
 
-Example snippets live under [`examples/`](examples/) and a full JSON‑Schema is in [`docs/schema`](docs/schema) – CI fails if you drift.
+Example snippets live under [`examples/`](examples/) and a full JSON‑Schema is in [`schemas/`](schemas/) – CI fails if you drift.
 
 ### Secret back‑ends
 
@@ -121,7 +121,8 @@ Also see [`cmd/allowlist`](cmd/allowlist) for CRUD operations on the allow‑lis
 ## 🛠️ Development
 
 ```bash
-make            # fmt + vet + tests
+make precommit  # fmt + vet + lint
+make test       # run unit tests
 make docker     # build container
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -160,21 +160,15 @@ callers:
 
 ```bash
 yq eval -o=json config.yaml | \
-  jsonschema -i - docs/schema/config‑v1alpha1.json
-```
-
-### With CUE
-
-```bash
-cue vet config.yaml docs/schema/config.cue
+  jsonschema -i - schemas/config.schema.json
 ```
 
 A sample `Makefile` target:
 
 ```make
 validate:
-	@cue vet config.yaml docs/schema/config.cue
-	@cue vet allowlist.yaml docs/schema/allowlist.cue
+        @yq eval -o=json config.yaml | jsonschema -i - schemas/config.schema.json
+        @yq eval -o=json allowlist.yaml | jsonschema -i - schemas/allowlist.schema.json
 ```
 
 CI fails fast on typos so you never ship an invalid proxy.


### PR DESCRIPTION
## Summary
- fix JSON schema path references
- update development Makefile commands
- drop stale CUE references

## Testing
- `make precommit` *(fails: can't load config: unsupported version)*
- `go test ./...`