### PR TITLE
Add config and allowlist variables for Terraform modules

### DIFF
--- a/terraform/aws/README.md
+++ b/terraform/aws/README.md
@@ -16,6 +16,8 @@ Optional:
 
 - `redis_address` – address for distributed rate limiting
 - `redis_ca` – CA file for verifying Redis TLS
+- `config_path` – path to the configuration file inside the container
+- `allowlist_path` – path to the allowlist file inside the container
 
 ## Example
 

--- a/terraform/aws/main.tf
+++ b/terraform/aws/main.tf
@@ -36,8 +36,11 @@ resource "aws_ecs_task_definition" "this" {
         protocol      = "tcp"
       }]
       command = concat([
-        "./authtranslator"
-        ], var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
+        "./authtranslator",
+        "-config", var.config_path,
+        "-allowlist", var.allowlist_path
+        ],
+        var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
         var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : [])
     }
   ])

--- a/terraform/aws/variables.tf
+++ b/terraform/aws/variables.tf
@@ -35,3 +35,15 @@ variable "redis_ca" {
   default     = ""
 }
 
+variable "config_path" {
+  description = "Path to the configuration file inside the container"
+  type        = string
+  default     = "config.yaml"
+}
+
+variable "allowlist_path" {
+  description = "Path to the allowlist file inside the container"
+  type        = string
+  default     = "allowlist.yaml"
+}
+

--- a/terraform/azure/README.md
+++ b/terraform/azure/README.md
@@ -16,6 +16,8 @@ Optional:
 
 - `redis_address` – address for distributed rate limiting
 - `redis_ca` – CA file for verifying Redis TLS
+- `config_path` – path to the configuration file inside the container
+- `allowlist_path` – path to the allowlist file inside the container
 
 ## Example
 

--- a/terraform/azure/main.tf
+++ b/terraform/azure/main.tf
@@ -31,8 +31,11 @@ resource "azurerm_container_group" "this" {
     memory = "1.0"
 
     command = concat([
-      "./authtranslator"
-      ], var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
+      "./authtranslator",
+      "-config", var.config_path,
+      "-allowlist", var.allowlist_path
+      ],
+      var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
       var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : [])
 
     ports {

--- a/terraform/azure/variables.tf
+++ b/terraform/azure/variables.tf
@@ -35,3 +35,15 @@ variable "redis_ca" {
   default     = ""
 }
 
+variable "config_path" {
+  description = "Path to the configuration file inside the container"
+  type        = string
+  default     = "config.yaml"
+}
+
+variable "allowlist_path" {
+  description = "Path to the allowlist file inside the container"
+  type        = string
+  default     = "allowlist.yaml"
+}
+

--- a/terraform/gcp/README.md
+++ b/terraform/gcp/README.md
@@ -14,6 +14,8 @@ Optional:
 
 - `redis_address` – address for distributed rate limiting
 - `redis_ca` – CA file for verifying Redis TLS
+- `config_path` – path to the configuration file inside the container
+- `allowlist_path` – path to the allowlist file inside the container
 
 ## Example
 

--- a/terraform/gcp/main.tf
+++ b/terraform/gcp/main.tf
@@ -27,6 +27,7 @@ resource "google_cloud_run_service" "this" {
             container_port = 8080
           }]
           args = concat(
+            ["-config", var.config_path, "-allowlist", var.allowlist_path],
             var.redis_address != "" ? ["-redis-addr", var.redis_address] : [],
             var.redis_ca != "" ? ["-redis-ca", var.redis_ca] : []
           )

--- a/terraform/gcp/variables.tf
+++ b/terraform/gcp/variables.tf
@@ -25,3 +25,15 @@ variable "redis_ca" {
   default     = ""
 }
 
+variable "config_path" {
+  description = "Path to the configuration file inside the container"
+  type        = string
+  default     = "config.yaml"
+}
+
+variable "allowlist_path" {
+  description = "Path to the allowlist file inside the container"
+  type        = string
+  default     = "allowlist.yaml"
+}
+


### PR DESCRIPTION
## Summary
- support specifying config and allowlist paths for each Terraform module
- pass the new variables as CLI flags
- document the new optional variables

## Testing
- `make precommit` *(fails: can't load golangci-lint config)*