### PR TITLE
Fix outdated docs

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -53,10 +53,10 @@ callers:
 > **Discovering capabilities** Run the CLI helper:
 >
 > ```bash
-> go run ./cmd/integrations list-capabilities --integration slack
+> go run ./cmd/allowlist list
 > ```
 >
-> (Use `--help` for the exact flag name.)
+> (Use `--help` for plugin-specific flags.)
 >
 > For guidelines on adding new capabilities, see [integration-plugins.md](integration-plugins.md).
 
@@ -74,9 +74,6 @@ rules:
       json:
         text: "Hello world"               # exact match on top-level key
       form: {}
-    rate_limit:                           # optional override
-      window: 10s
-      requests: 20
 ```
 
 > **Subset principle** *Every* field you specify must match the request; unspecified fields are ignored. This means your rule must be a **subset** of the incoming request.
@@ -94,16 +91,7 @@ A request passes if **any** rule (or capability‑expanded rule) matches.
 
 ---
 
-## 3  Per‑rule vs integration‑wide rate‑limits
-
-* Integration block in `config.yaml` sets a **default** bucket.
-* A rule’s `rate_limit:` overrides *for that caller + rule only*.
-
-This lets you allow a bursty webhook while keeping other calls throttled.
-
----
-
-## 4  Tips & conventions
+## 3  Tips & conventions
 
 * **One capability ≈ one business use‑case** (e.g. `slack.chat.write.public`).
 * Prefer **uppercase** HTTP methods (`GET`, `POST`) for consistency.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2,9 +2,9 @@
 
 AuthTranslator ships with two small helper binaries under **`cmd/`**:
 
-| Binary         | Purpose                                       | Typical usage                                       |
-| -------------- | --------------------------------------------- | --------------------------------------------------- |
-| `integrations` | Scaffold or inspect entries in *config.yaml*. | `go run ./cmd/integrations slack > config.yaml`     |
+| Binary         | Purpose                                       | Typical usage                                     |
+| -------------- | --------------------------------------------- | ------------------------------------------------- |
+| `integrations` | Scaffold or inspect entries in *config.yaml*. | `go run ./cmd/integrations slack > config.yaml`   |
 | `allowlist`    | Modify or inspect *allowlist.yaml*.           | `go run ./cmd/allowlist add -integration slack -caller bot -capability ping` |
 
 > **Heads‑up** Both helpers are thin wrappers around Go structs—check the `--help` output for the definitive flag list because the CLI evolves alongside the schema.
@@ -32,11 +32,41 @@ integrations <command> [flags]
 
 ### Common commands
 
-| Command  | What it does |
-| -------- | ---------------------------------------------- |
-| `list`   | Prints available capability names for each integration. |
-| `add`    | Adds an entry to `allowlist.yaml`. |
-| `remove` | Deletes an entry from `allowlist.yaml`. |
+| Command    | Purpose                                                             |
+| ---------- | ------------------------------------------------------------------- |
+| `list`     | Print the names of integrations currently loaded by the server.     |
+| `update`   | Replace an existing integration using one of the plugin builders.   |
+| `delete`   | Remove an integration by name.                                      |
+| `<plugin>` | Generate a new integration using that plugin’s flags and send it.   |
+
+```bash
+# Add a Slack integration from env vars
+go run ./cmd/integrations slack \
+  -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING
+
+# Delete an integration
+go run ./cmd/integrations delete slack
+```
+
+#### Flags
+
+| Flag       | Default                              | Meaning                    |
+| ---------- | ------------------------------------ | -------------------------- |
+| `--server` | `http://localhost:8080/integrations` | Management API endpoint.   |
+
+## 3  `allowlist` helper
+
+```text
+allowlist <command> [flags]
+```
+
+### Common commands
+
+| Command  | Purpose                                              |
+| -------- | ---------------------------------------------------- |
+| `list`   | Show capabilities provided by integration plugins.   |
+| `add`    | Append a capability entry to `allowlist.yaml`.       |
+| `remove` | Delete an entry from `allowlist.yaml`.               |
 
 ```bash
 # Show available capabilities
@@ -44,21 +74,21 @@ go run ./cmd/allowlist list
 
 # Grant a caller permission
 go run ./cmd/allowlist add -integration slack \
-    -caller bot-123 -capability post_public_as
+  -caller bot-123 -capability post_public_as
 
 # Revoke that permission
 go run ./cmd/allowlist remove -integration slack \
-    -caller bot-123 -capability post_public_as
+  -caller bot-123 -capability post_public_as
 ```
 
 #### Flags
 
