### PR TITLE
Fix docs discrepancies

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -30,7 +30,7 @@ Either:
 kill -s SIGHUP <pid>
 ```
 
-—or—start the proxy with `-watch` so it polls the config directory for changes every second.
+—or—start the proxy with `-watch` so it automatically reloads when the config or allowlist files change.
 
 ---
 

--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -30,7 +30,6 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | `stripe` | `https://api.stripe.com` | `token` |
 | `trufflehog` | `https://trufflehog.cloud/api` | `token` |
 | `twilio` | `https://api.twilio.com` | `basic` |
-| `workday` | `https://<domain>/api` | `token` |
 | `zendesk` | `https://api.zendesk.com` | `token` |
 *(Full list lives under **[`app/integrations/plugins/`](../app/integrations/plugins/)**)*
 ## Creating an integration via the CLI


### PR DESCRIPTION
## Summary
- update hot reload FAQ to match actual watch implementation
- remove defunct Workday entry from integration plugin list

## Testing
- `make test`