### PR TITLE
Fix metric reference

### DIFF
--- a/docs/ops/grafana-rate-limits.json
+++ b/docs/ops/grafana-rate-limits.json
@@ -6,7 +6,7 @@
       "title": "Rate Limit Exceeded",
       "targets": [
         {
-          "expr": "sum(rate(authtranslator_rate_limit_exceeded_total[5m])) by (integration)",
+          "expr": "sum(rate(authtranslator_rate_limit_events_total[5m])) by (integration)",
           "legendFormat": "{{integration}}"
         }
       ]


### PR DESCRIPTION
## Summary
- fix reference to `authtranslator_rate_limit_events_total`

## Testing
- `make precommit` *(fails: can't load config)*
- `make test`