### PR TITLE
Fix numeric comparison in allowlist matcher

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -284,7 +284,46 @@ func matchValue(data, rule interface{}) bool {
 		}
 		return true
 	default:
+		// YAML unmarshals numbers without decimals as ints while JSON
+		// decoding uses float64. Normalize numeric types so the values
+		// compare equal regardless of how they were parsed.
+		if df, ok := toFloat(data); ok {
+			if rf, ok2 := toFloat(rv); ok2 {
+				return df == rf
+			}
+		}
 		return data == rule
+	}
+}
+
+func toFloat(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int8:
+		return float64(n), true
+	case int16:
+		return float64(n), true
+	case int32:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case uint:
+		return float64(n), true
+	case uint8:
+		return float64(n), true
+	case uint16:
+		return float64(n), true
+	case uint32:
+		return float64(n), true
+	case uint64:
+		return float64(n), true
+	case float32:
+		return float64(n), true
+	case float64:
+		return n, true
+	default:
+		return 0, false
 	}
 }
 

--- a/app/allowlist_body_filter_test.go
+++ b/app/allowlist_body_filter_test.go
@@ -5,6 +5,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	yaml "gopkg.in/yaml.v3"
 )
 
 // helper to create request preserving body
@@ -110,5 +112,18 @@ func TestBodyNestedMatching(t *testing.T) {
 		if got := validateRequest(r, RequestConstraint{Body: tt.rule}); got != tt.want {
 			t.Errorf("%s: got %v want %v", tt.name, got, tt.want)
 		}
+	}
+}
+
+func TestBodyNumericTypeMismatch(t *testing.T) {
+	body := []byte(`{"num":1}`)
+	var rule map[string]interface{}
+	if err := yaml.Unmarshal([]byte("num: 1"), &rule); err != nil {
+		t.Fatal(err)
+	}
+
+	r := req(http.MethodPost, body)
+	if !validateRequest(r, RequestConstraint{Body: rule}) {
+		t.Fatal("expected numeric types to match")
 	}
 }


### PR DESCRIPTION
## Summary
- handle numeric comparison in allowlist body filtering
- add regression test

## Testing
- `go test ./...`
