### PR TITLE
Fix log-level docs

### DIFF
--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -121,6 +121,6 @@ Identifiers flow through to:
 |   |
 | - |
 
-* Use `AUTH_TRANSLATOR_LOG_LEVEL=debug` to dump request headers after plugin injection (redacted for secrets).
+* Use `-log-level DEBUG` to dump request headers after plugin injection (redacted for secrets).
 
 ---

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -100,4 +100,4 @@ Not built‑in. Most users expose Prometheus metrics to Grafana.
 
 ### 14 How do I log request/response headers for debugging?
 
-Set `AUTH_TRANSLATOR_LOG_LEVEL=debug`. Secrets are automatically redacted.
+Run the proxy with `-log-level DEBUG`. Secrets are automatically redacted.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -74,7 +74,7 @@ Sample line (wrapped for readability):
 ### Log level
 
 * Default: **INFO**
-* Override: `AUTH_TRANSLATOR_LOG_LEVEL=debug` (adds request/response headers—secrets redacted)
+* Override: run the proxy with `-log-level DEBUG` (adds request/response headers—secrets redacted)
 
 ---
 


### PR DESCRIPTION
## Summary
- correct docs to use `-log-level` flag instead of nonexistent `AUTH_TRANSLATOR_LOG_LEVEL`

## Testing
- `go test ./...`
