### PR TITLE
Add unit tests for plugin registry List

### DIFF
--- a/cmd/integrations/plugins/registry_test.go
+++ b/cmd/integrations/plugins/registry_test.go
@@ -1,0 +1,22 @@
+package plugins
+
+import "testing"
+
+func TestListReturnsAllRegisteredNames(t *testing.T) {
+	names := List()
+	if len(names) != len(registry) {
+		t.Fatalf("expected %d names, got %d", len(registry), len(names))
+	}
+	seen := make(map[string]bool, len(names))
+	for _, n := range names {
+		if seen[n] {
+			t.Errorf("duplicate name %s", n)
+		}
+		seen[n] = true
+	}
+	for want := range registry {
+		if !seen[want] {
+			t.Errorf("missing name %s", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add registry_test for cmd/integrations/plugins

## Testing
- `go test ./...`