### PR TITLE
Fix incorrect import path in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Go Report Card](https://goreportcard.com/badge/github.com/winhowes/AuthTranslator)](https://goreportcard.com/report/github.com/winhowes/AuthTranslator) [![Coverage](https://codecov.io/gh/winhowes/AuthTranslator/branch/main/graph/badge.svg)](https://codecov.io/gh/winhowes/AuthTranslator) [![Go Reference](https://pkg.go.dev/badge/github.com/winhowes/authtranslator.svg)](https://pkg.go.dev/github.com/winhowes/authtranslator)
+[![Go Report Card](https://goreportcard.com/badge/github.com/winhowes/AuthTranslator)](https://goreportcard.com/report/github.com/winhowes/AuthTranslator) [![Coverage](https://codecov.io/gh/winhowes/AuthTranslator/branch/main/graph/badge.svg)](https://codecov.io/gh/winhowes/AuthTranslator) [![Go Reference](https://pkg.go.dev/badge/github.com/winhowes/AuthTranslator.svg)](https://pkg.go.dev/github.com/winhowes/AuthTranslator)
 
 
 # AuthTranslator

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -89,7 +89,7 @@ The proxy treats the entire value as opaque until the chosen back‑end returns 
 3. Register in `init()`:
 
    ```go
-   secret.Register("<scheme>", Fetch)
+   secrets.Register("<scheme>", Fetch)
    ```
 4. Unit‑test with a fake server or env vars.
 
@@ -102,11 +102,11 @@ import (
     "context"
     "net/url"
 
-    "github.com/winhowes/authtranslator/secret"
+    "github.com/winhowes/AuthTranslator/app/secrets"
 )
 
 func init() {
-    secret.Register("foo", fetch)
+    secrets.Register("foo", fetch)
 }
 
 func fetch(ctx context.Context, uri *url.URL) ([]byte, error) {


### PR DESCRIPTION
## Summary
- correct import path case in Go reference badge
- update secret backend docs to use the actual `secrets` package

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`