### PR TITLE
Fix docs to show allowlist optional

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -5,6 +5,7 @@ The **allow‑list** answers a single question:
 > *Given this caller ID and integration, is the request allowed?*
 
 It lives in `allowlist.yaml` and is hot‑reloaded just like `config.yaml`.
+While the proxy starts without this file, doing so lets any authenticated caller access every integration. In production we **strongly recommend** defining an allowlist, even if it initially grants a single wildcard caller.
 
 ```yaml
 apiVersion: v1alpha1  # optional, ignored today

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,11 +1,14 @@
 # Configuration Reference
 
-AuthTranslator loads **two** YAML (or pure‑JSON) documents at runtime:
+AuthTranslator loads up to **two** YAML (or pure‑JSON) documents at runtime:
 
 | File             | Required? | Hot‑reload? | Purpose                                                                            |
 | ---------------- | --------- | ----------- | ---------------------------------------------------------------------------------- |
 | `config.yaml`    | ✅         | ✅           | Declares *integrations* – where to proxy traffic and how to authenticate outwards. |
-| `allowlist.yaml` | ✅         | ✅           | Grants each *caller ID* a set of capabilities **or** low‑level request filters.    |
+| `allowlist.yaml` | –          | ✅           | Grants each *caller ID* a set of capabilities **or** low‑level request filters.    |
+
+If no allowlist is provided, every request is permitted once inbound authentication succeeds.
+Running without an allowlist effectively gives all authenticated callers unrestricted access, so supplying `allowlist.yaml` is **strongly recommended** even if it just contains a single wildcard entry to start.
 
 The proxy currently infers its schema directly from Go structs. A top‑level `apiVersion` key is **optional** and ignored at runtime (reserved for future compatibility).
 


### PR DESCRIPTION
## Summary
- document that `allowlist.yaml` is optional
- recommend running with an allowlist to restrict caller access

## Testing
- `make test`
