### PR TITLE
Add more integration plugin tests

### DIFF
--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -60,6 +60,11 @@ func TestBuilderErrors(t *testing.T) {
 		{"slack", []string{"-token", "t"}},
 		{"twilio", []string{}},
 		{"workday", []string{"-token", "t"}},
+		{"github", []string{"-token", "t"}},
+		{"openai", []string{}},
+		{"sendgrid", []string{}},
+		{"monday", []string{}},
+		{"okta", []string{"-token", "t"}},
 	}
 	for _, tt := range tests {
 		b := Get(tt.name)
@@ -68,6 +73,8 @@ func TestBuilderErrors(t *testing.T) {
 		}
 		if _, err := b(tt.args); err == nil {
 			t.Errorf("%s: expected error for args %v", tt.name, tt.args)
+		} else if tt.name == "slack" && err.Error() != "-token and -signing-secret are required" {
+			t.Errorf("unexpected slack error: %v", err)
 		}
 	}
 
@@ -77,11 +84,13 @@ func TestBuilderErrors(t *testing.T) {
 }
 
 func TestBuilderParseError(t *testing.T) {
-	b := Get("asana")
-	if b == nil {
-		t.Fatalf("asana builder missing")
-	}
-	if _, err := b([]string{"-bogus"}); err == nil {
-		t.Fatalf("expected parse error")
+	for _, name := range []string{"asana", "openai"} {
+		b := Get(name)
+		if b == nil {
+			t.Fatalf("%s builder missing", name)
+		}
+		if _, err := b([]string{"-bogus"}); err == nil {
+			t.Fatalf("%s: expected parse error", name)
+		}
 	}
 }

--- a/cmd/integrations/plugins/registry_test.go
+++ b/cmd/integrations/plugins/registry_test.go
@@ -20,3 +20,22 @@ func TestListReturnsAllRegisteredNames(t *testing.T) {
 		}
 	}
 }
+
+func TestRegisterAndGet(t *testing.T) {
+	dummy := func(args []string) (Integration, error) { return Integration{Name: "dummy"}, nil }
+	Register("dummy", dummy)
+	if Get("dummy") == nil {
+		t.Fatalf("registered builder not found")
+	}
+	found := false
+	for _, n := range List() {
+		if n == "dummy" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("dummy not listed")
+	}
+	delete(registry, "dummy")
+}

--- a/cmd/integrations/plugins/slack_test.go
+++ b/cmd/integrations/plugins/slack_test.go
@@ -11,3 +11,23 @@ func TestSlackIntegration(t *testing.T) {
 		t.Fatalf("auth config missing")
 	}
 }
+
+func TestOktaIntegration(t *testing.T) {
+	i := Okta("o", "okta.example.com/", "tok")
+	if i.Destination != "https://okta.example.com/api/v1" {
+		t.Fatalf("unexpected destination: %s", i.Destination)
+	}
+	if got := i.OutgoingAuth[0].Params["prefix"]; got != "SSWS " {
+		t.Fatalf("unexpected prefix: %v", got)
+	}
+}
+
+func TestWorkdayIntegration(t *testing.T) {
+	i := Workday("w", "work.example.com/", "tok")
+	if i.Destination != "https://work.example.com/api" {
+		t.Fatalf("unexpected destination: %s", i.Destination)
+	}
+	if got := i.OutgoingAuth[0].Params["prefix"]; got != "Bearer " {
+		t.Fatalf("unexpected prefix: %v", got)
+	}
+}


### PR DESCRIPTION
## Summary
- extend builder error cases and parse error tests
- test Okta and Workday integration helpers
- ensure registry Register/Get are covered

## Testing
- `go test ./...`