### PR TITLE
Fix example auth plugin build tag implementation

### DIFF
--- a/app/auth/plugins/example/example.go
+++ b/app/auth/plugins/example/example.go
@@ -3,16 +3,19 @@
 package example
 
 import (
-	"github.com/winhowes/AuthTranslator/app/auth"
+	"context"
 	"net/http"
+
+	authplugins "github.com/winhowes/AuthTranslator/app/auth"
 )
 
 // Incoming example plugin that allows all requests.
 type incoming struct{}
 
-func (incoming) RequiredParams() []string                                    { return nil }
-func (incoming) OptionalParams() []string                                    { return nil }
-func (incoming) ParseParams(map[string]interface{}) (interface{}, error)     { return struct{}{}, nil }
-func (incoming) Authenticate(_ interface{}, _ *http.Request) (string, error) { return "", nil }
+func (incoming) Name() string                                                  { return "example" }
+func (incoming) RequiredParams() []string                                      { return nil }
+func (incoming) OptionalParams() []string                                      { return nil }
+func (incoming) ParseParams(map[string]interface{}) (interface{}, error)       { return struct{}{}, nil }
+func (incoming) Authenticate(context.Context, *http.Request, interface{}) bool { return true }
 
-func init() { authplugins.RegisterIncoming("example", incoming{}) }
+func init() { authplugins.RegisterIncoming(&incoming{}) }


### PR DESCRIPTION
## Summary
- update the `example` auth plugin to implement the correct interface

## Testing
- `go test ./...`