### PR TITLE
Add cmd plugin test coverage

### DIFF
--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -57,14 +57,22 @@ func TestBuilderErrors(t *testing.T) {
 	}{
 		{"asana", []string{}},
 		{"ghe", []string{"-domain", "d", "-token", "t"}},
+		{"confluence", []string{}},
 		{"slack", []string{"-token", "t"}},
 		{"twilio", []string{}},
 		{"workday", []string{"-token", "t"}},
 		{"github", []string{"-token", "t"}},
+		{"gitlab", []string{}},
 		{"openai", []string{}},
 		{"sendgrid", []string{}},
+		{"servicenow", []string{}},
 		{"monday", []string{}},
+		{"jira", []string{}},
 		{"okta", []string{"-token", "t"}},
+		{"linear", []string{}},
+		{"stripe", []string{}},
+		{"trufflehog", []string{}},
+		{"zendesk", []string{}},
 	}
 	for _, tt := range tests {
 		b := Get(tt.name)
@@ -84,7 +92,7 @@ func TestBuilderErrors(t *testing.T) {
 }
 
 func TestBuilderParseError(t *testing.T) {
-	for _, name := range []string{"asana", "openai"} {
+	for _, name := range []string{"asana", "openai", "confluence", "jira"} {
 		b := Get(name)
 		if b == nil {
 			t.Fatalf("%s builder missing", name)

--- a/cmd/integrations/plugins/jira_confluence_test.go
+++ b/cmd/integrations/plugins/jira_confluence_test.go
@@ -1,0 +1,23 @@
+package plugins
+
+import "testing"
+
+func TestJiraIntegrationDefaultDomain(t *testing.T) {
+	i := Jira("j", "tok", "")
+	if i.Destination != "https://api.atlassian.com" {
+		t.Fatalf("unexpected destination: %s", i.Destination)
+	}
+	if pref := i.OutgoingAuth[0].Params["prefix"]; pref != "Bearer " {
+		t.Fatalf("unexpected prefix: %v", pref)
+	}
+}
+
+func TestConfluenceIntegrationDefaultDomain(t *testing.T) {
+	i := Confluence("c", "tok", "")
+	if i.Destination != "https://api.atlassian.com" {
+		t.Fatalf("unexpected destination: %s", i.Destination)
+	}
+	if pref := i.OutgoingAuth[0].Params["prefix"]; pref != "Bearer " {
+		t.Fatalf("unexpected prefix: %v", pref)
+	}
+}


### PR DESCRIPTION
## Summary
- add integration tests for jira and confluence default domain behaviour
- extend builder error tests to cover more plugins and parse error cases

## Testing
- `go test ./cmd/... -cover`