### PR TITLE
Add metrics caller context

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -176,7 +176,8 @@ func prepareIntegration(i *Integration) error {
 	i.proxy = httputil.NewSingleHostReverseProxy(u)
 	// Fire metrics hooks after the upstream responds.
 	i.proxy.ModifyResponse = func(resp *http.Response) error {
-		metrics.OnResponse(i.Name, resp.Request, resp)
+		caller := metrics.Caller(resp.Request.Context())
+		metrics.OnResponse(i.Name, caller, resp.Request, resp)
 		return nil
 	}
 

--- a/app/main.go
+++ b/app/main.go
@@ -602,6 +602,8 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 
 	logger.Info("incoming request", "method", r.Method, "integration", integ.Name, "path", r.URL.Path, "caller_id", callerID)
 
+	r = r.WithContext(metrics.WithCaller(r.Context(), callerID))
+
 	if !integ.inLimiter.Allow(rateKey) {
 		logger.Warn("caller exceeded rate limit", "caller", rateKey, "host", host)
 		incRateLimit(integ.Name)

--- a/app/metrics/callerctx.go
+++ b/app/metrics/callerctx.go
@@ -1,0 +1,19 @@
+package metrics
+
+import "context"
+
+// WithCaller returns a new context with the caller ID stored.
+func WithCaller(ctx context.Context, caller string) context.Context {
+	return context.WithValue(ctx, callerKey{}, caller)
+}
+
+// Caller retrieves the caller ID from the context if present.
+func Caller(ctx context.Context) string {
+	if v, ok := ctx.Value(callerKey{}).(string); ok {
+		return v
+	}
+	return ""
+}
+
+// callerKey is unexported to avoid collisions.
+type callerKey struct{}

--- a/app/metrics/plugins/example/README.md
+++ b/app/metrics/plugins/example/README.md
@@ -1,0 +1,4 @@
+# Example Metrics Plugin
+
+This directory contains a minimal metrics plugin showing how to track token
+usage from the OpenAI API. It is excluded from normal builds with a `//go:build example` tag so it can serve purely as a reference.

--- a/app/metrics/plugins/example/plugin.go
+++ b/app/metrics/plugins/example/plugin.go
@@ -1,0 +1,40 @@
+//go:build example
+
+package example
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type tokenCounter struct {
+	mu     sync.Mutex
+	totals map[string]uint64
+}
+
+func (t *tokenCounter) OnRequest(string, *http.Request) {}
+
+func (t *tokenCounter) OnResponse(integ, caller string, r *http.Request, resp *http.Response) {
+	if integ != "openai" {
+		return
+	}
+	var body struct {
+		Usage struct {
+			TotalTokens int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return
+	}
+	t.mu.Lock()
+	if t.totals == nil {
+		t.totals = make(map[string]uint64)
+	}
+	t.totals[caller] += uint64(body.Usage.TotalTokens)
+	t.mu.Unlock()
+}
+
+func init() { metrics.Register(&tokenCounter{}) }

--- a/app/metrics/registry.go
+++ b/app/metrics/registry.go
@@ -8,7 +8,7 @@ import (
 // Plugin can record custom metrics for each request and response.
 type Plugin interface {
 	OnRequest(integration string, r *http.Request)
-	OnResponse(integration string, r *http.Request, resp *http.Response)
+	OnResponse(integration, caller string, r *http.Request, resp *http.Response)
 }
 
 var (
@@ -41,11 +41,11 @@ func OnRequest(integration string, r *http.Request) {
 }
 
 // OnResponse triggers all registered plugins for a completed response.
-func OnResponse(integration string, r *http.Request, resp *http.Response) {
+func OnResponse(integration, caller string, r *http.Request, resp *http.Response) {
 	mu.RLock()
 	ps := append([]Plugin(nil), plugins...)
 	mu.RUnlock()
 	for _, p := range ps {
-		p.OnResponse(integration, r, resp)
+		p.OnResponse(integration, caller, r, resp)
 	}
 }

--- a/app/metrics/registry_test.go
+++ b/app/metrics/registry_test.go
@@ -15,7 +15,7 @@ func (p *testPlugin) OnRequest(integration string, r *http.Request) {
 	p.reqs++
 }
 
-func (p *testPlugin) OnResponse(integration string, r *http.Request, resp *http.Response) {
+func (p *testPlugin) OnResponse(integration, caller string, r *http.Request, resp *http.Response) {
 	p.resps++
 }
 
@@ -36,7 +36,7 @@ func TestRegistry(t *testing.T) {
 
 	req, _ := http.NewRequest(http.MethodGet, "http://example", nil)
 	OnRequest("foo", req)
-	OnResponse("foo", req, &http.Response{})
+	OnResponse("foo", "caller", req, &http.Response{})
 
 	if tp.reqs != 1 {
 		t.Fatalf("expected 1 request call, got %d", tp.reqs)

--- a/app/metrics_hook_test.go
+++ b/app/metrics_hook_test.go
@@ -17,7 +17,7 @@ func (h *hookPlugin) OnRequest(integ string, r *http.Request) {
 	h.req++
 }
 
-func (h *hookPlugin) OnResponse(integ string, r *http.Request, resp *http.Response) {
+func (h *hookPlugin) OnResponse(integ, caller string, r *http.Request, resp *http.Response) {
 	h.resp++
 }
 

--- a/docs/metrics-plugins.md
+++ b/docs/metrics-plugins.md
@@ -1,0 +1,86 @@
+# Metrics Plugins
+
+AuthTranslator exposes basic Prometheus metrics out of the box. When you need extra
+counters or histograms, write a small **metrics plugin**. Plugins see every
+request and response but never mutate them.
+
+---
+
+## Interface
+
+```go
+// app/metrics/registry.go
+ type Plugin interface {
+     OnRequest(integration string, r *http.Request)
+     OnResponse(integration, caller string, r *http.Request, resp *http.Response)
+ }
+```
+
+`OnRequest` fires just before the proxy forwards a request upstream and
+`OnResponse` runs once the upstream reply is received. The integration name is
+passed so you can apply per-service logic.
+
+---
+
+## Writing your own plugin
+
+1. Create `app/metrics/plugins/<name>`.
+2. Implement the interface above.
+3. Register it in `init()` with `metrics.Register(&MyPlugin{})`.
+4. Build or run the proxy – registered plugins load automatically.
+
+A minimal reference implementation lives in
+[`app/metrics/plugins/example`](../app/metrics/plugins/example).
+
+---
+
+## Example – counting OpenAI tokens
+
+The OpenAI API responds with a JSON body containing a `usage.total_tokens` field.
+The plugin below keeps a simple in-memory total per caller ID passed in from the
+proxy:
+
+```go
+//go:build example
+
+package example
+
+import (
+    "encoding/json"
+    "net/http"
+    "sync"
+
+    "github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type tokenCounter struct {
+    mu     sync.Mutex
+    totals map[string]uint64
+}
+
+func (t *tokenCounter) OnRequest(string, *http.Request) {}
+
+func (t *tokenCounter) OnResponse(integ, caller string, r *http.Request, resp *http.Response) {
+    if integ != "openai" {
+        return
+    }
+    var body struct {
+        Usage struct {
+            TotalTokens int `json:"total_tokens"`
+        } `json:"usage"`
+    }
+    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+        return
+    }
+    t.mu.Lock()
+    if t.totals == nil {
+        t.totals = make(map[string]uint64)
+    }
+    t.totals[caller] += uint64(body.Usage.TotalTokens)
+    t.mu.Unlock()
+}
+
+func init() { metrics.Register(&tokenCounter{}) }
+```
+
+Use the `totals` map to expose custom Prometheus counters or logs as needed.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -30,7 +30,7 @@ exposed by default but can be disabled with `-enable-metrics=false`. Provide
 | `authtranslator_rate_limit_events_total`  | counter   | `integration`         | Incremented when a request is rejected with 429. |
 | `authtranslator_auth_failures_total`      | counter   | `integration`         | Authentication plugin failures.                  |
 
-Missing a metric? Write a small **metrics plugin** to hook into requests and responses or open a PR—new counters are easy to wire in.
+Missing a metric? Write a small **metrics plugin** to hook into requests and responses or open a PR—new counters are easy to wire in. See [Metrics Plugins](metrics-plugins.md) for a primer.
 
 ---
 


### PR DESCRIPTION
## Summary
- pass caller ID through request context to metrics plugins
- update metrics plugin interface for caller argument
- show updated interface and example plugin in docs

## Testing
- `go test ./...`
- `golangci-lint run` *(fails: can't load config)*
