### PR TITLE
Increase main.go test coverage

### DIFF
--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -294,3 +294,40 @@ func TestReloadAllowlistMissing(t *testing.T) {
 		t.Fatal("allowlist entry lost after missing file reload")
 	}
 }
+
+func TestReloadDuplicateIntegration(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"dup","destination":"http://example.com"},{"name":"dup","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	if err := os.WriteFile(alFile.Name(), []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+
+	err = reload()
+	if err == nil {
+		t.Fatal("expected duplicate integration error")
+	}
+	if len(ListIntegrations()) != 0 {
+		t.Fatal("integration map should remain empty on failure")
+	}
+}


### PR DESCRIPTION
## Summary
- add metrics flag mismatch test to `main_test.go`
- add duplicate integration handling test to `reload_test.go`

## Testing
- `go test ./...`
