### PR TITLE
Fix metrics documentation

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -88,7 +88,9 @@ Remember limits are **per callerÂ ID** *and* **per integration**. If your loadâ€
 * Liveness: `/_at_internal/healthz`
 * Prometheus metrics: `/_at_internal/metrics`
 
-Both are always enabled and do **not** require authentication.
+The health endpoint is always enabled. Metrics are exposed by default but you can
+disable them with `-enable-metrics=false` and require HTTP Basic credentials via
+`-metrics-user` and `-metrics-pass`.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -83,7 +83,7 @@ Sample line (wrapped for readability):
 | Alert                     | Expression                                                        | Rationale                        |
 | ------------------------- | ----------------------------------------------------------------- | -------------------------------- |
 | High 5xx rate             | `sum(rate(authtranslator_requests_total{code=~"5.."}[5m])) > 0.1` | Upstream failures or mis‑config. |
-| Prolonged rate‑limit hits | `increase(authtranslator_rate_limit_exceeded_total[5m]) > 100`    | Callers need higher quota.       |
+| Prolonged rate‑limit hits | `increase(authtranslator_rate_limit_events_total[5m]) > 100`    | Callers need higher quota.       |
 | Health endpoint down      | Blackbox probe against `/_at_internal/healthz` fails              | Pod crash or network break.      |
 
 Tune thresholds to your traffic patterns.

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -64,7 +64,7 @@ Example: If a caller peaks at 12 RPS and you choose a 60 s window → `12 × 
   ```json
   {"lvl":"WARN","msg":"rate‑limit exceeded","caller_id":"bot‑123","integration":"slack","limit":800,"window":"60s"}
   ```
-* Prometheus: `authtranslator_rate_limit_exceeded_total{integration="slack"}`
+* Prometheus: `authtranslator_rate_limit_events_total{integration="slack"}`
 
 Grafana sample dashboard lives in `docs/ops/grafana-rate-limits.json`.
 


### PR DESCRIPTION
## Summary
- correct metric names in rate limiting docs
- fix alert snippet for rate limit events
- clarify metrics endpoint behaviour in FAQ

## Testing
- `go test ./...`
- `golangci-lint run ./...` *(fails: unsupported config version)*