### PR TITLE
Improve token and urlpath plugin coverage

### DIFF
--- a/app/auth/plugins/token/token_test.go
+++ b/app/auth/plugins/token/token_test.go
@@ -236,3 +236,39 @@ func TestTokenAuthenticateSecretError(t *testing.T) {
 		t.Fatal("expected authentication to fail due to secret load error")
 	}
 }
+
+func TestTokenParseParamsUnknownField(t *testing.T) {
+	in := TokenAuth{}
+	if _, err := in.ParseParams(map[string]interface{}{
+		"secrets": []string{"env:X"},
+		"header":  "H",
+		"extra":   true,
+	}); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	out := TokenAuthOut{}
+	if _, err := out.ParseParams(map[string]interface{}{
+		"secrets": []string{"env:X"},
+		"header":  "H",
+		"extra":   true,
+	}); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestTokenParseParamsTypeMismatch(t *testing.T) {
+	in := TokenAuth{}
+	if _, err := in.ParseParams(map[string]interface{}{
+		"secrets": "bad",
+		"header":  "H",
+	}); err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+	out := TokenAuthOut{}
+	if _, err := out.ParseParams(map[string]interface{}{
+		"secrets": "bad",
+		"header":  "H",
+	}); err == nil {
+		t.Fatal("expected type mismatch error")
+	}
+}

--- a/app/auth/plugins/urlpath/urlpath_test.go
+++ b/app/auth/plugins/urlpath/urlpath_test.go
@@ -157,3 +157,31 @@ func TestURLPathIncomingEdgeCases(t *testing.T) {
 		t.Fatalf("path changed on failure: %s", r.URL.Path)
 	}
 }
+
+func TestURLPathParseParamsUnknownField(t *testing.T) {
+	in := URLPathAuth{}
+	if _, err := in.ParseParams(map[string]interface{}{
+		"secrets": []string{"env:S"},
+		"extra":   1,
+	}); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+	out := URLPathAuthOut{}
+	if _, err := out.ParseParams(map[string]interface{}{
+		"secrets": []string{"env:S"},
+		"extra":   1,
+	}); err == nil {
+		t.Fatal("expected error for unknown field")
+	}
+}
+
+func TestURLPathParseParamsTypeMismatch(t *testing.T) {
+	in := URLPathAuth{}
+	if _, err := in.ParseParams(map[string]interface{}{"secrets": "bad"}); err == nil {
+		t.Fatal("expected type error")
+	}
+	out := URLPathAuthOut{}
+	if _, err := out.ParseParams(map[string]interface{}{"secrets": "bad"}); err == nil {
+		t.Fatal("expected type error")
+	}
+}


### PR DESCRIPTION
## Summary
- add parse error tests for Token auth plugin
- add parse error tests for URLPath auth plugin

## Testing
- `go test ./app/auth/plugins/token -cover`
- `go test ./app/auth/plugins/urlpath -cover`
- `go test ./...`