### PR TITLE
Add Docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ COPY app/config.yaml ./config.yaml
 RUN chown -R app:app /app
 USER app
 EXPOSE 8080
+HEALTHCHECK CMD wget -qO- http://localhost:8080/_at_internal/healthz || exit 1
 CMD ["./authtranslator"]

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Also see [`cmd/allowlist`](cmd/allowlist) for CRUD operations on the allow‑lis
 | `/_at_internal/metrics` | Prometheus metrics (Go runtime + per‑integration rate‑limit counters). |
 | Structured logs         | Text by default; pass `-log-format json` for JSON via `slog`. Includes method, integration, path, status; adds `caller_id` when known. |
 
+Official container images include a Docker HEALTHCHECK that polls the health endpoint; the container reports **healthy** once it returns 200.
 ---
 
 ## 📚 Documentation map

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -74,6 +74,8 @@ Navigate to:
 * Health: [http://localhost:8080/\_at\_internal/healthz](http://localhost:8080/_at_internal/healthz)
 * Metrics: [http://localhost:8080/\_at\_internal/metrics](http://localhost:8080/_at_internal/metrics)
 
+Docker will keep hitting the health URL above using the image's `HEALTHCHECK`. The `authtranslator` service shows as `healthy` once the endpoint responds with `200 OK`.
+
 ---
 
 ## 3  Customising


### PR DESCRIPTION
## Summary
- add a `HEALTHCHECK` directive in Dockerfile to poll `/​_at_internal/healthz`
- document container health check in Compose guide
- document the same health check behaviour in the README

## Testing
- `make test`
- `make precommit` *(fails: can't load config for golangci-lint)*