### PR TITLE
Add unit tests for query and value matching

### DIFF
--- a/app/match_form_test.go
+++ b/app/match_form_test.go
@@ -56,3 +56,77 @@ func TestMatchFormInvalidType(t *testing.T) {
 		t.Fatal("expected invalid type to fail")
 	}
 }
+
+func TestMatchQuerySuccess(t *testing.T) {
+	vals := url.Values{"a": {"1", "2"}, "b": {"x"}}
+	rule := map[string][]string{"a": {"1"}, "b": {"x"}}
+	if !matchQuery(vals, rule) {
+		t.Fatal("expected match")
+	}
+}
+
+func TestMatchQueryMissingKey(t *testing.T) {
+	vals := url.Values{"a": {"1"}}
+	rule := map[string][]string{"a": {"1"}, "b": {"2"}}
+	if matchQuery(vals, rule) {
+		t.Fatal("expected missing key to fail")
+	}
+}
+
+func TestMatchQueryMissingValue(t *testing.T) {
+	vals := url.Values{"a": {"1"}, "b": {"x"}}
+	rule := map[string][]string{"a": {"1", "2"}}
+	if matchQuery(vals, rule) {
+		t.Fatal("expected missing value to fail")
+	}
+}
+
+func TestMatchValuePrimitive(t *testing.T) {
+	if !matchValue("a", "a") {
+		t.Fatal("expected primitive match")
+	}
+	if matchValue("a", "b") {
+		t.Fatal("expected primitive mismatch")
+	}
+}
+
+func TestMatchValueMap(t *testing.T) {
+	data := map[string]interface{}{"a": "1", "b": "2"}
+	rule := map[string]interface{}{"a": "1"}
+	if !matchValue(data, rule) {
+		t.Fatal("expected map match")
+	}
+	rule2 := map[string]interface{}{"c": "3"}
+	if matchValue(data, rule2) {
+		t.Fatal("expected missing key to fail")
+	}
+}
+
+func TestMatchValueArray(t *testing.T) {
+	data := []interface{}{"a", "b", "c"}
+	rule := []interface{}{"a", "c"}
+	if !matchValue(data, rule) {
+		t.Fatal("expected array match")
+	}
+	rule2 := []interface{}{"a", "d"}
+	if matchValue(data, rule2) {
+		t.Fatal("expected array mismatch")
+	}
+}
+
+func TestMatchValueNested(t *testing.T) {
+	data := map[string]interface{}{
+		"arr": []interface{}{
+			map[string]interface{}{"x": "1"},
+			map[string]interface{}{"x": "2"},
+		},
+	}
+	rule := map[string]interface{}{
+		"arr": []interface{}{
+			map[string]interface{}{"x": "2"},
+		},
+	}
+	if !matchValue(data, rule) {
+		t.Fatal("expected nested match")
+	}
+}


### PR DESCRIPTION
## Summary
- add unit tests for matchQuery and matchValue in match_form_test.go
- remove temporary files for those tests

## Testing
- `go vet ./...`
- `go test ./...`
- `golangci-lint run` *(fails: unsupported config version)*