### PR TITLE
Fix outgoing auth example

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -14,9 +14,10 @@ integrations:
             - vault:/old/token
             - vault:/new/token
     outgoing_auth:
-      type: bearer_static
+      type: token
       params:
         header: Authorization
+        prefix: "Bearer "
         secrets:
           - env:APP_TOKEN_1
           - env:APP_TOKEN_2


### PR DESCRIPTION
## Notes
- adjust docs example to use the existing `token` plugin instead of nonexistent `bearer_static`

## Testing
- `make test`