### PR TITLE
Add tests for secret plugins

### DIFF
--- a/app/secrets/plugins/aws/plugin.go
+++ b/app/secrets/plugins/aws/plugin.go
@@ -12,6 +12,12 @@ import (
 	"github.com/winhowes/AuthTranslator/app/secrets"
 )
 
+// functions to allow stubbing during tests
+var (
+	newAESCipher = aes.NewCipher
+	newGCM       = cipher.NewGCM
+)
+
 // awsKMSPlugin decrypts secrets using a symmetric key provided via the
 // AWS_KMS_KEY environment variable. The ciphertext must be base64 encoded and
 // include a 12 byte nonce prefix followed by the encrypted data. This is not a
@@ -58,11 +64,11 @@ func (p *awsKMSPlugin) Load(ctx context.Context, id string) (string, error) {
 	nonce := ct[:12]
 	data := ct[12:]
 
-	block, err := aes.NewCipher(p.key)
+	block, err := newAESCipher(p.key)
 	if err != nil {
 		return "", err
 	}
-	gcm, err := cipher.NewGCM(block)
+	gcm, err := newGCM(block)
 	if err != nil {
 		return "", err
 	}

--- a/app/secrets/plugins/azure/plugin.go
+++ b/app/secrets/plugins/azure/plugin.go
@@ -23,6 +23,9 @@ type azureKMSPlugin struct{}
 
 var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
+// helper to allow request stubbing in tests
+var newRequest = http.NewRequest
+
 // Prefix returns the identifier prefix used in configuration strings.
 func (azureKMSPlugin) Prefix() string { return "azure" }
 
@@ -42,7 +45,7 @@ func (azureKMSPlugin) Load(ctx context.Context, id string) (string, error) {
 		return "", err
 	}
 
-	req, err := http.NewRequest("GET", id+"?api-version=7.2", nil)
+	req, err := newRequest("GET", id+"?api-version=7.2", nil)
 	if err != nil {
 		return "", err
 	}
@@ -73,7 +76,7 @@ func getAzureToken(tenant, client, secret string) (string, error) {
 	form.Set("scope", "https://vault.azure.net/.default")
 
 	u := fmt.Sprintf("https://login.microsoftonline.com/%s/oauth2/v2.0/token", tenant)
-	req, err := http.NewRequest("POST", u, bytes.NewBufferString(form.Encode()))
+	req, err := newRequest("POST", u, bytes.NewBufferString(form.Encode()))
 	if err != nil {
 		return "", err
 	}

--- a/app/secrets/plugins/gcp/plugin_test.go
+++ b/app/secrets/plugins/gcp/plugin_test.go
@@ -31,6 +31,19 @@ func (errorRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
 	return nil, fmt.Errorf("network error")
 }
 
+type tokenThenError struct{ done bool }
+
+func (t *tokenThenError) RoundTrip(r *http.Request) (*http.Response, error) {
+	if !t.done {
+		t.done = true
+		rec := httptest.NewRecorder()
+		rec.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(rec).Encode(map[string]string{"access_token": "tok"})
+		return rec.Result(), nil
+	}
+	return nil, fmt.Errorf("net err")
+}
+
 func setGCPTestClient(ts *httptest.Server) func() {
 	oldDef := http.DefaultClient
 	old := HTTPClient
@@ -192,6 +205,80 @@ func TestGCPKMSTokenRequestError(t *testing.T) {
 		http.DefaultClient = oldDef
 		HTTPClient = old
 	}()
+
+	p := gcpKMSPlugin{}
+	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGCPKMSMetadataRequestCreateError(t *testing.T) {
+	old := httpNewRequest
+	httpNewRequest = func(method, url string, body io.Reader) (*http.Request, error) { return nil, fmt.Errorf("bad req") }
+	defer func() { httpNewRequest = old }()
+
+	p := gcpKMSPlugin{}
+	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGCPKMSDecryptRequestCreateError(t *testing.T) {
+	count := 0
+	oldReq := httpNewRequest
+	httpNewRequest = func(method, url string, body io.Reader) (*http.Request, error) {
+		count++
+		if count == 1 {
+			return oldReq(method, url, body)
+		}
+		return nil, fmt.Errorf("bad req")
+	}
+	defer func() { httpNewRequest = oldReq }()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+	}))
+	defer ts.Close()
+	restore := setGCPTestClient(ts)
+	defer restore()
+
+	p := gcpKMSPlugin{}
+	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGCPKMSDecryptNetworkError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+	}))
+	defer ts.Close()
+	u, _ := url.Parse(ts.URL)
+	rt := &tokenThenError{}
+	failing := &http.Client{Transport: &gcpRewriteTransport{rt: rt, scheme: u.Scheme, host: u.Host}}
+	oldDef := http.DefaultClient
+	old := HTTPClient
+	http.DefaultClient = failing
+	HTTPClient = failing
+	defer func() { http.DefaultClient = oldDef; HTTPClient = old }()
+
+	p := gcpKMSPlugin{}
+	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestGCPKMSMarshalError(t *testing.T) {
+	oldM := jsonMarshal
+	jsonMarshal = func(v any) ([]byte, error) { return nil, fmt.Errorf("bad") }
+	defer func() { jsonMarshal = oldM }()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"access_token": "tok"})
+	}))
+	defer ts.Close()
+	restore := setGCPTestClient(ts)
+	defer restore()
 
 	p := gcpKMSPlugin{}
 	if _, err := p.Load(context.Background(), "projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher"); err == nil {

--- a/app/secrets/plugins/vault/plugin.go
+++ b/app/secrets/plugins/vault/plugin.go
@@ -23,6 +23,9 @@ type vaultPlugin struct{}
 // HTTPClient is used for requests to Vault and can be overridden in tests.
 var HTTPClient = &http.Client{Timeout: 5 * time.Second}
 
+// helper to stub request creation in tests
+var newRequest = http.NewRequest
+
 func (vaultPlugin) Prefix() string { return "vault" }
 
 func (vaultPlugin) Load(ctx context.Context, id string) (string, error) {
@@ -38,7 +41,7 @@ func (vaultPlugin) Load(ctx context.Context, id string) (string, error) {
 	}
 	path := strings.TrimLeft(id, "/")
 	base.Path = "/v1/" + path
-	req, err := http.NewRequest("GET", base.String(), nil)
+	req, err := newRequest("GET", base.String(), nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- allow stubbing crypto and network helpers in secret plugins
- add tests covering error paths for all secret plugins

## Testing
- `go test ./...`
- `go test ./app/secrets/plugins/... -cover`