### PR TITLE
Update rate limit docs

### DIFF
--- a/app/config_validate.go
+++ b/app/config_validate.go
@@ -40,6 +40,13 @@ func validateConfig(c *Config) error {
 				return fmt.Errorf("integration %s has invalid rate_limit_window", i.Name)
 			}
 		}
+		if i.RateLimitStrategy != "" {
+			switch i.RateLimitStrategy {
+			case "fixed_window", "token_bucket":
+			default:
+				return fmt.Errorf("integration %s has invalid rate_limit_strategy", i.Name)
+			}
+		}
 		if i.IdleConnTimeout != "" {
 			d, err := time.ParseDuration(i.IdleConnTimeout)
 			if err != nil || d < 0 {

--- a/app/integration.go
+++ b/app/integration.go
@@ -127,13 +127,14 @@ type RequestConstraint = integrationplugins.RequestConstraint
 
 // Integration represents a configured proxy integration.
 type Integration struct {
-	Name            string             `json:"name"`
-	Destination     string             `json:"destination"`
-	InRateLimit     int                `json:"in_rate_limit"`
-	OutRateLimit    int                `json:"out_rate_limit"`
-	IncomingAuth    []AuthPluginConfig `json:"incoming_auth"`
-	OutgoingAuth    []AuthPluginConfig `json:"outgoing_auth"`
-	RateLimitWindow string             `json:"rate_limit_window"`
+	Name              string             `json:"name"`
+	Destination       string             `json:"destination"`
+	InRateLimit       int                `json:"in_rate_limit"`
+	OutRateLimit      int                `json:"out_rate_limit"`
+	IncomingAuth      []AuthPluginConfig `json:"incoming_auth"`
+	OutgoingAuth      []AuthPluginConfig `json:"outgoing_auth"`
+	RateLimitWindow   string             `json:"rate_limit_window"`
+	RateLimitStrategy string             `json:"rate_limit_strategy,omitempty"`
 
 	rateLimitDur time.Duration `json:"-"`
 
@@ -185,6 +186,15 @@ func prepareIntegration(i *Integration) error {
 		i.rateLimitDur = d
 	} else {
 		i.rateLimitDur = 0
+	}
+
+	if i.RateLimitStrategy == "" {
+		i.RateLimitStrategy = "fixed_window"
+	}
+	switch i.RateLimitStrategy {
+	case "fixed_window", "token_bucket":
+	default:
+		return fmt.Errorf("invalid rate_limit_strategy %s", i.RateLimitStrategy)
 	}
 
 	// ─── Validate incoming-auth configs ───────────────────────────────────────
@@ -297,8 +307,8 @@ func AddIntegration(i *Integration) error {
 		integrations.Unlock()
 		return fmt.Errorf("integration %s already exists", i.Name)
 	}
-	i.inLimiter = NewRateLimiter(i.InRateLimit, window)
-	i.outLimiter = NewRateLimiter(i.OutRateLimit, window)
+	i.inLimiter = NewRateLimiter(i.InRateLimit, window, i.RateLimitStrategy)
+	i.outLimiter = NewRateLimiter(i.OutRateLimit, window, i.RateLimitStrategy)
 	integrations.m[i.Name] = i
 	integrations.Unlock()
 
@@ -338,8 +348,8 @@ func UpdateIntegration(i *Integration) error {
 		old.inLimiter.Stop()
 		old.outLimiter.Stop()
 	}
-	i.inLimiter = NewRateLimiter(i.InRateLimit, window)
-	i.outLimiter = NewRateLimiter(i.OutRateLimit, window)
+	i.inLimiter = NewRateLimiter(i.InRateLimit, window, i.RateLimitStrategy)
+	i.outLimiter = NewRateLimiter(i.OutRateLimit, window, i.RateLimitStrategy)
 	integrations.m[i.Name] = i
 	integrations.Unlock()
 	return nil

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -140,7 +140,7 @@ func TestServeError(t *testing.T) {
 func TestRateLimiterStopClosesConnections(t *testing.T) {
 	old := *redisAddr
 	*redisAddr = "dummy"
-	rl := NewRateLimiter(1, time.Hour)
+	rl := NewRateLimiter(1, time.Hour, "")
 	defer func() { *redisAddr = old }()
 
 	c1, c2 := net.Pipe()
@@ -176,7 +176,7 @@ func readRedisRequest(br *bufio.Reader) error {
 func TestAllowRedisUnsupportedScheme(t *testing.T) {
 	old := *redisAddr
 	*redisAddr = "foo://localhost"
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	t.Cleanup(func() {
 		*redisAddr = old
 		rl.Stop()
@@ -190,7 +190,7 @@ func TestAllowRedisTLSCAError(t *testing.T) {
 	oldAddr, oldCA := *redisAddr, *redisCA
 	*redisAddr = "rediss://localhost:1"
 	*redisCA = "does_not_exist.pem"
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	t.Cleanup(func() {
 		*redisAddr = oldAddr
 		*redisCA = oldCA
@@ -204,7 +204,7 @@ func TestAllowRedisTLSCAError(t *testing.T) {
 func TestAllowRedisErrorResponse(t *testing.T) {
 	old := *redisAddr
 	*redisAddr = "dummy"
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	t.Cleanup(func() {
 		*redisAddr = old
 		rl.Stop()
@@ -225,7 +225,7 @@ func TestAllowRedisErrorResponse(t *testing.T) {
 func TestAllowRedisSuccess(t *testing.T) {
 	old := *redisAddr
 	*redisAddr = "dummy"
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	t.Cleanup(func() {
 		*redisAddr = old
 		rl.Stop()

--- a/app/redis_tls_auth_test.go
+++ b/app/redis_tls_auth_test.go
@@ -85,7 +85,7 @@ func TestRateLimiterRedisAuth(t *testing.T) {
 	oldTimeout := *redisTimeout
 	*redisAddr = "redis://:pw@" + ln.Addr().String()
 	*redisTimeout = time.Second
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	defer func() {
 		rl.Stop()
 		*redisAddr = oldAddr
@@ -133,7 +133,7 @@ func TestRateLimiterRedisAuthUsername(t *testing.T) {
 	oldTimeout := *redisTimeout
 	*redisAddr = "redis://user:pw@" + ln.Addr().String()
 	*redisTimeout = time.Second
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	defer func() {
 		rl.Stop()
 		*redisAddr = oldAddr
@@ -193,7 +193,7 @@ func TestRateLimiterRedisTLSAuth(t *testing.T) {
 	oldTimeout := *redisTimeout
 	*redisAddr = "rediss://:pw@" + ln.Addr().String()
 	*redisTimeout = time.Second
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	defer func() {
 		rl.Stop()
 		*redisAddr = oldAddr
@@ -269,7 +269,7 @@ func TestRateLimiterRedisTLSVerify(t *testing.T) {
 	*redisAddr = "rediss://:pw@" + ln.Addr().String()
 	*redisTimeout = time.Second
 	*redisCA = caFile
-	rl := NewRateLimiter(1, time.Second)
+	rl := NewRateLimiter(1, time.Second, "")
 	defer func() {
 		rl.Stop()
 		*redisAddr = oldAddr

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -56,6 +56,7 @@ See [Secret Back-Ends](secret-backends.md) for all supported URI schemes.
 | `in_rate_limit` | int            | `0`          | Max inbound requests per caller within the window. |
 | `out_rate_limit` | int           | `0`          | Max outbound requests per caller within the window. |
 | `rate_limit_window` | duration    | `1m`         | Rolling window length for rate limiting. |
+| `rate_limit_strategy` | string    | `fixed_window` | Rate limit algorithm (`fixed_window` or `token_bucket`). |
 | `idle_conn_timeout` | duration    | `0`          | How long idle connections stay pooled. |
 | `tls_handshake_timeout` | duration | `0`          | Maximum time to wait for TLS handshakes. |
 | `response_header_timeout` | duration | `0`        | Time to wait for the first response header. |

--- a/docs/rate-limiting.md
+++ b/docs/rate-limiting.md
@@ -1,6 +1,6 @@
 # Rate‑Limiting
 
-AuthTranslator implements a **fixed‑window counter with elastic expiry** (aka *sliding window approximation*). Limits apply **per‑caller ID per integration** so noisy neighbours can’t starve other users of the same upstream service.
+AuthTranslator defaults to a **fixed‑window counter with elastic expiry** (aka *sliding window approximation*). Limits apply **per‑caller ID per integration** so noisy neighbours can’t starve other users of the same upstream service. The schema allows choosing between `fixed_window` and `token_bucket` strategies for different workloads.
 
 ---
 
@@ -30,7 +30,11 @@ integrations:
 | `in_rate_limit`     | int      | `0`     | Max inbound requests per caller within the window. |
 | `out_rate_limit`    | int      | `0`     | Max outbound requests per caller within the window. |
 | `rate_limit_window` | duration | `1m`    | Rolling window length for rate limiting. |
+| `rate_limit_strategy` | string | `fixed_window` | Algorithm to apply (`fixed_window` or `token_bucket`). |
 
+### Strategies
+
+`fixed_window` resets counters every `rate_limit_window`. `token_bucket` allows bursts up to the limit and refills steadily over the same window.
 
 ---
 
@@ -75,4 +79,5 @@ Grafana sample dashboard lives in [`docs/ops/grafana-rate-limits.json`](ops/graf
 
 * Leaky‑bucket smoothing for less burst‑biased fairness.
 * Back‑pressure headers (`Retry‑After`).
+* Additional algorithms (e.g., leaky bucket).
 * Pluggable backends (Memcached / Cloud Spanner).

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -19,6 +19,10 @@
         "in_rate_limit": { "type": "integer" },
         "out_rate_limit": { "type": "integer" },
         "rate_limit_window": { "type": "string" },
+        "rate_limit_strategy": {
+          "type": "string",
+          "enum": ["fixed_window", "token_bucket"]
+        },
         "incoming_auth": {
           "type": "array",
           "items": { "$ref": "#/definitions/authPlugin" }


### PR DESCRIPTION
## Summary
- mention that rate limiting schema allows other algorithms like token bucket
- document `rate_limit_strategy` configuration field
- add token bucket note to future work list

## Testing
- `go vet ./...`
- `go test ./...`
