### PR TITLE
Add metrics plugin hooks

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/winhowes/AuthTranslator/app/auth"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins"
+	"github.com/winhowes/AuthTranslator/app/metrics"
 	"github.com/winhowes/AuthTranslator/app/secrets"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
@@ -638,6 +639,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	metrics.OnRequest(integ.Name, r)
 	rec := &statusRecorder{ResponseWriter: w}
 	integ.proxy.ServeHTTP(rec, r)
 	if rec.status == 0 {

--- a/app/metrics/registry.go
+++ b/app/metrics/registry.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"net/http"
+	"sync"
+)
+
+// Plugin can record custom metrics for each request and response.
+type Plugin interface {
+	OnRequest(integration string, r *http.Request)
+	OnResponse(integration string, r *http.Request, resp *http.Response)
+}
+
+var (
+	mu      sync.RWMutex
+	plugins []Plugin
+)
+
+// Reset removes all registered plugins. Primarily used in tests.
+func Reset() {
+	mu.Lock()
+	plugins = nil
+	mu.Unlock()
+}
+
+// Register adds a metrics plugin.
+func Register(p Plugin) {
+	mu.Lock()
+	plugins = append(plugins, p)
+	mu.Unlock()
+}
+
+// OnRequest triggers all registered plugins for a new request.
+func OnRequest(integration string, r *http.Request) {
+	mu.RLock()
+	ps := append([]Plugin(nil), plugins...)
+	mu.RUnlock()
+	for _, p := range ps {
+		p.OnRequest(integration, r)
+	}
+}
+
+// OnResponse triggers all registered plugins for a completed response.
+func OnResponse(integration string, r *http.Request, resp *http.Response) {
+	mu.RLock()
+	ps := append([]Plugin(nil), plugins...)
+	mu.RUnlock()
+	for _, p := range ps {
+		p.OnResponse(integration, r, resp)
+	}
+}

--- a/app/metrics/registry_test.go
+++ b/app/metrics/registry_test.go
@@ -1,0 +1,47 @@
+package metrics
+
+import (
+	"net/http"
+	"testing"
+)
+
+// simple plugin that counts calls
+type testPlugin struct {
+	reqs  int
+	resps int
+}
+
+func (p *testPlugin) OnRequest(integration string, r *http.Request) {
+	p.reqs++
+}
+
+func (p *testPlugin) OnResponse(integration string, r *http.Request, resp *http.Response) {
+	p.resps++
+}
+
+func TestRegistry(t *testing.T) {
+	// save original state
+	mu.Lock()
+	saved := plugins
+	mu.Unlock()
+	Reset()
+	t.Cleanup(func() {
+		mu.Lock()
+		plugins = saved
+		mu.Unlock()
+	})
+
+	tp := &testPlugin{}
+	Register(tp)
+
+	req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
+	OnRequest("foo", req)
+	OnResponse("foo", req, &http.Response{})
+
+	if tp.reqs != 1 {
+		t.Fatalf("expected 1 request call, got %d", tp.reqs)
+	}
+	if tp.resps != 1 {
+		t.Fatalf("expected 1 response call, got %d", tp.resps)
+	}
+}

--- a/app/metrics_hook_test.go
+++ b/app/metrics_hook_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type hookPlugin struct {
+	req  int
+	resp int
+}
+
+func (h *hookPlugin) OnRequest(integ string, r *http.Request) {
+	h.req++
+}
+
+func (h *hookPlugin) OnResponse(integ string, r *http.Request, resp *http.Response) {
+	h.resp++
+}
+
+func TestMetricsHooks(t *testing.T) {
+	metrics.Reset()
+
+	hp := &hookPlugin{}
+	metrics.Register(hp)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTeapot)
+	}))
+	defer srv.Close()
+
+	integ := Integration{Name: "metric", Destination: srv.URL, InRateLimit: 1, OutRateLimit: 1}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("add integration: %v", err)
+	}
+	t.Cleanup(func() {
+		integ.inLimiter.Stop()
+		integ.outLimiter.Stop()
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "http://metric/foo", nil)
+	req.Host = "metric"
+	rr := httptest.NewRecorder()
+	proxyHandler(rr, req)
+
+	if hp.req != 1 {
+		t.Fatalf("expected request hook 1, got %d", hp.req)
+	}
+	if hp.resp != 1 {
+		t.Fatalf("expected response hook 1, got %d", hp.resp)
+	}
+}

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -22,15 +22,15 @@ exposed by default but can be disabled with `-enable-metrics=false`. Provide
 
 > The exact metric list is taken from code; field names below match what ships today.
 
