### PR TITLE
Improve coverage for capabilities and integration listing

### DIFF
--- a/app/integrations/registry_test.go
+++ b/app/integrations/registry_test.go
@@ -1,6 +1,9 @@
 package integrationplugins
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestExpandCapabilities(t *testing.T) {
 	// Save current registry state and restore after test
@@ -38,5 +41,36 @@ func TestExpandCapabilities(t *testing.T) {
 	}
 	if len(got.Capabilities) != 0 {
 		t.Errorf("expected capabilities to be cleared")
+	}
+}
+
+func TestExpandCapabilitiesUnknown(t *testing.T) {
+	orig := capabilityRegistry
+	t.Cleanup(func() { capabilityRegistry = orig })
+
+	callers := []CallerConfig{{ID: "c", Capabilities: []CapabilityConfig{{Name: "unknown"}}}}
+	res := ExpandCapabilities("test", callers)
+	if len(res) != 1 || len(res[0].Rules) != 0 {
+		t.Fatalf("unexpected result: %+v", res)
+	}
+	if len(res[0].Capabilities) != 0 {
+		t.Fatalf("capabilities not cleared")
+	}
+}
+
+func TestExpandCapabilitiesGenerateError(t *testing.T) {
+	orig := capabilityRegistry
+	capabilityRegistry = map[string]map[string]CapabilitySpec{}
+	t.Cleanup(func() { capabilityRegistry = orig })
+	RegisterCapability("e", "cap", CapabilitySpec{
+		Generate: func(map[string]interface{}) ([]CallRule, error) { return nil, errors.New("boom") },
+	})
+	callers := []CallerConfig{{ID: "c", Capabilities: []CapabilityConfig{{Name: "cap"}}}}
+	res := ExpandCapabilities("e", callers)
+	if len(res) != 1 || len(res[0].Rules) != 0 {
+		t.Fatalf("expected no rules on error")
+	}
+	if len(res[0].Capabilities) != 0 {
+		t.Fatalf("capabilities not cleared")
 	}
 }

--- a/cmd/integrations/main_test.go
+++ b/cmd/integrations/main_test.go
@@ -445,3 +445,29 @@ func TestMainAddBuilderError(t *testing.T) {
 		t.Fatalf("unexpected output: %s", out)
 	}
 }
+
+func TestListIntegrationHelper(t *testing.T) {
+	if os.Getenv("GO_WANT_LIST_HELPER") != "1" {
+		return
+	}
+	cfg := os.Getenv("CFG")
+	flag.CommandLine = flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+	file = flag.CommandLine.String("file", cfg, "config file")
+	listIntegrations()
+	os.Exit(0)
+}
+
+func TestListIntegrationsError(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "cfg.yaml")
+	os.Mkdir(cfg, 0755)
+	cmd := exec.Command(os.Args[0], "-test.run=TestListIntegrationHelper", "--")
+	cmd.Env = append(os.Environ(), "GO_WANT_LIST_HELPER=1", "CFG="+cfg)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if len(out) == 0 {
+		t.Fatalf("expected error output")
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for unknown and erroring capabilities
- add test for list command error path
- move capability tests into existing file

## Testing
- `go test ./... -coverprofile=coverage.out`