### PR TITLE
Fix secret backend names in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,9 @@ Secrets can be pulled from several providers:
 
 * **env:** `SLACK_TOKEN=…`
 * **file:** path to an on‑disk file
-* **gcp‑secret:** Google Secret Manager
-* **aws‑secret:** AWS Secrets Manager
-* **azure‑keyvault:** Azure Key Vault
+* **gcp:** Google Cloud KMS
+* **aws:** AWS Secrets Manager
+* **azure:** Azure Key Vault
 * **vault:** HashiCorp Vault
 
 Need another store? Writing a plug‑in takes \~50 LoC – see [`app/secrets/plugins/env`](app/secrets/plugins/env).

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,9 +50,9 @@ Set `in_rate_limit: 0` and `out_rate_limit: 0` (or omit the fields entirely). Ra
 
 * `env:` (environment variable)
 * `file:` (volume‑mounted file)
-* `gcp-secret:` (Google Secret Manager)
-* `aws-secret:` (AWS Secrets Manager)
-* `azure-keyvault:` (Azure Key Vault)
+* `gcp:` (Cloud KMS)
+* `aws:` (AWS Secrets Manager)
+* `azure:` (Azure Key Vault)
 * `vault:` (HashiCorp Vault)
 
 You can add more with \~50 LoC—see [Secret Back‑Ends](secret-backends.md).


### PR DESCRIPTION
## Summary
- update documentation to match secret backend prefix names in code
- adjust examples for Cloud KMS and other providers

## Testing
- `make test`