### PR TITLE
Add health probes and resource options to helm chart

### DIFF
--- a/charts/authtranslator/README.md
+++ b/charts/authtranslator/README.md
@@ -11,6 +11,9 @@ This chart deploys [AuthTranslator](https://github.com/winhowes/AuthTranslator) 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `redisAddress` | Address passed to `-redis-addr` – either `host:port` or a `redis://`/`rediss://` URL | `""` |
 | `redisCA` | CA file for verifying Redis TLS passed to `-redis-ca` | `""` |
+| `resources` | Pod resource requests/limits | see `values.yaml` |
+| `imagePullSecrets` | List of image pull secrets | `[]` |
+| `serviceAccountName` | Pod service account | `""` |
 | `config` | Contents of `config.yaml` stored in a ConfigMap | sample configuration |
 | `allowlist` | Contents of `allowlist.yaml` stored in a ConfigMap | sample allowlist |
 

--- a/charts/authtranslator/templates/deployment.yaml
+++ b/charts/authtranslator/templates/deployment.yaml
@@ -15,6 +15,15 @@ spec:
       labels:
         {{- include "authtranslator.labels" . | nindent 8 }}
     spec:
+      {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
       containers:
         - name: authtranslator
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -39,6 +48,16 @@ spec:
           ports:
             - containerPort: 8080
               name: http
+          livenessProbe:
+            httpGet:
+              path: /_at_internal/healthz
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /_at_internal/healthz
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
       volumes:
         - name: config
           configMap:

--- a/charts/authtranslator/values.yaml
+++ b/charts/authtranslator/values.yaml
@@ -6,6 +6,17 @@ image:
 redisAddress: ""
 redisCA: ""
 
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 64Mi
+
+imagePullSecrets: []
+serviceAccountName: ""
+
 config: |
   integrations:
     - name: example

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -33,6 +33,9 @@ This:
 | `image.pullPolicy` | `IfNotPresent`                    | Image pull policy.                                                 |
 | `redisAddress`     | `""`                              | Address passed to `-redis-addr` – either `host:port` or a `redis://`/`rediss://` URL. |
 | `redisCA`          | `""`                              | CA file verifying Redis TLS passed to `-redis-ca`. |
+| `resources`        | *(object)*                        | Pod resource requests/limits. |
+| `imagePullSecrets` | `[]`                              | Names of image pull secrets. |
+| `serviceAccountName` | `""`                            | Pod service account name. |
 | `config`           | *(string)*                        | Raw YAML for `config.yaml`.                                        |
 | `allowlist`        | *(string)*                        | Raw YAML for `allowlist.yaml`.                                     |
 


### PR DESCRIPTION
## Summary
- add service account and image pull secrets support to Deployment template
- include readiness/liveness probes and resources block in container spec
- expose new `resources`, `imagePullSecrets`, and `serviceAccountName` values
- document new helm values in README and docs/helm.md

## Testing
- `make test`