### PR TITLE
Implement secret refresh interval

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -75,6 +75,7 @@ var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (ho
 var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout for redis")
 var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS; disables InsecureSkipVerify")
 var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies (0 to disable)")
+var secretRefresh = flag.Duration("secret-refresh", 0, "refresh interval for cached secrets (0 disables)")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
 var metricsUser = flag.String("metrics-user", "", "username for metrics endpoint")
@@ -672,6 +673,7 @@ func main() {
 	}
 
 	authplugins.MaxBodySize = *maxBodySizeFlag
+	secrets.CacheTTL = *secretRefresh
 
 	if *showVersion {
 		fmt.Println(version)

--- a/app/secrets/registry_cache_test.go
+++ b/app/secrets/registry_cache_test.go
@@ -3,6 +3,7 @@ package secrets_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/winhowes/AuthTranslator/app/secrets"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
@@ -34,5 +35,41 @@ func TestClearCache(t *testing.T) {
 	}
 	if val != "second" {
 		t.Fatalf("expected 'second' after clear, got %s", val)
+	}
+}
+
+func TestCacheTTL(t *testing.T) {
+	defer secrets.ClearCache()
+	old := secrets.CacheTTL
+	secrets.CacheTTL = 50 * time.Millisecond
+	defer func() { secrets.CacheTTL = old }()
+
+	ctx := context.Background()
+	t.Setenv("TTL_SECRET", "first")
+
+	val, err := secrets.LoadSecret(ctx, "env:TTL_SECRET")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if val != "first" {
+		t.Fatalf("expected 'first', got %s", val)
+	}
+
+	// Change underlying secret; cached value should persist until expiry.
+	t.Setenv("TTL_SECRET", "second")
+	if val, err := secrets.LoadSecret(ctx, "env:TTL_SECRET"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	} else if val != "first" {
+		t.Fatalf("expected cached 'first', got %s", val)
+	}
+
+	time.Sleep(60 * time.Millisecond)
+
+	val, err = secrets.LoadSecret(ctx, "env:TTL_SECRET")
+	if err != nil {
+		t.Fatalf("unexpected error after ttl: %v", err)
+	}
+	if val != "second" {
+		t.Fatalf("expected 'second' after ttl, got %s", val)
 	}
 }

--- a/charts/authtranslator/README.md
+++ b/charts/authtranslator/README.md
@@ -11,6 +11,7 @@ This chart deploys [AuthTranslator](https://github.com/winhowes/AuthTranslator) 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `redisAddress` | Address passed to `-redis-addr` – either `host:port` or a `redis://`/`rediss://` URL | `""` |
 | `redisCA` | CA file for verifying Redis TLS passed to `-redis-ca` | `""` |
+| `secretRefresh` | Value passed to `-secret-refresh` | `""` |
 | `resources` | Pod resource requests/limits | see `values.yaml` |
 | `imagePullSecrets` | List of image pull secrets | `[]` |
 | `serviceAccountName` | Pod service account | `""` |

--- a/charts/authtranslator/templates/deployment.yaml
+++ b/charts/authtranslator/templates/deployment.yaml
@@ -38,6 +38,10 @@ spec:
             - "-redis-ca"
             - {{ .Values.redisCA | quote }}
             {{- end }}
+            {{- if .Values.secretRefresh }}
+            - "-secret-refresh"
+            - {{ .Values.secretRefresh | quote }}
+            {{- end }}
           volumeMounts:
             - name: config
               mountPath: /app/config.yaml

--- a/charts/authtranslator/values.yaml
+++ b/charts/authtranslator/values.yaml
@@ -5,6 +5,7 @@ image:
 
 redisAddress: ""
 redisCA: ""
+secretRefresh: ""
 
 resources:
   limits:

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -40,6 +40,7 @@ AuthTranslator exposes several command‑line options:
 | `-redis-ca` | CA certificate for verifying Redis TLS |
 | `-redis-timeout` | timeout for dialing Redis (default `5s`) |
 | `-max_body_size` | maximum bytes buffered from request bodies; use `0` to disable |
+| `-secret-refresh` | refresh interval for cached secrets; `0` disables expiry |
 | `-log-level` | log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 | `-log-format` | log output format (`text` or `json`) |
 | `-version` | print the build version and exit |

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -76,7 +76,7 @@ The proxy treats the entire value as opaque until the chosen back‑end returns 
 | On startup | All secret URIs are resolved **once**. Failure → fatal log + exit.                     |
 | Hot reload | On `SIGHUP` / `-watch`, new or changed URIs are fetched; unchanged values are re‑used. |
 | In‑request | Plugins never re‑fetch — avoids per‑call latency and rate limits.                      |
-| TTL        | Currently fixed; future work may add periodic refresh for rotated keys.                |
+| TTL        | Controlled by the `-secret-refresh` flag; `0` disables expiry. |
 
 ---
 


### PR DESCRIPTION
## Summary
- add `-secret-refresh` CLI flag
- support per-secret cache TTL via `secrets.CacheTTL`
- document new option and chart values
- update Helm deployment
- test secret cache expiry

## Testing
- `make test`
- `make precommit` *(fails: unsupported version of golangci-lint)*