### PR TITLE
Add passthrough auth plugin

### DIFF
--- a/app/auth/plugins/passthrough/incoming.go
+++ b/app/auth/plugins/passthrough/incoming.go
@@ -1,0 +1,30 @@
+package passthrough
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/winhowes/AuthTranslator/app/auth"
+)
+
+// PassThruAuth accepts every request without modifying it.
+type PassThruAuth struct{}
+
+func (p *PassThruAuth) Name() string             { return "passthrough" }
+func (p *PassThruAuth) RequiredParams() []string { return nil }
+func (p *PassThruAuth) OptionalParams() []string { return nil }
+
+func (p *PassThruAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	// Disallow unknown fields even though we don't expect any parameters.
+	_, err := authplugins.ParseParams[struct{}](m)
+	if err != nil {
+		return nil, err
+	}
+	return struct{}{}, nil
+}
+
+func (p *PassThruAuth) Authenticate(ctx context.Context, r *http.Request, _ interface{}) bool {
+	return true
+}
+
+func init() { authplugins.RegisterIncoming(&PassThruAuth{}) }

--- a/app/auth/plugins/passthrough/outgoing.go
+++ b/app/auth/plugins/passthrough/outgoing.go
@@ -1,0 +1,30 @@
+package passthrough
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/winhowes/AuthTranslator/app/auth"
+)
+
+// PassThruAuthOut performs no modification to the request.
+type PassThruAuthOut struct{}
+
+func (p *PassThruAuthOut) Name() string             { return "passthrough" }
+func (p *PassThruAuthOut) RequiredParams() []string { return nil }
+func (p *PassThruAuthOut) OptionalParams() []string { return nil }
+
+func (p *PassThruAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) {
+	// Disallow unknown fields even though we don't expect any parameters.
+	_, err := authplugins.ParseParams[struct{}](m)
+	if err != nil {
+		return nil, err
+	}
+	return struct{}{}, nil
+}
+
+func (p *PassThruAuthOut) AddAuth(ctx context.Context, r *http.Request, _ interface{}) {
+	// No-op
+}
+
+func init() { authplugins.RegisterOutgoing(&PassThruAuthOut{}) }

--- a/app/auth/plugins/passthrough/passthrough_test.go
+++ b/app/auth/plugins/passthrough/passthrough_test.go
@@ -1,0 +1,49 @@
+package passthrough
+
+import (
+	"context"
+	"net/http"
+	"testing"
+)
+
+func TestPassThruIncomingAlways(t *testing.T) {
+	r := &http.Request{Header: http.Header{}}
+	p := PassThruAuth{}
+	cfg, err := p.ParseParams(map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to always succeed")
+	}
+}
+
+func TestPassThruOutgoingNoop(t *testing.T) {
+	r := &http.Request{Header: http.Header{"X-Test": []string{"value"}}}
+	p := PassThruAuthOut{}
+	cfg, err := p.ParseParams(map[string]interface{}{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	p.AddAuth(context.Background(), r, cfg)
+	if got := r.Header.Get("X-Test"); got != "value" {
+		t.Fatalf("expected header to remain unchanged, got %s", got)
+	}
+}
+
+func TestPassThruPluginParams(t *testing.T) {
+	in := PassThruAuth{}
+	out := PassThruAuthOut{}
+	if in.RequiredParams() != nil && len(in.RequiredParams()) != 0 {
+		t.Fatalf("unexpected required params: %v", in.RequiredParams())
+	}
+	if out.RequiredParams() != nil && len(out.RequiredParams()) != 0 {
+		t.Fatalf("unexpected required params: %v", out.RequiredParams())
+	}
+	if in.OptionalParams() != nil && len(in.OptionalParams()) != 0 {
+		t.Fatalf("unexpected optional params: %v", in.OptionalParams())
+	}
+	if out.OptionalParams() != nil && len(out.OptionalParams()) != 0 {
+		t.Fatalf("unexpected optional params: %v", out.OptionalParams())
+	}
+}

--- a/app/auth/plugins/plugins.go
+++ b/app/auth/plugins/plugins.go
@@ -7,6 +7,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/hmac"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/jwt"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/mtls"
+	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/passthrough"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/slack_signature"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/token"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/urlpath"

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -25,12 +25,14 @@ AuthTranslator’s behaviour is extended by **plugins** – small Go packages th
 | Inbound   | `slack_signature`  | Validates Slack request signatures. |
 | Inbound   | `token`            | Compares a shared token header. |
 | Inbound   | `url_path`         | Checks a token embedded in the request path. |
+| Inbound   | `passthrough`      | Accepts every request with no authentication. |
 | Outbound  | `basic`            | Adds HTTP Basic credentials to the upstream request. |
 | Outbound  | `google_oidc`      | Attaches a Google identity token from the metadata service. |
 | Outbound  | `hmac_signature`   | Computes an HMAC for the request. |
 | Outbound  | `jwt`              | Adds a signed JWT to the request. |
 | Outbound  | `mtls`             | Sends a client certificate and exposes the CN via header. |
 | Outbound  | `token`            | Adds a token header on outgoing requests. |
+| Outbound  | `passthrough`      | Does nothing; useful when upstream handles auth. |
 | Outbound  | `url_path`         | Appends a secret segment to the request path. |
 ---
 


### PR DESCRIPTION
## Summary
- implement `passthrough` incoming and outgoing auth plugins
- register the new plugin
- document `passthrough` in the auth plugin list
- add unit tests

## Testing
- `go test ./app/auth/plugins/passthrough -v`
- `go test ./...`
