### PR TITLE
Improve main.go tests

### DIFF
--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -135,3 +135,82 @@ func TestReloadClearsSecretCache(t *testing.T) {
 		t.Fatalf("expected 'second' after reload, got %s", val)
 	}
 }
+
+func TestReloadMissingConfig(t *testing.T) {
+	oldCfg := *configFile
+	t.Cleanup(func() { flag.Set("config", oldCfg) })
+	flag.Set("config", "nonexistent.yaml")
+	if err := reload(); err == nil {
+		t.Fatal("expected error for missing config")
+	}
+}
+
+func TestReloadIntegrationError(t *testing.T) {
+	// reset global state
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"bad","destination":"://"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	if err := os.WriteFile(alFile.Name(), []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	if err := reload(); err == nil {
+		t.Fatal("expected integration error")
+	}
+}
+
+func TestReloadInvalidAllowlist(t *testing.T) {
+	// reset global state
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"test","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	al := `[{"integration":"test","callers":[{"id":"a"},{"id":"a"}]}]`
+	if err := os.WriteFile(alFile.Name(), []byte(al), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	if err := reload(); err == nil {
+		t.Fatal("expected allowlist validation error")
+	}
+}

--- a/app/watch_files_test.go
+++ b/app/watch_files_test.go
@@ -83,3 +83,22 @@ func TestWatchFilesRename(t *testing.T) {
 		t.Fatal("timeout waiting for write event after rename")
 	}
 }
+
+func TestWatchFilesCancel(t *testing.T) {
+	ch := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		watchFiles(ctx, []string{"/path/does/not/exist"}, ch)
+		close(done)
+	}()
+	// let goroutine start
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+		// success
+	case <-time.After(time.Second):
+		t.Fatal("watchFiles did not exit after cancel")
+	}
+}


### PR DESCRIPTION
## Summary
- improve watchFiles coverage by testing cancellation
- add reload error-path tests for missing config, integration failure and invalid allowlist

## Testing
- `go test ./... -coverprofile=coverage.out`
