### PR TITLE
Increase config_validate test coverage

### DIFF
--- a/app/config_validate_test.go
+++ b/app/config_validate_test.go
@@ -68,6 +68,13 @@ func TestValidateConfigBadIdleConns(t *testing.T) {
 	}
 }
 
+func TestValidateConfigMissingDestination(t *testing.T) {
+	c := Config{Integrations: []Integration{{Name: "a"}}}
+	if err := validateConfig(&c); err == nil {
+		t.Fatalf("expected error for missing destination")
+	}
+}
+
 func TestValidateConfigBadRateLimitWindow(t *testing.T) {
 	c := Config{Integrations: []Integration{{Name: "a", Destination: "http://ex", RateLimitWindow: "bad"}}}
 	if err := validateConfig(&c); err == nil {


### PR DESCRIPTION
## Summary
- test missing destination in config validation

## Testing
- `go test ./...`
- `go test ./app -coverprofile=coverage.txt ./app`
