### PR TITLE
Add gRPC and WebSocket support

### DIFF
--- a/app/grpc_test.go
+++ b/app/grpc_test.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestProxyHandlerGRPC(t *testing.T) {
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.ProtoMajor != 2 {
+			t.Fatalf("expected HTTP/2, got %s", r.Proto)
+		}
+		w.Header().Set("Content-Type", "application/grpc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	defer upstream.Close()
+
+	integ := Integration{Name: "grpcint", Destination: upstream.URL, InRateLimit: 1, OutRateLimit: 1, TLSInsecureSkipVerify: true}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("add integration: %v", err)
+	}
+	t.Cleanup(func() { integ.inLimiter.Stop(); integ.outLimiter.Stop() })
+
+	proxy := httptest.NewUnstartedServer(http.HandlerFunc(proxyHandler))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	defer proxy.Close()
+
+	client := proxy.Client()
+	client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = "grpcint"
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("TE", "trailers")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if resp.ProtoMajor != 2 {
+		t.Fatalf("expected HTTP/2 response, got %s", resp.Proto)
+	}
+}

--- a/app/proxy_ws_test.go
+++ b/app/proxy_ws_test.go
@@ -1,0 +1,75 @@
+package main
+
+import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func wsAccept(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key))
+	h.Write([]byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11"))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func TestProxyHandlerWebSocket(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			t.Fatalf("expected websocket upgrade, got %q", r.Header.Get("Upgrade"))
+		}
+		hij, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("hijacking not supported")
+		}
+		conn, buf, err := hij.Hijack()
+		if err != nil {
+			t.Fatalf("hijack failed: %v", err)
+		}
+		defer conn.Close()
+		accept := wsAccept(r.Header.Get("Sec-WebSocket-Key"))
+		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\n")
+		fmt.Fprintf(buf, "Upgrade: websocket\r\n")
+		fmt.Fprintf(buf, "Connection: Upgrade\r\n")
+		fmt.Fprintf(buf, "Sec-WebSocket-Accept: %s\r\n\r\n", accept)
+		buf.Flush()
+	}))
+	defer upstream.Close()
+
+	integ := Integration{Name: "wsint", Destination: upstream.URL, InRateLimit: 1, OutRateLimit: 1}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("add integration: %v", err)
+	}
+	t.Cleanup(func() { integ.inLimiter.Stop(); integ.outLimiter.Stop() })
+
+	proxy := httptest.NewServer(http.HandlerFunc(proxyHandler))
+	defer proxy.Close()
+
+	conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "GET / HTTP/1.1\r\n")
+	fmt.Fprintf(conn, "Host: wsint\r\n")
+	fmt.Fprintf(conn, "Upgrade: websocket\r\n")
+	fmt.Fprintf(conn, "Connection: Upgrade\r\n")
+	fmt.Fprintf(conn, "Sec-WebSocket-Key: testkey==\r\n")
+	fmt.Fprintf(conn, "Sec-WebSocket-Version: 13\r\n\r\n")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+}

--- a/app/statusrecorder.go
+++ b/app/statusrecorder.go
@@ -1,11 +1,30 @@
 package main
 
-import "net/http"
+import (
+	"bufio"
+	"fmt"
+	"net"
+	"net/http"
+)
 
 // statusRecorder captures the HTTP status code written by a handler.
 type statusRecorder struct {
 	http.ResponseWriter
 	status int
+}
+
+// ensure interfaces are forwarded when supported by the underlying writer
+func (r *statusRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	if h, ok := r.ResponseWriter.(http.Hijacker); ok {
+		return h.Hijack()
+	}
+	return nil, nil, fmt.Errorf("hijacker not supported")
+}
+
+func (r *statusRecorder) Flush() {
+	if f, ok := r.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }
 
 func (r *statusRecorder) WriteHeader(code int) {

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -71,9 +71,9 @@ Update the value in your vault/provider **and** trigger a hot reload (SIGHUP or 
 
 ---
 
-### 10 Does AuthTranslator support gRPC or WebSockets?
+### 10 Does AuthTranslator support gRPC or WebSockets?
 
-Not today. It operates on plain HTTP(S) requests; gRPC/WebSocket upgrades are currently rejected with **426 Upgrade Required**.
+Yes. Both protocols are proxied transparently so long as the upstream service speaks the same protocol. WebSocket upgrades and HTTP/2 gRPC calls work without extra configuration.
 
 ---
 


### PR DESCRIPTION
## Summary
- implement Hijacker/Flusher passthrough in `statusrecorder`
- add regression tests for gRPC and WebSocket proxying
- update FAQ to document support

## Testing
- `go test ./...`