### PR TITLE
Add capability plugin location info

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -43,6 +43,7 @@ Capabilities serve two goals:
 2. **Auditability** – security reviewers can grep for the label instead of combing through lengthy rule lists. If a suitable capability exists, **prefer it over hand‑rolled granular rules**.
 
 Capabilities are defined **next to each integration plugin**. They expand into one or more granular rules that match that integration’s API surface.
+Look for a `capabilities.go` file under `app/integrations/plugins/<integration>/` to see the code powering each capability.
 
 ```yaml
 - integration: slack


### PR DESCRIPTION
## Summary
- document that capability plugin code lives in `app/integrations/plugins/<integration>/capabilities.go`

## Testing
- `make precommit` *(fails: can't load config: unsupported version of the configuration: "1")*
- `make test`