### PR TITLE
Fix header matching in allowlists

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -132,7 +132,7 @@ func matchSegments(pattern, path []string) bool {
 // validateRequest checks headers and body according to the request constraint.
 func validateRequest(r *http.Request, c RequestConstraint) bool {
 	for name, wantVals := range c.Headers {
-		gotVals, ok := r.Header[name]
+		gotVals, ok := r.Header[http.CanonicalHeaderKey(name)]
 		if !ok {
 			return false
 		}

--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -50,6 +50,12 @@ func TestValidateRequestHeaders(t *testing.T) {
 	if validateRequest(r2, RequestConstraint{Headers: map[string][]string{"X-Test": {"val"}}}) {
 		t.Fatal("expected failure without header")
 	}
+
+	r3 := httptest.NewRequest(http.MethodGet, "http://x", nil)
+	r3.Header.Set("X-Test", "v")
+	if !validateRequest(r3, RequestConstraint{Headers: map[string][]string{"x-test": {"v"}}}) {
+		t.Fatal("expected case-insensitive header match")
+	}
 }
 
 func TestValidateRequestJSONBody(t *testing.T) {


### PR DESCRIPTION
## Summary
- normalize header names when validating requests so allowlist rules work regardless of case
- consolidate header case-insensitive regression test in existing file

## Testing
- `go test ./...`
