### PR TITLE
Support header value checks and recursive body matching

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -131,9 +131,22 @@ func matchSegments(pattern, path []string) bool {
 
 // validateRequest checks headers and body according to the request constraint.
 func validateRequest(r *http.Request, c RequestConstraint) bool {
-	for _, h := range c.Headers {
-		if r.Header.Get(h) == "" {
+	for name, wantVals := range c.Headers {
+		gotVals, ok := r.Header[name]
+		if !ok {
 			return false
+		}
+		for _, want := range wantVals {
+			found := false
+			for _, got := range gotVals {
+				if got == want {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return false
+			}
 		}
 	}
 	if len(c.Query) > 0 {

--- a/app/allowlist_helpers_test.go
+++ b/app/allowlist_helpers_test.go
@@ -58,13 +58,13 @@ func TestValidateRequestTable(t *testing.T) {
 				r.Header.Set("X-Test", "v")
 				return r
 			}(),
-			cons:   RequestConstraint{Headers: []string{"X-Test"}},
+			cons:   RequestConstraint{Headers: map[string][]string{"X-Test": {"v"}}},
 			wantOK: true,
 		},
 		{
 			name:   "header missing",
 			r:      httptest.NewRequest(http.MethodGet, "http://x", nil),
-			cons:   RequestConstraint{Headers: []string{"X-Test"}},
+			cons:   RequestConstraint{Headers: map[string][]string{"X-Test": {"v"}}},
 			wantOK: false,
 		},
 		{

--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -43,11 +43,11 @@ func newRequest(method, urlStr, ct string, body []byte) *http.Request {
 func TestValidateRequestHeaders(t *testing.T) {
 	r := httptest.NewRequest(http.MethodGet, "http://x", nil)
 	r.Header.Set("X-Test", "val")
-	if !validateRequest(r, RequestConstraint{Headers: []string{"X-Test"}}) {
+	if !validateRequest(r, RequestConstraint{Headers: map[string][]string{"X-Test": {"val"}}}) {
 		t.Fatal("expected header match")
 	}
 	r2 := httptest.NewRequest(http.MethodGet, "http://x", nil)
-	if validateRequest(r2, RequestConstraint{Headers: []string{"X-Test"}}) {
+	if validateRequest(r2, RequestConstraint{Headers: map[string][]string{"X-Test": {"val"}}}) {
 		t.Fatal("expected failure without header")
 	}
 }

--- a/app/integrations/types.go
+++ b/app/integrations/types.go
@@ -9,7 +9,7 @@ type CallRule struct {
 
 // RequestConstraint lists required headers and body parameters.
 type RequestConstraint struct {
-	Headers []string               `json:"headers"`
+	Headers map[string][]string    `json:"headers"`
 	Query   map[string][]string    `json:"query"`
 	Body    map[string]interface{} `json:"body"`
 }

--- a/cmd/allowlist/plugins/types.go
+++ b/cmd/allowlist/plugins/types.go
@@ -18,7 +18,7 @@ type CallRule struct {
 }
 
 type RequestConstraint struct {
-	Headers []string               `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Headers map[string][]string    `json:"headers,omitempty" yaml:"headers,omitempty"`
 	Body    map[string]interface{} `json:"body,omitempty" yaml:"body,omitempty"`
 }
 

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -68,11 +68,11 @@ rules:
     method: POST                          # string or [string]
     query:                                # list of key=value pairs (ANDed)
       - channel=C12345678
-    headers:                              # must all be present (values optional)
-      - X-Custom-Trace
+    headers:                              # header=value list; empty list checks only presence
+      X-Custom-Trace: [abc123]
     body:                                 # optional JSON *or* form filters
       json:
-        text: "Hello world"               # exact match on top-level key
+        text: "Hello world"               # matched recursively
       form: {}
 ```
 
@@ -83,9 +83,9 @@ rules:
 | Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
 | Method       | Case‑insensitive string compare.                                                                    |
 | Query params | Each `key=value` must exist & match **first** value. Extra params allowed.                          |
-| Headers      | Header names must exist (value not checked).                                                        |
-| Body JSON    | The top‑level key must exist and its string value match exactly. Non‑string/absent keys → reject.   |
-| Body form    | Same as JSON but for `application/x-www-form-urlencoded`.                                           |
+| Headers      | Each `key=[values]` must exist with those values; an empty list only checks for presence. |
+| Body JSON    | The specified object must be a recursive subset of the request body. |
+| Body form    | Same as JSON but for `application/x-www-form-urlencoded`. |
 
 A request passes if **any** rule (or capability‑expanded rule) matches.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -106,7 +106,7 @@ callers:
               text: "^.+"              # any non‑empty string
             form: {}
           headers:
-            - X-Custom-Trace
+            X-Custom-Trace: [abc123]
 ```
 
 ### Top‑level keys
@@ -132,9 +132,9 @@ callers:
 | `path`       | string               | Anchored to the upstream path. Supports `*` and `**` wildcards. |
 | `method`     | string or `[string]` | `GET`, `POST`, …                                       |
 | `query`      | `[string]`           | Each element `key=value`. All must match.              |
-| `headers`    | `[string]`           | Header names that **must be present** (value ignored). |
-| `body.json`  | map\[string]interface{} | JSON pointer‑like top‑level keys; values must match exactly. |
-| `body.form`  | map\[string]interface{} | For `application/x-www-form-urlencoded`; values must match exactly. |
+| `headers`    | map\[string][]string | Header names and required values. Empty list checks only presence. |
+| `body.json`  | map\[string]interface{} | Object matched recursively; must be a subset of the request. |
+| `body.form`  | map\[string]interface{} | Same subset matching for `application/x-www-form-urlencoded`. |
 
 > **Performance note** Low‑level matching adds negligible latency (<50 µs at 10 rules). Tune rule ordering so the most frequent match comes first.
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -211,8 +211,9 @@ In production the proxy usually sits behind a wildcard DNS record and matching w
 ### Allowlist Rules
 
 Each caller entry lists path patterns and method constraints. `*` matches a
-single path segment while `**` matches any remaining segments. Header names are
-listed under `headers` and required body fields under `body`.
+single path segment while `**` matches any remaining segments. Headers are
+listed under `headers` with optional values and required body fields under
+`body`.
 
 Example rule requiring an `X-Token` header and a JSON field:
 
@@ -221,7 +222,7 @@ path: /api/**
 methods:
   POST:
     headers:
-      - X-Token
+      X-Token: [abc123]
     body:
       action: create
 ```

--- a/schemas/allowlist.schema.json
+++ b/schemas/allowlist.schema.json
@@ -55,8 +55,11 @@
       "type": "object",
       "properties": {
         "headers": {
-          "type": "array",
-          "items": { "type": "string" }
+          "type": "object",
+          "additionalProperties": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
         },
         "query": {
           "type": "object",


### PR DESCRIPTION
## Summary
- allow headers in allowlist to specify required values
- ensure body rules are recursively matched
- document the updated allowlist syntax
- adjust schema and tests

## Testing
- `make precommit` *(fails: can't load config: unsupported version of the configuration)*
- `make test`