### PR TITLE
Clean up integrations tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,4 @@
+version: 1
 run:
   timeout: 5m
 


### PR DESCRIPTION
## Summary
- remove unused server flag and cleanup main_test.go
- add version to `.golangci.yml`

## Testing
- `make precommit` *(fails: can't load config: unsupported version)*
- `make test`