-| Metric                                     | Type      | Labels                     | Description                                                          |
-| ------------------------------------------ | --------- | -------------------------- | -------------------------------------------------------------------- |
-| `authtranslator_requests_total`            | counter   | `integration`               | Total requests processed per integration. |
-| `authtranslator_upstream_responses_total`  | counter   | `integration`, `code`       | HTTP status codes returned by upstreams. |
-| `authtranslator_request_duration_seconds`  | histogram | `integration`               | Histogram of upstream request latency. |
-| `authtranslator_rate_limit_events_total`   | counter   | `integration`               | Incremented when a request is rejected with 429. |
-| `authtranslator_auth_failures_total`       | counter   | `integration`               | Authentication plugin failures. |
+| Metric                                    | Type      | Labels                | Description                                      |
+| ----------------------------------------- | --------- | --------------------- | ------------------------------------------------ |
+| `authtranslator_requests_total`           | counter   | `integration`         | Total requests processed per integration.        |
+| `authtranslator_upstream_responses_total` | counter   | `integration`, `code` | HTTP status codes returned by upstreams.         |
+| `authtranslator_request_duration_seconds` | histogram | `integration`         | Histogram of upstream request latency.           |
+| `authtranslator_rate_limit_events_total`  | counter   | `integration`         | Incremented when a request is rejected with 429. |
+| `authtranslator_auth_failures_total`      | counter   | `integration`         | Authentication plugin failures.                  |
 
-Missing a metric? Open an issue or PR—new counters are easy to wire in.
+Missing a metric? Write a small **metrics plugin** to hook into requests and responses or open a PR—new counters are easy to wire in.
 
 ---
 
@@ -38,10 +38,10 @@ Missing a metric? Open an issue or PR—new counters are easy to wire in.
 
 ```yaml
 targets:
-  - job_name: 'authtranslator'
-    metrics_path: '/_at_internal/metrics'
+  - job_name: "authtranslator"
+    metrics_path: "/_at_internal/metrics"
     static_configs:
-      - targets: ['authtranslator.default.svc.cluster.local:8080']
+      - targets: ["authtranslator.default.svc.cluster.local:8080"]
 ```
 
 When running multiple replicas behind a Service or Load Balancer, prefer the **Prometheus ServiceMonitor** CRD (Kube‑Prometheus stack) or scrape via the node exporter.
@@ -53,15 +53,15 @@ When running multiple replicas behind a Service or Load Balancer, prefer the **P
 The proxy logs in structured **text** by default. Pass
 `-log-format json` to emit **JSON** using Go’s `slog`. Fields:
 
-| Key           | Example                   | Meaning                                                     |
-| ------------- | ------------------------- | ----------------------------------------------------------- |
-| `level`       | `INFO` / `WARN` / `ERROR` | Log severity                                                |
-| `msg`         | `"incoming request"` / `"upstream response"` | Log message |
-| `integration` | `"slack"`                 | Integration block name |
-| `caller_id`   | `"user-123"`              | Identifier from incoming plugin |
-| `method`      | `"POST"`                  | HTTP method (request log) |
-| `path`        | `"/api/chat.postMessage"` | Request path (request log) |
-| `status`      | `200`                     | Upstream status code (response log) |
+| Key           | Example                                      | Meaning                             |
+| ------------- | -------------------------------------------- | ----------------------------------- |
+| `level`       | `INFO` / `WARN` / `ERROR`                    | Log severity                        |
+| `msg`         | `"incoming request"` / `"upstream response"` | Log message                         |
+| `integration` | `"slack"`                                    | Integration block name              |
+| `caller_id`   | `"user-123"`                                 | Identifier from incoming plugin     |
+| `method`      | `"POST"`                                     | HTTP method (request log)           |
+| `path`        | `"/api/chat.postMessage"`                    | Request path (request log)          |
+| `status`      | `200`                                        | Upstream status code (response log) |
 
 Sample line (wrapped for readability):
 
@@ -72,8 +72,8 @@ Sample line (wrapped for readability):
 
 ### Log level
 
-* Default: **INFO**
-* Override: run the proxy with `-log-level DEBUG` (adds request/response headers—secrets redacted)
+- Default: **INFO**
+- Override: run the proxy with `-log-level DEBUG` (adds request/response headers—secrets redacted)
 
 ---
 
@@ -82,7 +82,7 @@ Sample line (wrapped for readability):
 | Alert                     | Expression                                                        | Rationale                        |
 | ------------------------- | ----------------------------------------------------------------- | -------------------------------- |
 | High 5xx rate             | `sum(rate(authtranslator_requests_total{code=~"5.."}[5m])) > 0.1` | Upstream failures or mis‑config. |
-| Prolonged rate‑limit hits | `increase(authtranslator_rate_limit_events_total[5m]) > 100`    | Callers need higher quota.       |
+| Prolonged rate‑limit hits | `increase(authtranslator_rate_limit_events_total[5m]) > 100`      | Callers need higher quota.       |
 | Health endpoint down      | Blackbox probe against `/_at_internal/healthz` fails              | Pod crash or network break.      |
 
 Tune thresholds to your traffic patterns.


### PR DESCRIPTION
## Summary
- add metrics plugin registry and reset function
- fire metrics hooks in proxy
- test hooks and registry
- document metrics plugin support

## Testing
- `gofmt -w $(git ls-files "*.go")`
- `go vet ./...`
- `golangci-lint run` *(fails: unsupported config)*
- `go test ./...`