### PR TITLE
Clarify allowlist matching

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -78,6 +78,8 @@ rules:
           # body format is detected via Content-Type; other types skip matching
 ```
 
+Allowed values are matched **exactly**; the proxy does not interpret regular expressions.
+
 Each key under `methods:` represents an HTTP method. Mapping a method to `{}`
 means the request is allowed for that verb as soon as the path matches. Add
 `query`, `headers`, or `body` constraints inside a method block to further limit
@@ -89,8 +91,8 @@ which requests are permitted.
 | ------------ | --------------------------------------------------------------------------------------------------- |
 | Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
 | Method       | Case‑insensitive string compare. Each method key contains its own constraints. |
-| Query params | In `methods.<HTTP_METHOD>.query`, each key maps to allowed value list. Extra params allowed.
-| Headers      | In `methods.<HTTP_METHOD>.headers`, each key has required values; an empty list only checks for presence.
+| Query params | In `methods.<HTTP_METHOD>.query`, each key maps to allowed value list. Extra params allowed. Values match exactly.
+| Headers      | In `methods.<HTTP_METHOD>.headers`, each key has required values; an empty list only checks for presence. Values match exactly.
 | Body         | `methods.<HTTP_METHOD>.body` must be a recursive subset of the request body (JSON or form). Arrays matched unordered. Detection relies on the `Content-Type` header; if it's neither JSON nor form, body checks are skipped.
 
 A rule like:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,13 +105,16 @@ apiVersion: v1alpha1
           methods:                             # per-method constraints
             POST:
               query:
-                channel: ["^C[0-9A-Z]{8}$"]   # workspace channel IDs
+                channel: [C12345678]           # workspace channel IDs (exact match)
               body:
-                text: "^.+"              # any non‑empty string
+                text: "Hello world"            # match the whole value exactly
                 # format detection uses Content-Type; other types skip body matching
               headers:
                 X-Custom-Trace: [abc123]
 ```
+
+Values for `query`, `headers`, and `body` are compared using **exact string equality**.
+Regular expressions are not supported.
 
 ### Top‑level keys
 


### PR DESCRIPTION
## Summary
- clarify that allowlist matching for query, headers, and body uses exact string equality
- fix misleading regex-like examples

## Testing
- `make test`