### PR TITLE
Update docs for per-method constraints

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -66,15 +66,16 @@ Capabilities are defined **next to each integration plugin**. They expand into o
 ```yaml
 rules:
   - path:   /api/chat.postMessage          # path pattern, anchored
-    method: POST                          # string or [string]
-    query:                                # list of key=value pairs (ANDed)
-      - channel=C12345678
-    headers:                              # header=value list; empty list checks only presence
-      X-Custom-Trace: [abc123]
-    body:                                 # optional JSON *or* form filters
-      json:
-        text: "Hello world"               # matched recursively
-      form: {}
+    methods:                               # each method has its own constraints
+      POST:
+        query:                             # map of query params (ANDed)
+          channel: [C12345678]
+        headers:                           # header=list of values; empty list checks only presence
+          X-Custom-Trace: [abc123]
+        body:                              # optional JSON *or* form filters
+          json:
+            text: "Hello world"            # matched recursively
+          form: {}
 ```
 
 > **Subset principle** *Every* field you specify must match the request; unspecified fields are ignored. This means your rule must be a **subset** of the incoming request.
@@ -82,11 +83,11 @@ rules:
 | Request part | Matching logic                                                                                      |
 | ------------ | --------------------------------------------------------------------------------------------------- |
 | Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
-| Method       | Case‑insensitive string compare.                                                                    |
-| Query params | Each `key=value` must exist & match **first** value. Extra params allowed.                          |
-| Headers      | Each `key=[values]` must exist with those values; an empty list only checks for presence. |
-| Body JSON    | The specified object must be a recursive subset of the request body. Arrays are matched unordered. |
-| Body form    | Same as JSON but for `application/x-www-form-urlencoded`. |
+| Method       | Case‑insensitive string compare. Each method key contains its own constraints. |
+| Query params | In `methods.<HTTP_METHOD>.query`, each key maps to allowed value list. Extra params allowed.
+| Headers      | In `methods.<HTTP_METHOD>.headers`, each key has required values; an empty list only checks for presence.
+| Body JSON    | `methods.<HTTP_METHOD>.body.json` must be a recursive subset of the request. Arrays matched unordered.
+| Body form    | `methods.<HTTP_METHOD>.body.form` applies the same subset logic for `application/x-www-form-urlencoded`.
 
 A rule like:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -98,15 +98,16 @@ apiVersion: v1alpha1
       # granular example
       rules:
         - path:   /api/chat.postMessage
-          method: POST
-          query:
-            - channel=^C[0-9A-Z]{8}$   # workspace channel IDs
-          body:
-            json:
-              text: "^.+"              # any non‑empty string
-            form: {}
-          headers:
-            X-Custom-Trace: [abc123]
+          methods:                             # per-method constraints
+            POST:
+              query:
+                channel: ["^C[0-9A-Z]{8}$"]   # workspace channel IDs
+              body:
+                json:
+                  text: "^.+"              # any non‑empty string
+                form: {}
+              headers:
+                X-Custom-Trace: [abc123]
 ```
 
 ### Top‑level keys
@@ -130,11 +131,11 @@ apiVersion: v1alpha1
 | Field        | Type                 | Notes                                                  |
 | ------------ | -------------------- | ------------------------------------------------------ |
 | `path`       | string               | Anchored to the upstream path. Supports `*` and `**` wildcards. |
-| `method`     | string or `[string]` | `GET`, `POST`, …                                       |
-| `query`      | `[string]`           | Each element `key=value`. All must match.              |
-| `headers`    | map\[string][]string | Header names and required values. Empty list checks only presence. |
-| `body.json`  | map\[string]interface{} | Object matched recursively; must be a subset of the request. |
-| `body.form`  | map\[string]interface{} | Same subset matching for `application/x-www-form-urlencoded`. |
+| `methods`    | map[string]RequestConstraint | Map of HTTP method names to constraint objects. |
+| `methods.<name>.query` | map[string][]string | Query params to match; each key’s listed values must be present. |
+| `methods.<name>.headers` | map[string][]string | Header names and required values; empty list checks only presence. |
+| `methods.<name>.body.json` | map[string]interface{} | Object matched recursively; must be a subset of the request. |
+| `methods.<name>.body.form` | map[string]interface{} | Same subset matching for `application/x-www-form-urlencoded`. |
 
 > **Performance note** Low‑level matching adds negligible latency (<50 µs at 10 rules). Tune rule ordering so the most frequent match comes first.
 


### PR DESCRIPTION
## Summary
- nest `query`, `headers` and `body` under `methods` in allowlist examples
- document that each HTTP method has its own constraint object
- update configuration reference with `methods` field and nested constraint descriptions
- clarify that query constraints are maps, not key=value lists

## Testing
- `go vet ./...`
- `golangci-lint run` *(fails: unsupported version of the configuration)*