### PR TITLE
Improve secret registry test coverage

### DIFF
--- a/app/secrets/secret_test.go
+++ b/app/secrets/secret_test.go
@@ -153,3 +153,15 @@ func TestLoadSecretFileMissing(t *testing.T) {
 		t.Fatal("expected error for missing file")
 	}
 }
+
+func TestLoadSecretInvalidReference(t *testing.T) {
+	if _, err := secrets.LoadSecret(context.Background(), "missingcolon"); err == nil {
+		t.Fatal("expected error for invalid reference")
+	}
+}
+
+func TestLoadRandomSecretEmpty(t *testing.T) {
+	if _, err := secrets.LoadRandomSecret(context.Background(), nil); err == nil {
+		t.Fatal("expected error for empty secret list")
+	}
+}


### PR DESCRIPTION
## Summary
- extend secret registry tests to cover invalid secret references
- cover error case for LoadRandomSecret when no secrets provided

## Testing
- `go test ./...`
- `go test ./... -coverprofile=coverage.out`