### PR TITLE
Fix docs/helm Terraform variable list

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -132,5 +132,4 @@ Example Terraform configurations live in the [`terraform/`](../terraform/) direc
 
 Set the variables for your environment and run `terraform apply` inside the
 chosen folder to create the service. The modules accept optional
-`redis_address`, `redis_timeout` and `redis_ca` variables which map to the
-container flags.
+`redis_address` and `redis_ca` variables which map to the container flags.


### PR DESCRIPTION
## Summary
- correct Terraform module variables in Helm docs

## Testing
- `make lint` *(fails: unsupported golangci-lint config)*
- `make test`
