### PR TITLE
Add more jwt and hmac auth plugin tests

### DIFF
--- a/app/auth/plugins/hmac/hmac_test.go
+++ b/app/auth/plugins/hmac/hmac_test.go
@@ -255,3 +255,14 @@ func TestHMACIncomingEdgeCases(t *testing.T) {
 		t.Fatal("expected authentication to succeed")
 	}
 }
+
+func TestHMACParseParamsMissingSecrets(t *testing.T) {
+	in := HMACSignatureAuth{}
+	out := HMACSignature{}
+	if _, err := in.ParseParams(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error for missing secrets")
+	}
+	if _, err := out.ParseParams(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error for missing secrets")
+	}
+}


### PR DESCRIPTION
## Summary
- expand jwt plugin tests with RS256 validation and outgoing edge cases
- cover missing-secret cases for hmac plugins

## Testing
- `go test ./... -coverprofile=coverage.txt`