### PR TITLE
Fix log field name in rate-limiting docs

### DIFF
--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -62,7 +62,7 @@ Example: If a caller peaks at 12 RPS and you choose a 60 s window → `12 × 
 * **Structured log** when a request is throttled:
 
   ```json
-  {"lvl":"WARN","msg":"rate‑limit exceeded","caller_id":"bot‑123","integration":"slack","limit":800,"window":"60s"}
+  {"level":"WARN","msg":"rate‑limit exceeded","caller_id":"bot‑123","integration":"slack","limit":800,"window":"60s"}
   ```
 * Prometheus: `authtranslator_rate_limit_events_total{integration="slack"}`
 


### PR DESCRIPTION
## Summary
- correct structured log example to use `level` field name

## Testing
- `make precommit` *(fails: can't load config: unsupported version of the configuration)*
- `make test`