-| Flag            | Default          | Meaning                                    |
-| --------------- | ---------------- | ------------------------------------------ |
-| `--file`        | `allowlist.yaml` | Path to YAML file for `add`/`remove`.      |
-| `--caller`      | –                | Caller ID for `add`/`remove`.              |
-| `--integration` | –                | Integration name for `add`/`remove`.       |
-| `--capability`  | –                | Capability name for `add`/`remove`.        |
+| Flag            | Default          | Meaning                             |
+| --------------- | ---------------- | ----------------------------------- |
+| `--file`        | `allowlist.yaml` | Path to YAML file for `add`/`remove`. |
+| `--caller`      | –                | Caller ID for `add`/`remove`.       |
+| `--integration` | –                | Integration name for `add`/`remove`. |
+| `--capability`  | –                | Capability name for `add`/`remove`. |
 | `--params`      | ""               | Extra key=value pairs for `add` (optional). |
 
 ---
@@ -70,7 +100,7 @@ A minimal **GitHub Actions** snippet that checks both files on every PR:
 ```yaml
 - name: Validate AuthTranslator config
   run: |
-    go run ./cmd/integrations list --file config.yaml
+    go run ./cmd/integrations list
     go run ./cmd/allowlist list
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -22,9 +22,9 @@ integrations:
           - env:APP_TOKEN_2
     transport:
       timeout: 10s
-    rate_limit:
-      window: 1m
-      requests: 800
+    in_rate_limit:  100
+    out_rate_limit: 800
+    rate_limit_window: 1m
 ```
 
 The integration name (`slack` above) is referenced by the allowlist. Incoming plugins run in order until one succeeds, optionally producing the caller ID (depending on the auth plugins). Outgoing plugins modify each request before forwarding it to the `destination` URL.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -42,7 +42,7 @@ Yes. For **rate‑limiting** accuracy you should point the pods at a shared Redi
 
 ### 6 How do I disable rate‑limiting entirely?
 
-Set `window: 0` or omit the `rate_limit:` block in the integration. (It’s disabled by default.)
+Set `in_rate_limit: 0` and `out_rate_limit: 0` (or omit the fields entirely). Rate limits are disabled by default.
 
 ---
 

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -20,35 +20,17 @@ This approximates a smooth sliding window while touching Redis once per request.
 ```yaml
 integrations:
   slack:
-    rate_limit:
-      backend:   redis       # memory | redis (default memory)
-      window:    60s         # any Go duration string
-      requests:  800         # max within that window
+    in_rate_limit:  100
+    out_rate_limit: 800
+    rate_limit_window: 1m
 ```
 
-| Field      | Type     | Default  | Notes                                           |
-| ---------- | -------- | -------- | ----------------------------------------------- |
-| `backend`  | string   | `memory` | `redis` recommended for multi‑instance deploys. |
-| `window`   | duration | `0`      | `0` disables limiting.                          |
-| `requests` | int      | `0`      | Required when `window` > 0.                     |
+| Field               | Type     | Default | Notes |
+| ------------------- | -------- | ------- | ------------------------------------------- |
+| `in_rate_limit`     | int      | `0`     | Max inbound requests per caller within the window. |
+| `out_rate_limit`    | int      | `0`     | Max outbound requests per caller within the window. |
+| `rate_limit_window` | duration | `1m`    | Rolling window length for rate limiting. |
 
-> **CLI helper** `go run ./cmd/integrations slack -rate-window 1m -rate-requests 800` will scaffold those fields for you.
-
-### Per‑rule overrides in `allowlist.yaml`
-
-```yaml
-callers:
-  bot‑123:
-    slack:
-      rules:
-        - path: /api/chat.postMessage
-          method: POST
-          rate_limit:
-            window:   10s
-            requests: 20
-```
-
-Useful for giving webhooks a burstier bucket than normal REST calls.
 
 ---
 


### PR DESCRIPTION
## Summary
- correct CLI helper documentation
- update config examples to reflect rate limit fields
- document current integration plugin layout
- clarify capability discovery and FAQ answers
- adjust rate limiting guide

## Testing
- `make precommit` *(fails: can't load config for golangci-lint)*
- `make test`