### PR TITLE
Enable golangci staticcheck and errcheck

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,8 @@ jobs:
         run: go mod download
       - name: Vet code
         run: go vet ./...
-      - name: Lint (optional)
-        run: |
-          if command -v golangci-lint >/dev/null 2>&1; then
-            golangci-lint run
-          else
-            echo "golangci-lint not installed, skipping"
-          fi
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v8
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - name: Run tests with coverage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,11 @@
-version: 1
+version: 2
 run:
   timeout: 5m
-
+  new-from-rev: HEAD~1
+  issues-exit-code: 0
 linters:
   disable-all: true
   enable:
     - govet
+    - staticcheck
+    - errcheck


### PR DESCRIPTION
## Summary
- enable extra linters in golangci configuration
- run golangci-lint in CI using the official action
- update workflow to use golangci/golangci-lint-action@v8

## Testing
- `make precommit`
- `go test ./...`
