### PR TITLE
Increase urlpath auth plugin test coverage

### DIFF
--- a/app/auth/plugins/urlpath/urlpath_test.go
+++ b/app/auth/plugins/urlpath/urlpath_test.go
@@ -2,10 +2,12 @@ package urlpath
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/url"
 	"testing"
 
+	"github.com/winhowes/AuthTranslator/app/secrets"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
@@ -83,5 +85,75 @@ func TestURLPathParseParamsError(t *testing.T) {
 	in := URLPathAuth{}
 	if _, err := in.ParseParams(map[string]interface{}{}); err == nil {
 		t.Fatal("expected error for missing secrets")
+	}
+}
+
+// failPlugin simulates a failing secrets provider.
+type failPlugin struct{}
+
+func (failPlugin) Prefix() string                               { return "fail" }
+func (failPlugin) Load(context.Context, string) (string, error) { return "", errors.New("fail") }
+
+func TestURLPathRequiredParams(t *testing.T) {
+	in := URLPathAuth{}
+	out := URLPathAuthOut{}
+	if got := in.RequiredParams(); len(got) != 1 || got[0] != "secrets" {
+		t.Fatalf("unexpected required params: %v", got)
+	}
+	if got := out.RequiredParams(); len(got) != 1 || got[0] != "secrets" {
+		t.Fatalf("unexpected required params: %v", got)
+	}
+}
+
+func TestURLPathOutgoingParseParamsError(t *testing.T) {
+	out := URLPathAuthOut{}
+	if _, err := out.ParseParams(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error for missing secrets")
+	}
+}
+
+func TestURLPathOutgoingEdgeCases(t *testing.T) {
+	secrets.Register(failPlugin{})
+	p := URLPathAuthOut{}
+	// invalid params type
+	r := &http.Request{URL: &url.URL{Path: "/api"}}
+	p.AddAuth(context.Background(), r, struct{}{})
+	if r.URL.Path != "/api" {
+		t.Fatalf("path changed for invalid params: %s", r.URL.Path)
+	}
+	// missing secrets
+	r = &http.Request{URL: &url.URL{Path: "/api"}}
+	p.AddAuth(context.Background(), r, &outParams{})
+	if r.URL.Path != "/api" {
+		t.Fatalf("path changed for empty secrets: %s", r.URL.Path)
+	}
+	// secret loading error
+	r = &http.Request{URL: &url.URL{Path: "/api"}}
+	cfg := &outParams{Secrets: []string{"fail:oops"}}
+	p.AddAuth(context.Background(), r, cfg)
+	if r.URL.Path != "/api" {
+		t.Fatalf("path changed on load failure: %s", r.URL.Path)
+	}
+}
+
+func TestURLPathIncomingEdgeCases(t *testing.T) {
+	secrets.Register(failPlugin{})
+	p := URLPathAuth{}
+	// invalid params type
+	r := &http.Request{URL: &url.URL{Path: "/api/secret"}}
+	if p.Authenticate(context.Background(), r, struct{}{}) {
+		t.Fatal("expected false for invalid params")
+	}
+	if r.URL.Path != "/api/secret" {
+		t.Fatalf("path changed for invalid params: %s", r.URL.Path)
+	}
+	// secret loading error
+	r = &http.Request{URL: &url.URL{Path: "/api/secret"}}
+	cfg := &inParams{Secrets: []string{"fail:oops"}}
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected false for secret error")
+	}
+	if r.URL.Path != "/api/secret" {
+		t.Fatalf("path changed on failure: %s", r.URL.Path)
 	}
 }


### PR DESCRIPTION
## Summary
- expand unit tests for urlpath auth plugin
- cover required params, parse errors and edge cases

## Testing
- `make test`
- `go test ./app/auth/plugins/urlpath -cover`
