### PR TITLE
Add more websocket and gRPC tests

### DIFF
--- a/app/grpc_test.go
+++ b/app/grpc_test.go
@@ -52,3 +52,52 @@ func TestProxyHandlerGRPC(t *testing.T) {
 		t.Fatalf("expected HTTP/2 response, got %s", resp.Proto)
 	}
 }
+
+func TestProxyHandlerGRPCHeaders(t *testing.T) {
+	var gotCT, gotTE string
+	upstream := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotCT = r.Header.Get("Content-Type")
+		gotTE = r.Header.Get("TE")
+		w.Header().Set("Content-Type", "application/grpc")
+		w.WriteHeader(http.StatusOK)
+	}))
+	upstream.EnableHTTP2 = true
+	upstream.StartTLS()
+	defer upstream.Close()
+
+	integ := Integration{Name: "grpchdr", Destination: upstream.URL, InRateLimit: 1, OutRateLimit: 1, TLSInsecureSkipVerify: true}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("add integration: %v", err)
+	}
+	t.Cleanup(func() { integ.inLimiter.Stop(); integ.outLimiter.Stop() })
+
+	proxy := httptest.NewUnstartedServer(http.HandlerFunc(proxyHandler))
+	proxy.EnableHTTP2 = true
+	proxy.StartTLS()
+	defer proxy.Close()
+
+	client := proxy.Client()
+	client.Transport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+
+	req, err := http.NewRequest(http.MethodPost, proxy.URL+"/", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Host = "grpchdr"
+	req.Header.Set("Content-Type", "application/grpc")
+	req.Header.Set("TE", "trailers")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("do request: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if gotCT != "application/grpc" {
+		t.Fatalf("Content-Type not forwarded: %q", gotCT)
+	}
+	if gotTE != "trailers" {
+		t.Fatalf("TE header not forwarded: %q", gotTE)
+	}
+}

--- a/app/proxy_ws_test.go
+++ b/app/proxy_ws_test.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"crypto/sha1"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -71,5 +73,84 @@ func TestProxyHandlerWebSocket(t *testing.T) {
 	}
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+}
+
+func TestProxyHandlerWebSocketEcho(t *testing.T) {
+	message := []byte{0x81, 0x05, 'h', 'e', 'l', 'l', 'o'}
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			t.Fatalf("expected websocket upgrade, got %q", r.Header.Get("Upgrade"))
+		}
+		hij, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("hijacking not supported")
+		}
+		conn, buf, err := hij.Hijack()
+		if err != nil {
+			t.Fatalf("hijack failed: %v", err)
+		}
+		defer conn.Close()
+		accept := wsAccept(r.Header.Get("Sec-WebSocket-Key"))
+		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\n")
+		fmt.Fprintf(buf, "Upgrade: websocket\r\n")
+		fmt.Fprintf(buf, "Connection: Upgrade\r\n")
+		fmt.Fprintf(buf, "Sec-WebSocket-Accept: %s\r\n\r\n", accept)
+		buf.Flush()
+
+		echo := make([]byte, len(message))
+		if _, err := io.ReadFull(conn, echo); err != nil {
+			t.Fatalf("read message: %v", err)
+		}
+		if !bytes.Equal(echo, message) {
+			t.Fatalf("server received %v, want %v", echo, message)
+		}
+		if _, err := conn.Write(echo); err != nil {
+			t.Fatalf("write echo: %v", err)
+		}
+	}))
+	defer upstream.Close()
+
+	integ := Integration{Name: "wsecho", Destination: upstream.URL, InRateLimit: 1, OutRateLimit: 1}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("add integration: %v", err)
+	}
+	t.Cleanup(func() { integ.inLimiter.Stop(); integ.outLimiter.Stop() })
+
+	proxy := httptest.NewServer(http.HandlerFunc(proxyHandler))
+	defer proxy.Close()
+
+	conn, err := net.Dial("tcp", proxy.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer conn.Close()
+
+	fmt.Fprintf(conn, "GET / HTTP/1.1\r\n")
+	fmt.Fprintf(conn, "Host: wsecho\r\n")
+	fmt.Fprintf(conn, "Upgrade: websocket\r\n")
+	fmt.Fprintf(conn, "Connection: Upgrade\r\n")
+	fmt.Fprintf(conn, "Sec-WebSocket-Key: testkey==\r\n")
+	fmt.Fprintf(conn, "Sec-WebSocket-Version: 13\r\n\r\n")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("expected 101, got %d", resp.StatusCode)
+	}
+
+	if _, err := conn.Write(message); err != nil {
+		t.Fatalf("write message: %v", err)
+	}
+
+	reply := make([]byte, len(message))
+	if _, err := io.ReadFull(br, reply); err != nil {
+		t.Fatalf("read reply: %v", err)
+	}
+	if !bytes.Equal(reply, message) {
+		t.Fatalf("expected echo %v, got %v", message, reply)
 	}
 }


### PR DESCRIPTION
## Summary
- extend websocket tests with an echo test
- add new gRPC header forwarding test

## Testing
- `go test ./...`