### PR TITLE
Fix broken docs links for plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Secrets can be pulled from several providers:
 * **azure‑keyvault:** Azure Key Vault
 * **vault:** HashiCorp Vault
 
-Need another store? Writing a plug‑in takes \~50 LoC – see [`plugins/secret/env`](plugins/secret/env).
+Need another store? Writing a plug‑in takes \~50 LoC – see [`app/secrets/plugins/env`](app/secrets/plugins/env).
 
 ---
 

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -68,7 +68,7 @@ Adds the configured token to the `X-Api-Key` header on each request.
 
 ## Writing your own plugin
 
-1. **Create a new package** under `plugins/auth/<name>`.
+1. **Create a new package** under `app/auth/plugins/<name>`.
 2. Implement exactly one of:
 
    ```go
@@ -82,9 +82,9 @@ Adds the configured token to the `X-Api-Key` header on each request.
    ```go
    auth.Register("<name>", &MyPlugin{})
    ```
-4. `go test ./plugins/...` – the main binary picks it up automatically.
+4. `go test ./app/...` – the main binary picks it up automatically.
 
-A minimal example lives in [`plugins/auth/example`](../plugins/auth/example).
+A minimal example lives in [`app/auth/plugins/example`](../app/auth/plugins/example).
 
 ---
 

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -80,7 +80,7 @@ The proxy treats the entire value as opaque until the chosen back‑end returns 
 
 ## Writing a new back‑end
 
-1. **New package** under `plugins/secret/<name>`.
+1. **New package** under `app/secrets/plugins/<name>`.
 2. Implement:
 
    ```go
@@ -115,7 +115,7 @@ func fetch(ctx context.Context, uri *url.URL) ([]byte, error) {
 }
 ```
 
-A working GCP implementation is in [`plugins/secret/gcp`](../plugins/secret/gcp).
+A working GCP implementation is in [`app/secrets/plugins/gcp`](../app/secrets/plugins/gcp).
 
 ---
 


### PR DESCRIPTION
## Summary
- update README example link
- fix paths for plugin docs

## Testing
- `make precommit` *(fails: can't load golangci-lint config)*
- `make test`