### PR TITLE
Fix docs cross references

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,6 +36,8 @@ integrations:
     tags: [chat, team‑comm]
 ```
 
+See [Secret Back-Ends](secret-backends.md) for all supported URI schemes.
+
 ### Top‑level keys
 
 | Field          | Type                    | Default | Notes                                                    |   |

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -42,7 +42,7 @@ This:
 | `extraEnv`         | `{}`                              | Map of extra env vars (e.g., `STRIPE_TOKEN`).                      |
 | `resources`        | `{}`                              | Pod CPU/memory requests & limits.                                  |
 
-Full schema lives in `charts/authtranslator/values.yaml`.
+Full schema lives in [`charts/authtranslator/values.yaml`](../charts/authtranslator/values.yaml).
 
 ### Example `values.yaml`
 
@@ -133,12 +133,12 @@ helm install authtranslator oci://ghcr.io/winhowes/charts/authtranslator --versi
 
 ## 6  Deploying with Terraform
 
-Example Terraform configurations live in the `terraform/` directory:
+Example Terraform configurations live in the [`terraform/`](../terraform/) directory:
 
-- `terraform/quickstart` – minimal Docker provider example.
-- `terraform/aws` – deploys to AWS ECS Fargate.
-- `terraform/gcp` – deploys to Google Cloud Run.
-- `terraform/azure` – deploys to Azure Container Instances.
+- [`terraform/quickstart`](../terraform/quickstart) – minimal Docker provider example.
+- [`terraform/aws`](../terraform/aws) – deploys to AWS ECS Fargate.
+- [`terraform/gcp`](../terraform/gcp) – deploys to Google Cloud Run.
+- [`terraform/azure`](../terraform/azure) – deploys to Azure Container Instances.
 
 Set the variables for your environment and run `terraform apply` inside the
 chosen folder to create the service. The modules accept optional

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -66,7 +66,7 @@ Example: If a caller peaks at 12 RPS and you choose a 60 s window → `12 × 
   ```
 * Prometheus: `authtranslator_rate_limit_exceeded_total{integration="slack"}`
 
-Grafana sample dashboard lives in `docs/ops/grafana-rate-limits.json`.
+Grafana sample dashboard lives in [`docs/ops/grafana-rate-limits.json`](ops/grafana-rate-limits.json).
 
 ---
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -21,4 +21,4 @@ curl http://localhost:8080/_at_internal/healthz
 curl http://localhost:8080/_at_internal/metrics
 ```
 
-Need a full walkthrough? Head over to **docs/getting-started.md**.
+Need a full walkthrough? Head over to [**docs/getting-started.md**](../docs/getting-started.md).


### PR DESCRIPTION
## Summary
- add secret back-end link
- point Helm docs at chart values and Terraform examples
- link rate limit dashboard reference
- add getting-started doc link in examples README

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*