### PR TITLE
Increase parseutil.go coverage

### DIFF
--- a/app/auth/parseutil_test.go
+++ b/app/auth/parseutil_test.go
@@ -32,3 +32,10 @@ func TestParseParamsTypeMismatch(t *testing.T) {
 		t.Fatal("expected type error")
 	}
 }
+
+func TestParseParamsMarshalError(t *testing.T) {
+	m := map[string]interface{}{"bad": make(chan int)}
+	if _, err := ParseParams[sampleParams](m); err == nil {
+		t.Fatal("expected marshal error")
+	}
+}


### PR DESCRIPTION
## Summary
- add marshal error test for ParseParams

## Testing
- `go test ./...`
- `go test -cover ./app/auth`