### PR TITLE
Fix documentation mismatch

### DIFF
--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -30,6 +30,7 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | `stripe` | `https://api.stripe.com` | `token` |
 | `trufflehog` | `https://trufflehog.cloud/api` | `token` |
 | `twilio` | `https://api.twilio.com` | `basic` |
+| `workday` | `https://<domain>/api` (configurable) | `token` |
 | `zendesk` | `https://api.zendesk.com` | `token` |
 *(Full list lives under **[`app/integrations/plugins/`](../app/integrations/plugins/)**)*
 ## Creating an integration via the CLI


### PR DESCRIPTION
## Summary
- add missing Workday integration to plugin list

## Testing
- `go test ./...`
