### PR TITLE
Add Kubernetes secret backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Secrets can be pulled from several providers:
 
 * **env:** `SLACK_TOKEN=…`
 * **file:** path to an on‑disk file
+* **k8s:** Kubernetes secrets
 * **gcp:** Google Cloud KMS
 * **aws:** AWS Secrets Manager
 * **azure:** Azure Key Vault

--- a/app/secrets/plugins/k8s/plugin.go
+++ b/app/secrets/plugins/k8s/plugin.go
@@ -1,0 +1,105 @@
+package plugins
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/winhowes/AuthTranslator/app/secrets"
+)
+
+// k8sPlugin retrieves secrets from the Kubernetes API using the
+// service account credentials available when running inside a
+// cluster. The identifier has the form "<namespace>/<name>#<key>".
+// The secret data is assumed to be base64 encoded as returned by the
+// Kubernetes API.
+type k8sPlugin struct{}
+
+var (
+	httpClient = &http.Client{Timeout: 5 * time.Second}
+	tokenPath  = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	caPath     = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+
+	readFile   = os.ReadFile
+	newRequest = http.NewRequestWithContext
+)
+
+func (k8sPlugin) Prefix() string { return "k8s" }
+
+func (k8sPlugin) Load(ctx context.Context, id string) (string, error) {
+	parts := strings.SplitN(id, "#", 2)
+	if len(parts) != 2 {
+		return "", fmt.Errorf("invalid k8s id: %s", id)
+	}
+	secretRef, key := parts[0], parts[1]
+	nsName := strings.SplitN(secretRef, "/", 2)
+	if len(nsName) != 2 || nsName[0] == "" || nsName[1] == "" || key == "" {
+		return "", fmt.Errorf("invalid k8s id: %s", id)
+	}
+	namespace, name := nsName[0], nsName[1]
+
+	host := os.Getenv("KUBERNETES_SERVICE_HOST")
+	port := os.Getenv("KUBERNETES_SERVICE_PORT")
+	if host == "" || port == "" {
+		return "", fmt.Errorf("not running in a cluster")
+	}
+
+	token, err := readFile(tokenPath)
+	if err != nil {
+		return "", err
+	}
+	caData, err := readFile(caPath)
+	if err != nil {
+		return "", err
+	}
+
+	pool := x509.NewCertPool()
+	pool.AppendCertsFromPEM(caData)
+
+	client := httpClient
+	if client.Transport == nil {
+		client = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}, Timeout: client.Timeout}
+	}
+
+	url := fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/secrets/%s", host, port, namespace, name)
+	req, err := newRequest(ctx, "GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+strings.TrimSpace(string(token)))
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("k8s request failed: %s: %s", resp.Status, body)
+	}
+	var out struct {
+		Data map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", err
+	}
+	valB64, ok := out.Data[key]
+	if !ok {
+		return "", fmt.Errorf("key %s not found in secret %s/%s", key, namespace, name)
+	}
+	val, err := base64.StdEncoding.DecodeString(valB64)
+	if err != nil {
+		return "", err
+	}
+	return string(val), nil
+}
+
+func init() { secrets.Register(k8sPlugin{}) }

