### PR TITLE
Fix docs to reflect outgoing_auth list

### DIFF
--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -55,11 +55,11 @@ incoming_auth:
 
 ```yaml
 outgoing_auth:
-  type: token
-  params:
-    secrets:
-      - env:API_TOKEN
-    header: X-Api-Key
+  - type: token
+    params:
+      secrets:
+        - env:API_TOKEN
+      header: X-Api-Key
 ```
 
 Adds the configured token to the `X-Api-Key` header on each request.

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,13 +14,13 @@ integrations:
             - vault:/old/token
             - vault:/new/token
     outgoing_auth:
-      type: token
-      params:
-        header: Authorization
-        prefix: "Bearer "
-        secrets:
-          - env:APP_TOKEN_1
-          - env:APP_TOKEN_2
+      - type: token
+        params:
+          header: Authorization
+          prefix: "Bearer "
+          secrets:
+            - env:APP_TOKEN_1
+            - env:APP_TOKEN_2
     idle_conn_timeout: 10s
     in_rate_limit:  100
     out_rate_limit: 800

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,12 +24,12 @@ integrations:
   slack:
     destination: https://slack.com
     outgoing_auth:
-      type: token
-      params:
-        secrets:
-          - env:SLACK_TOKEN            # secret URI – see docs/secret-backends.md
-        header: Authorization
-        prefix: "Bearer "
+      - type: token
+        params:
+          secrets:
+            - env:SLACK_TOKEN            # secret URI – see docs/secret-backends.md
+          header: Authorization
+          prefix: "Bearer "
     idle_conn_timeout: 10s
     tls_insecure_skip_verify: false
     in_rate_limit:  100
@@ -51,7 +51,7 @@ See [Secret Back-Ends](secret-backends.md) for all supported URI schemes.
 | Field           | Type           | Default      | Description                                                                  |
 | --------------- | -------------- | ------------ | ---------------------------------------------------------------------------- |
 | `destination`   | URL            | **required** | Base URL; path from client is appended as‑is.                                |
-| `outgoing_auth` | `PluginSpec`   | –            | Injects long‑lived credential **before** forwarding.                         |
+| `outgoing_auth` | `[]PluginSpec` | `[]`         | Injects long‑lived credential **before** forwarding.                         |
 | `incoming_auth` | `[]PluginSpec` | `[]`         | Zero or more validators that run **in order**; the first that succeeds wins. |
 | `in_rate_limit` | int            | `0`          | Max inbound requests per caller within the window. |
 | `out_rate_limit` | int           | `0`          | Max outbound requests per caller within the window. |

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -60,12 +60,12 @@ configYaml: |
     slack:
       destination: https://slack.com
       outgoing_auth:
-        type: token
-        params:
-          secrets:
-            - env:SLACK_TOKEN
-          header: Authorization
-          prefix: "Bearer "
+        - type: token
+          params:
+            secrets:
+              - env:SLACK_TOKEN
+            header: Authorization
+            prefix: "Bearer "
 
 allowlistYaml: |
   - integration: slack

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -4,12 +4,12 @@ AuthTranslator never expects you to paste raw API keys into a YAML file. Inste
 
 ```yaml
 outgoing_auth:
-  type: token
-  params:
-    secrets:
-      - gcp:projects/acme/locations/global/keyRings/auth/cryptoKeys/token:ciphertext
-    header: Authorization
-    prefix: "Bearer "
+  - type: token
+    params:
+      secrets:
+        - gcp:projects/acme/locations/global/keyRings/auth/cryptoKeys/token:ciphertext
+      header: Authorization
+      prefix: "Bearer "
 ```
 
 ---


### PR DESCRIPTION
## Summary
- fix docs examples that showed outgoing_auth as a single object
- document outgoing_auth as `[]PluginSpec`

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`