### PR TITLE
Fix allowlist param handling

### DIFF
--- a/cmd/allowlist/main.go
+++ b/cmd/allowlist/main.go
@@ -63,8 +63,9 @@ func addEntry(args []string) {
 		fmt.Println("-integration, -caller and -capability required")
 		return
 	}
-	params := map[string]interface{}{}
+	var params map[string]interface{}
 	if *paramList != "" {
+		params = make(map[string]interface{})
 		for _, kv := range strings.Split(*paramList, ",") {
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) == 2 {
@@ -113,6 +114,7 @@ func addEntry(args []string) {
 	callerCfg.Capabilities = append(callerCfg.Capabilities, plugins.CapabilityConfig{Name: *capName, Params: params})
 
 	out, _ := yaml.Marshal(entries)
+	out = bytes.ReplaceAll(out, []byte("params: {}"), []byte("params: null"))
 
 	if err := os.WriteFile(*file, out, 0644); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -64,7 +64,7 @@ func TestAddEntryNewFile(t *testing.T) {
 		{
 			Integration: "foo",
 			Callers: []plugins.CallerConfig{
-				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap", Params: map[string]interface{}{}}}},
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap", Params: nil}}},
 			},
 		},
 	}
@@ -210,7 +210,7 @@ func TestAddEntryNewCaller(t *testing.T) {
 		{
 			Integration: "foo",
 			Callers: []plugins.CallerConfig{
-				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: map[string]interface{}{}}}},
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: nil}}},
 			},
 		},
 	}
@@ -237,8 +237,8 @@ func TestAddEntryNewCaller(t *testing.T) {
 		{
 			Integration: "foo",
 			Callers: []plugins.CallerConfig{
-				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: map[string]interface{}{}}}},
-				{ID: "u2", Capabilities: []plugins.CapabilityConfig{{Name: "cap2", Params: map[string]interface{}{}}}},
+				{ID: "u1", Capabilities: []plugins.CapabilityConfig{{Name: "cap1", Params: nil}}},
+				{ID: "u2", Capabilities: []plugins.CapabilityConfig{{Name: "cap2", Params: nil}}},
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- fix allowlist CLI to write `params: null` for capabilities with no parameters
- update tests for nil params

## Testing
- `go test ./...`