### PR TITLE
Remove obsolete management endpoints

### DIFF
--- a/app/main_handlers_test.go
+++ b/app/main_handlers_test.go
@@ -1,21 +1,11 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 
 	"log/slog"
 )
-
-func resetIntegrations() {
-	integrations.Lock()
-	integrations.m = make(map[string]*Integration)
-	integrations.Unlock()
-}
 
 func TestLoadAllowlistsValid(t *testing.T) {
 	tmp, err := os.CreateTemp("", "allowlist*.yaml")
@@ -51,55 +41,5 @@ func TestParseLevel(t *testing.T) {
 		if got := parseLevel(s); got != want {
 			t.Errorf("parseLevel(%q)=%v want %v", s, got, want)
 		}
-	}
-}
-
-func TestIntegrationsHandlerCRUD(t *testing.T) {
-	resetIntegrations()
-	// POST
-	integ := Integration{Name: "test", Destination: "http://example.com"}
-	body, _ := json.Marshal(integ)
-	req := httptest.NewRequest(http.MethodPost, "/integrations", bytes.NewReader(body))
-	rr := httptest.NewRecorder()
-	integrationsHandler(rr, req)
-	if rr.Code != http.StatusCreated {
-		t.Fatalf("post: expected 201 got %d", rr.Code)
-	}
-
-	// GET
-	req = httptest.NewRequest(http.MethodGet, "/integrations", nil)
-	rr = httptest.NewRecorder()
-	integrationsHandler(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("get: expected 200 got %d", rr.Code)
-	}
-	var got []*Integration
-	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil || len(got) != 1 || got[0].Name != "test" {
-		t.Fatalf("get: unexpected body %s", rr.Body.String())
-	}
-
-	// PUT
-	integ.Destination = "http://other.com"
-	body, _ = json.Marshal(integ)
-	req = httptest.NewRequest(http.MethodPut, "/integrations", bytes.NewReader(body))
-	rr = httptest.NewRecorder()
-	integrationsHandler(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("put: expected 200 got %d", rr.Code)
-	}
-
-	// DELETE
-	delReq := struct {
-		Name string `json:"name"`
-	}{Name: "test"}
-	body, _ = json.Marshal(delReq)
-	req = httptest.NewRequest(http.MethodDelete, "/integrations", bytes.NewReader(body))
-	rr = httptest.NewRecorder()
-	integrationsHandler(rr, req)
-	if rr.Code != http.StatusNoContent {
-		t.Fatalf("delete: expected 204 got %d", rr.Code)
-	}
-	if _, ok := GetIntegration("test"); ok {
-		t.Fatal("integration not deleted")
 	}
 }

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -121,7 +121,6 @@ Identifiers flow through to:
 |   |
 | - |
 
-* Start the proxy with `-debug` and curl `/_at_internal/metrics` to see **`auth_plugin_errors_total`**.
 * Use `AUTH_TRANSLATOR_LOG_LEVEL=debug` to dump request headers after plugin injection (redacted for secrets).
 
 ---

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -42,7 +42,6 @@ AuthTranslator exposes several command‑line options:
 | `-max_body_size` | maximum bytes buffered from request bodies; use `0` to disable |
 | `-log-level` | log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 | `-log-format` | log output format (`text` or `json`) |
-| `-debug` | expose the `/integrations` endpoint for the CLI |
 | `-version` | print the build version and exit |
 | `-watch` | automatically reload when config or allowlist files change |
 | `-enable-metrics` | expose the `/_at_internal/metrics` endpoint (default `true`) |


### PR DESCRIPTION
## Summary
- remove `/integrations` HTTP handler and debug flag
- clean up associated tests
- drop references to the debug flag in documentation

## Testing
- `go test ./...`
