### PR TITLE
Fix form rule matching

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -39,7 +39,7 @@ You can mix both—capabilities first, fall back to granular.
 Capabilities serve two goals:
 
 1. **Developer ergonomics** – a single label replaces dozens of path/method/body rules.
-2. **Auditability** – security reviewers can grep for the label instead of parsing regexes. If a suitable capability exists, **prefer it over hand‑rolled granular rules**.
+2. **Auditability** – security reviewers can grep for the label instead of combing through lengthy rule lists. If a suitable capability exists, **prefer it over hand‑rolled granular rules**.
 
 Capabilities are defined **next to each integration plugin**. They expand into one or more granular rules that match that integration’s API surface.
 
@@ -64,15 +64,15 @@ callers:
 
 ```yaml
 rules:
-  - path:   /api/chat.postMessage          # regex, anchored
+  - path:   /api/chat.postMessage          # path pattern, anchored
     method: POST                          # string or [string]
-    query:                                # list of key=regex pairs (ANDed)
-      - channel=^C[0-9A-Z]{8}$
+    query:                                # list of key=value pairs (ANDed)
+      - channel=C12345678
     headers:                              # must all be present (values optional)
       - X-Custom-Trace
     body:                                 # optional JSON *or* form filters
       json:
-        text: "^Hello .+"                # regex on top‑level key
+        text: "Hello world"               # exact match on top-level key
       form: {}
     rate_limit:                           # optional override
       window: 10s
@@ -83,11 +83,11 @@ rules:
 
 | Request part | Matching logic                                                                                      |
 | ------------ | --------------------------------------------------------------------------------------------------- |
-| Path         | Must match the regex **entirely** (`^` automatically added).                                        |
+| Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
 | Method       | Case‑insensitive string compare.                                                                    |
-| Query params | Each `key=regex` must exist & match **first** value. Extra params allowed.                          |
+| Query params | Each `key=value` must exist & match **first** value. Extra params allowed.                          |
 | Headers      | Header names must exist (value not checked).                                                        |
-| Body JSON    | The top‑level key must exist and its string value match the regex. Non‑string/absent keys → reject. |
+| Body JSON    | The top‑level key must exist and its string value match exactly. Non‑string/absent keys → reject.   |
 | Body form    | Same as JSON but for `application/x-www-form-urlencoded`.                                           |
 
 A request passes if **any** rule (or capability‑expanded rule) matches.
@@ -111,7 +111,7 @@ Run the helper:
 go run ./cmd/allowlist validate --file allowlist.yaml
 ```
 
-Fails on unknown fields, bad regexes, or YAML parse errors.
+Fails on unknown fields or YAML parse errors.
 
 Include it in CI so typos don’t ship:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -142,12 +142,12 @@ callers:
 
 | Field        | Type                 | Notes                                                  |
 | ------------ | -------------------- | ------------------------------------------------------ |
-| `path`       | regex                | Anchored to the upstream path.                         |
+| `path`       | string               | Anchored to the upstream path. Supports `*` and `**` wildcards. |
 | `method`     | string or `[string]` | `GET`, `POST`, …                                       |
-| `query`      | `[string]`           | Each element `key=regex`. All must match.              |
+| `query`      | `[string]`           | Each element `key=value`. All must match.              |
 | `headers`    | `[string]`           | Header names that **must be present** (value ignored). |
-| `body.json`  | map\[string]regex    | JSON pointer‑like top‑level keys.                      |
-| `body.form`  | map\[string]regex    | For `application/x-www-form-urlencoded`.               |
+| `body.json`  | map\[string]interface{} | JSON pointer‑like top‑level keys; values must match exactly. |
+| `body.form`  | map\[string]interface{} | For `application/x-www-form-urlencoded`; values must match exactly. |
 | `rate_limit` | `RateLimit`          | Optional per‑caller‑per‑rule override.                 |
 
 > **Performance note** Low‑level matching adds negligible latency (<50 µs at 10 rules). Tune rule ordering so the most frequent match comes first.


### PR DESCRIPTION
## Summary
- revert regex-based form rule changes
- clarify docs for path, query and body matching

## Testing
- `go test ./...`
