### PR TITLE
Make quickstart image configurable

### DIFF
--- a/terraform/quickstart/README.md
+++ b/terraform/quickstart/README.md
@@ -3,7 +3,7 @@ machine. Ensure Docker is installed then run:
 
 ```bash
 terraform init
-terraform apply
+terraform apply -var container_image=ghcr.io/winhowes/authtranslator:latest
 ```
 
 The container will listen on port 8080.

--- a/terraform/quickstart/main.tf
+++ b/terraform/quickstart/main.tf
@@ -12,8 +12,14 @@ terraform {
 
 provider "docker" {}
 
+variable "container_image" {
+  type        = string
+  description = "Container image to run"
+  default     = "ghcr.io/winhowes/authtranslator:latest"
+}
+
 resource "docker_image" "authtranslator" {
-  name         = "ghcr.io/winhowes/authtranslator:latest"
+  name = var.container_image
 }
 
 resource "docker_container" "authtranslator" {


### PR DESCRIPTION
## Summary
- make the quickstart docker image configurable via `container_image` variable
- document using `-var container_image=...` for terraform apply

## Testing
- `go test ./...`