### PR TITLE
Fix Redis documentation

### DIFF
--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -20,13 +20,13 @@ services:
       # Secret URIs resolve env: …
       SLACK_TOKEN: "xoxb‑REPLACE"
       SLACK_SIGNING: "8f2b‑REPLACE"
-      # Enable Redis rate‑limit backend (optional)
-      REDIS_URL: "redis://redis:6379/0"
+      # Optional: enable Redis-backed rate limits
     volumes:
       - ./config:/conf:ro          # bind‑mount configs for hot reload
     command: |
       -config /conf/config.yaml \
       -allowlist /conf/allowlist.yaml \
+      -redis-addr redis://redis:6379/0 \
       -watch                       # reload on file change
     depends_on:
       - redis
@@ -79,7 +79,7 @@ Navigate to:
 | Task                    | How                                                                                           |
 | ----------------------- | --------------------------------------------------------------------------------------------- |
 | Change the exposed port | Edit `ports:` → `- "9000:8080"`.                                                              |
-| Disable Redis           | Remove the `redis` service and the `REDIS_URL` env. The proxy falls back to in‑memory limits. |
+| Disable Redis           | Remove the `redis` service and drop the `-redis-addr` flag. The proxy falls back to in‑memory limits. |
 | Add extra env secrets   | Append under `environment:` (`STRIPE_KEY=…`).                                                 |
 | Mount PEM certificates  | Add another entry under `volumes:` and reference with `file:/` secret URIs.                   |
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -36,7 +36,7 @@ kill -s SIGHUP <pid>
 
 ### 5 Can I run more than one replica behind a load balancer?
 
-Yes. For **rate‑limiting** accuracy you should point the pods at a shared Redis instance (`REDIS_URL`). Everything else is stateless.
+Yes. For **rate‑limiting** accuracy you should point the pods at a shared Redis instance using the `-redis-addr` flag. Everything else is stateless.
 
 ---
 

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -35,7 +35,8 @@ This:
 | `image.tag`        | `latest`                          | Image tag or digest.                                               |
 | `replicaCount`     | `1`                               | Horizontal scaling factor.                                         |
 | `service.type`     | `ClusterIP`                       | `LoadBalancer` or `NodePort` as needed.                            |
-| `redis.enabled`    | `false`                           | When `true`, chart deploys a Redis sub-chart and sets `REDIS_URL`. |
+| `redisAddress`     | `""`                              | Connection string passed to `-redis-addr`. |
+| `redisCA`          | `""`                              | CA file verifying Redis TLS passed to `-redis-ca`. |
 | `configYaml`       | *(string)*                        | Raw YAML for `config.yaml`.                                        |
 | `allowlistYaml`    | *(string)*                        | Raw YAML for `allowlist.yaml`.                                     |
 | `extraEnv`         | `{}`                              | Map of extra env vars (e.g., `STRIPE_TOKEN`).                      |
@@ -51,8 +52,7 @@ image:
 
 replicaCount: 2
 
-redis:
-  enabled: true
+redisAddress: "redis://redis:6379/0"
 
 configYaml: |
   apiVersion: v1alpha1
@@ -108,11 +108,10 @@ charts/authtranslator/
   Chart.yaml          # metadata
   values.yaml         # user-tunable defaults
   templates/
+    _helpers.tpl
+    configmap.yaml
     deployment.yaml
     service.yaml
-    configmap.yaml
-    secret.yaml
-    redis.yaml        # included only when enabled
 ```
 
 Feel free to add ingress, PodDisruptionBudget, or HPA templates as your cluster demands.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -41,7 +41,7 @@ integrations:
 | `memory` | Zero deps, fastest (\~100 ns)   | Not shared across pods, resets on restart | Local dev, single‑pod demo.     |
 | `redis`  | Durable across restarts, shared | +0.2 ms per call; need Redis cluster      | Production / multiple replicas. |
 
-**Redis URI** is read from `REDIS_URL` env var (`redis://user:pass@host:6379/0`).
+**Redis URI** is configured via the `-redis-addr` flag (e.g., `-redis-addr redis://user:pass@host:6379/0`).
 
 ---
 


### PR DESCRIPTION
## Summary
- remove stale `REDIS_URL` references
- document `-redis-addr` flag in examples
- update Helm chart docs to match actual values

## Testing
- `make precommit` *(fails: can't load config for golangci-lint)*
- `make test`