### PR TITLE
Fix docs to match config struct

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,6 @@ integrations:
     in_rate_limit:  100
     out_rate_limit: 800
     rate_limit_window: 1m
-    tags: [chat, team‑comm]
 ```
 
 See [Secret Back-Ends](secret-backends.md) for all supported URI schemes.
@@ -64,7 +63,6 @@ See [Secret Back-Ends](secret-backends.md) for all supported URI schemes.
 | `disable_keep_alives` | bool       | `false`      | Disable HTTP keep‑alive connections. |
 | `max_idle_conns` | int            | `0`          | Total idle connections to keep open. |
 | `max_idle_conns_per_host` | int     | `0`          | Idle connection limit per upstream host. |
-| `tags`          | `[]string`     | `[]`         | Arbitrary labels for dashboards / CLI queries.                               |
 
 #### `PluginSpec`
 

--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -77,6 +77,5 @@ From here you can tweak fields—e.g. turn on `tls_insecure_skip_verify` for a d
 ## Best practices for authors
 
 * **Set sane timeouts** SaaS APIs differ; codify them so callers don’t guess.
-* **Namespace tags** Add `tags: [chat, slack]` so dashboards can group traffic.
 * **Keep zero secrets** Integration plugins should only reference secret URIs, never raw tokens.
 


### PR DESCRIPTION
## Summary
- remove unused `tags` field from documentation

## Testing
- `make precommit` *(fails: can't load config)*
- `make test`
