### PR TITLE
Add extra coverage for Redis helpers

### DIFF
--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -101,3 +101,10 @@ func TestRedisTTLArgs(t *testing.T) {
 		t.Fatalf("expected EXPIRE 0 for zero duration, got %s %s", cmd, val)
 	}
 }
+
+func TestRedisTTLArgsNegative(t *testing.T) {
+	cmd, val := redisTTLArgs(-500 * time.Millisecond)
+	if cmd != "EXPIRE" || val != "0" {
+		t.Fatalf("expected EXPIRE 0 for negative duration, got %s %s", cmd, val)
+	}
+}


### PR DESCRIPTION
## Summary
- extend redis helper tests with error cases
- test negative durations for redisTTLArgs

## Testing
- `go test ./...`
