### PR TITLE
Improve integrations test coverage

### DIFF
--- a/cmd/integrations/main_test.go
+++ b/cmd/integrations/main_test.go
@@ -339,3 +339,42 @@ func TestDeleteIntegrationWriteError(t *testing.T) {
 		t.Fatalf("expected error output")
 	}
 }
+
+func TestMainUpdateUnknownPlugin(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainHelper", "--", "update", "nop")
+	cmd.Env = append(os.Environ(), "GO_WANT_INTEGRATIONS_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(string(out), "unknown plugin nop") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestMainUpdateBuilderError(t *testing.T) {
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainHelper", "--", "update", "slack", "-token", "t")
+	cmd.Env = append(os.Environ(), "GO_WANT_INTEGRATIONS_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(string(out), "-token and -signing-secret are required") {
+		t.Fatalf("unexpected output: %s", out)
+	}
+}
+
+func TestMainListError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "cfg.yaml")
+	os.Mkdir(cfg, 0755)
+	cmd := exec.Command(os.Args[0], "-test.run=TestMainHelper", "--", "-file", cfg, "list")
+	cmd.Env = append(os.Environ(), "GO_WANT_INTEGRATIONS_HELPER=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected error output")
+	}
+}

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -49,3 +49,39 @@ func TestBuilders(t *testing.T) {
 		})
 	}
 }
+
+func TestBuilderErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{"asana", []string{}},
+		{"ghe", []string{"-domain", "d", "-token", "t"}},
+		{"slack", []string{"-token", "t"}},
+		{"twilio", []string{}},
+		{"workday", []string{"-token", "t"}},
+	}
+	for _, tt := range tests {
+		b := Get(tt.name)
+		if b == nil {
+			t.Fatalf("builder %s not registered", tt.name)
+		}
+		if _, err := b(tt.args); err == nil {
+			t.Errorf("%s: expected error for args %v", tt.name, tt.args)
+		}
+	}
+
+	if Get("nonexistent") != nil {
+		t.Errorf("expected nil builder for unknown plugin")
+	}
+}
+
+func TestBuilderParseError(t *testing.T) {
+	b := Get("asana")
+	if b == nil {
+		t.Fatalf("asana builder missing")
+	}
+	if _, err := b([]string{"-bogus"}); err == nil {
+		t.Fatalf("expected parse error")
+	}
+}


### PR DESCRIPTION
## Summary
- add builder error tests for plugin registry
- cover error cases in integrations CLI main
- merge builder error tests into existing file

## Testing
- `go test ./...`
