### PR TITLE
Fix token auth prefix requirement

### DIFF
--- a/app/auth/plugins/token/incoming.go
+++ b/app/auth/plugins/token/incoming.go
@@ -42,7 +42,14 @@ func (t *TokenAuth) Authenticate(ctx context.Context, r *http.Request, p interfa
 	if !ok {
 		return false
 	}
-	tokenValue := strings.TrimPrefix(r.Header.Get(cfg.Header), cfg.Prefix)
+	headerVal := r.Header.Get(cfg.Header)
+	if cfg.Prefix != "" {
+		if !strings.HasPrefix(headerVal, cfg.Prefix) {
+			return false
+		}
+		headerVal = strings.TrimPrefix(headerVal, cfg.Prefix)
+	}
+	tokenValue := headerVal
 	for _, ref := range cfg.Secrets {
 		token, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {

--- a/app/auth/plugins/token/token_prefix_test.go
+++ b/app/auth/plugins/token/token_prefix_test.go
@@ -1,0 +1,21 @@
+package token
+
+import (
+	"context"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
+	"net/http"
+	"testing"
+)
+
+func TestTokenAuthenticateRequiresPrefix(t *testing.T) {
+	r := &http.Request{Header: http.Header{"Authorization": []string{"secret"}}}
+	p := TokenAuth{}
+	t.Setenv("TOK", "secret")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "Authorization", "prefix": "Bearer "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to fail without prefix")
+	}
+}


### PR DESCRIPTION
## Summary
- enforce prefix presence when authenticating token headers
- add regression test for token auth prefix handling

## Testing
- `go test ./...`