### PR TITLE
Fix allowlist docs

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -66,15 +66,16 @@ Capabilities are defined **next to each integration plugin**. They expand into o
 ```yaml
 rules:
   - path:   /api/chat.postMessage          # path pattern, anchored
-    method: POST                          # string or [string]
-    query:                                # list of key=value pairs (ANDed)
-      - channel=C12345678
-    headers:                              # header=value list; empty list checks only presence
-      X-Custom-Trace: [abc123]
-    body:                                 # optional JSON *or* form filters
-      json:
-        text: "Hello world"               # matched recursively
-      form: {}
+    methods:                              # HTTP methods allowed for this path
+      POST:                               # map of method name to constraints
+        query:                            # map of query param to allowed values
+          channel: [C12345678]
+        headers:                          # header=value list; empty list checks only presence
+          X-Custom-Trace: [abc123]
+        body:                             # optional JSON *or* form filters
+          json:
+            text: "Hello world"           # matched recursively
+          form: {}
 ```
 
 > **Subset principle** *Every* field you specify must match the request; unspecified fields are ignored. This means your rule must be a **subset** of the incoming request.
@@ -83,7 +84,7 @@ rules:
 | ------------ | --------------------------------------------------------------------------------------------------- |
 | Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
 | Method       | Case‑insensitive string compare.                                                                    |
-| Query params | Each `key=value` must exist & match **first** value. Extra params allowed.                          |
+| Query params | Each `name:[values]` must exist with a matching value. Extra params allowed.                          |
 | Headers      | Each `key=[values]` must exist with those values; an empty list only checks for presence. |
 | Body JSON    | The specified object must be a recursive subset of the request body. Arrays are matched unordered. |
 | Body form    | Same as JSON but for `application/x-www-form-urlencoded`. |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,6 +86,7 @@ Two ways to authorise a caller:
 1. **High‑level capability** – human‑readable label that expands into many fine‑grained rules.
 2. **Low‑level filter** – match on HTTP path, method, query, headers, JSON‑body or form‑data.
 
+
 ```yaml
 apiVersion: v1alpha1
 - integration: slack
@@ -98,17 +99,17 @@ apiVersion: v1alpha1
       # granular example
       rules:
         - path:   /api/chat.postMessage
-          method: POST
-          query:
-            - channel=^C[0-9A-Z]{8}$   # workspace channel IDs
-          body:
-            json:
-              text: "^.+"              # any non‑empty string
-            form: {}
-          headers:
-            X-Custom-Trace: [abc123]
+          methods:
+            POST:
+              query:
+                channel: ["^C[0-9A-Z]{8}$"]   # workspace channel IDs
+              body:
+                json:
+                  text: "^.+"              # any non-empty string
+                form: {}
+              headers:
+                X-Custom-Trace: [abc123]
 ```
-
 ### Top‑level keys
 
 | Field        | Type               | Notes                                          |   |
@@ -129,13 +130,9 @@ apiVersion: v1alpha1
 
 | Field        | Type                 | Notes                                                  |
 | ------------ | -------------------- | ------------------------------------------------------ |
-| `path`       | string               | Anchored to the upstream path. Supports `*` and `**` wildcards. |
-| `method`     | string or `[string]` | `GET`, `POST`, …                                       |
-| `query`      | `[string]`           | Each element `key=value`. All must match.              |
-| `headers`    | map\[string][]string | Header names and required values. Empty list checks only presence. |
-| `body.json`  | map\[string]interface{} | Object matched recursively; must be a subset of the request. |
-| `body.form`  | map\[string]interface{} | Same subset matching for `application/x-www-form-urlencoded`. |
 
+| `path`    | string | Anchored to the upstream path. Supports `*` and `**` wildcards. |
+| `methods` | object | Map of HTTP method → filters (`headers`, `query`, `body`). |
 > **Performance note** Low‑level matching adds negligible latency (<50 µs at 10 rules). Tune rule ordering so the most frequent match comes first.
 
 ---


### PR DESCRIPTION
## Summary
- fix allowlist docs to show per-method constraints
- update configuration doc to match schema

## Testing
- `make precommit` *(fails: can't load config: unsupported version)*
- `make test`
