### PR TITLE
Fix allowlist query field handling

### DIFF
--- a/cmd/allowlist/plugins/types.go
+++ b/cmd/allowlist/plugins/types.go
@@ -19,6 +19,7 @@ type CallRule struct {
 
 type RequestConstraint struct {
 	Headers map[string][]string    `json:"headers,omitempty" yaml:"headers,omitempty"`
+	Query   map[string][]string    `json:"query,omitempty" yaml:"query,omitempty"`
 	Body    map[string]interface{} `json:"body,omitempty" yaml:"body,omitempty"`
 }
 

--- a/cmd/allowlist/plugins/types_test.go
+++ b/cmd/allowlist/plugins/types_test.go
@@ -1,0 +1,41 @@
+package plugins
+
+import (
+	"bytes"
+	"reflect"
+	"testing"
+
+	yaml "gopkg.in/yaml.v3"
+)
+
+func TestRequestConstraintQueryRoundTrip(t *testing.T) {
+	input := []byte(`
+- integration: foo
+  callers:
+  - id: u1
+    rules:
+    - path: /x
+      methods:
+        GET:
+          query:
+            a: ["1"]
+`)
+	var entries []AllowlistEntry
+	if err := yaml.Unmarshal(input, &entries); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(entries) != 1 || len(entries[0].Callers) != 1 {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+	q := entries[0].Callers[0].Rules[0].Methods["GET"].Query
+	if !reflect.DeepEqual(q, map[string][]string{"a": {"1"}}) {
+		t.Fatalf("query not parsed: %#v", q)
+	}
+	out, err := yaml.Marshal(entries)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !bytes.Contains(out, []byte("query:")) {
+		t.Fatalf("query missing from output: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- include missing `query` field in allowlist CLI types
- add regression test covering `query` round trip

## Testing
- `go test ./...`