### PR TITLE
Add missing docs on reload header and Terraform

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -129,3 +129,19 @@ helm push authtranslator-*.tgz oci://ghcr.io/winhowes/charts
 # Later, install via OCI reference
 helm install authtranslator oci://ghcr.io/winhowes/charts/authtranslator --version 1.2.3
 ```
+
+---
+
+## 6  Deploying with Terraform
+
+Example Terraform configurations live in the `terraform/` directory:
+
+- `terraform/quickstart` – minimal Docker provider example.
+- `terraform/aws` – deploys to AWS ECS Fargate.
+- `terraform/gcp` – deploys to Google Cloud Run.
+- `terraform/azure` – deploys to Azure Container Instances.
+
+Set the variables for your environment and run `terraform apply` inside the
+chosen folder to create the service. The modules accept optional
+`redis_address`, `redis_timeout` and `redis_ca` variables which map to the
+container flags.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,7 +11,9 @@ AuthTranslator surfaces **health probes, Prometheus metrics, and structured logs
 | `/_at_internal/healthz` | `GET`  | Liveness: returns **200 OK** once the HTTP server is up. No external deps are checked.                | Kubernetes `livenessProbe` every 10 s |
 | `/_at_internal/metrics` | `GET`  | Exposes **Prometheus** text format. Includes Go runtime metrics and AuthTranslator‑specific counters. | Prometheus `scrape_interval` 15 s     |
 
-Both endpoints are always available; no extra flag is required.
+Both endpoints are always available; no extra flag is required. The readiness
+check also returns an `X-Last-Reload` header showing the most recent
+configuration reload time.
 
 ---
 


### PR DESCRIPTION
## Summary
- document `X-Last-Reload` header in observability guide
- describe Terraform examples in Helm deployment doc

## Testing
- `make lint` *(fails: unsupported version of golangci-lint)*