--- a/app/secrets/plugins/k8s/plugin_test.go
+++ b/app/secrets/plugins/k8s/plugin_test.go
@@ -1,0 +1,122 @@
+package plugins
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+type rewriteTransport struct {
+	rt     http.RoundTripper
+	scheme string
+	host   string
+}
+
+func (t *rewriteTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL.Scheme = t.scheme
+	r.URL.Host = t.host
+	return t.rt.RoundTrip(r)
+}
+
+func setTestClient(ts *httptest.Server) func() {
+	oldClient := httpClient
+	u, _ := url.Parse(ts.URL)
+	httpClient = &http.Client{Transport: &rewriteTransport{rt: ts.Client().Transport, scheme: u.Scheme, host: u.Host}}
+	return func() { httpClient = oldClient }
+}
+
+func writeFiles(t *testing.T, token, ca string) func() {
+	t.Helper()
+	oldTok := tokenPath
+	oldCA := caPath
+	tokFile := t.TempDir() + "/token"
+	caFile := t.TempDir() + "/ca.crt"
+	if err := os.WriteFile(tokFile, []byte(token), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(caFile, []byte(ca), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	tokenPath = tokFile
+	caPath = caFile
+	return func() {
+		tokenPath = oldTok
+		caPath = oldCA
+	}
+}
+
+func TestK8sLoad(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer tok" {
+			t.Errorf("missing auth header")
+		}
+		if r.URL.Path != "/api/v1/namespaces/ns/secrets/sec" {
+			t.Errorf("bad path: %s", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]map[string]string{"data": {"foo": "YmFy"}})
+	}))
+	defer ts.Close()
+	restoreClient := setTestClient(ts)
+	defer restoreClient()
+	restoreFiles := writeFiles(t, "tok", "")
+	defer restoreFiles()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "k8s")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	p := k8sPlugin{}
+	got, err := p.Load(context.Background(), "ns/sec#foo")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "bar" {
+		t.Fatalf("expected bar, got %s", got)
+	}
+}
+
+func TestK8sLoadMissingKey(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]map[string]string{"data": {"foo": "YmFy"}})
+	}))
+	defer ts.Close()
+	restoreClient := setTestClient(ts)
+	defer restoreClient()
+	restoreFiles := writeFiles(t, "tok", "")
+	defer restoreFiles()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "k8s")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	p := k8sPlugin{}
+	if _, err := p.Load(context.Background(), "ns/sec#missing"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestK8sLoadBadID(t *testing.T) {
+	p := k8sPlugin{}
+	if _, err := p.Load(context.Background(), "badid"); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestK8sRequestError(t *testing.T) {
+	oldReq := newRequest
+	newRequest = func(context.Context, string, string, io.Reader) (*http.Request, error) {
+		return nil, fmt.Errorf("req")
+	}
+	defer func() { newRequest = oldReq }()
+	restoreFiles := writeFiles(t, "tok", "")
+	defer restoreFiles()
+	t.Setenv("KUBERNETES_SERVICE_HOST", "k8s")
+	t.Setenv("KUBERNETES_SERVICE_PORT", "443")
+
+	p := k8sPlugin{}
+	if _, err := p.Load(context.Background(), "ns/sec#foo"); err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/app/secrets/plugins/plugins.go
+++ b/app/secrets/plugins/plugins.go
@@ -6,5 +6,6 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/env"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/file"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/gcp"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/k8s"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins/vault"
 )

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -20,6 +20,7 @@ outgoing_auth:
 | ---------------- | ------------------------------------------------------------------- | ------------------------------------------------------------- |
 | `env`            | `env:SLACK_TOKEN`                                                   | Local dev & CI – the token sits in an env var.                |
 | `file`           | `file:///etc/secrets/slack_token`                                   | Kubernetes **secret volume** or Docker bind‑mount.            |
+| `k8s`            | `k8s:default/mysecret#token`         | In‑cluster secret via the Kubernetes API.                     |
 | `gcp`            | `gcp:projects/acme/locations/global/keyRings/auth/cryptoKeys/token:ciphertext` | Running on GKE / Cloud Run; decrypt via **Cloud KMS**. |
 | `aws`            | `aws:Ci0KU29tZUNpcGhlcnRleHQ=` | AES‑GCM encrypted values decrypted using `AWS_KMS_KEY`. |
 | `azure`          | `azure:https://kv-name.vault.azure.net/secrets/secret-name`         | AKS or VM SS with **Managed Identity**.                       |
@@ -35,6 +36,7 @@ Some schemes rely on environment variables for authentication or decryption:
 | ------ | -------------------- | ----------- | ------- |
 | `env`  | Names referenced in the configuration (e.g. `env:IN_TOKEN`) | Secrets are read directly from those variables. | `env:IN_TOKEN` resolves to `$IN_TOKEN` |
 | `file` | _none_ | Reads file contents from disk for `file:` secrets. | `file:/etc/token` reads `/etc/token` |
+| `k8s` | `KUBERNETES_SERVICE_HOST`, `KUBERNETES_SERVICE_PORT` | Provided by Kubernetes; used with the in-cluster service account. | `k8s:default/mysecret#token` |
 | `aws` | `AWS_KMS_KEY` | Base64 encoded 32 byte key for decrypting `aws:` secrets. | `aws:Ci0KU29tZUNpcGhlcnRleHQ=` |
 | `azure` | `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` | Credentials for fetching `azure:` secrets from Key Vault. | `azure:https://kv-name.vault.azure.net/secrets/token` |
 | `gcp` | _none_ | Uses the GCP metadata service when resolving `gcp:` secrets. | `gcp:projects/p/locations/l/keyRings/r/cryptoKeys/k:cipher` |


### PR DESCRIPTION
## Summary
- add Kubernetes secret plugin
- register the plugin
- mock API in new k8s plugin tests
- document k8s scheme in secret back-end docs
- list k8s in README secret back-ends
- clarify which environment variables the k8s plugin uses

## Testing
- `go vet ./...`
- `go test ./...`
