### PR TITLE
Migrate metrics to plugin

### DIFF
--- a/app/metrics/metrics_histogram_test.go
+++ b/app/metrics/metrics_histogram_test.go
@@ -1,4 +1,4 @@
-package main
+package metrics
 
 import (
 	"encoding/json"

--- a/app/metrics/plugins/duration_recorder.go
+++ b/app/metrics/plugins/duration_recorder.go
@@ -1,0 +1,26 @@
+package plugins
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type durationRecorder struct{}
+
+type startKey struct{}
+
+func (*durationRecorder) OnRequest(integration string, r *http.Request) {
+	ctx := context.WithValue(r.Context(), startKey{}, time.Now())
+	*r = *r.WithContext(ctx)
+}
+
+func (*durationRecorder) OnResponse(integration, caller string, r *http.Request, resp *http.Response) {
+	if t, ok := r.Context().Value(startKey{}).(time.Time); ok {
+		metrics.RecordDuration(integration, time.Since(t))
+	}
+}
+
+func init() { metrics.Register(&durationRecorder{}) }

--- a/app/metrics/plugins/request_counter.go
+++ b/app/metrics/plugins/request_counter.go
@@ -1,0 +1,17 @@
+package plugins
+
+import (
+	"net/http"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type requestCounter struct{}
+
+func (*requestCounter) OnRequest(integration string, r *http.Request) {
+	metrics.IncRequest(integration)
+}
+
+func (*requestCounter) OnResponse(string, string, *http.Request, *http.Response) {}
+
+func init() { metrics.Register(&requestCounter{}) }

--- a/app/metrics/plugins/status_metric.go
+++ b/app/metrics/plugins/status_metric.go
@@ -1,0 +1,17 @@
+package plugins
+
+import (
+	"net/http"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+type statusMetric struct{}
+
+func (*statusMetric) OnRequest(string, *http.Request) {}
+
+func (*statusMetric) OnResponse(integration, caller string, r *http.Request, resp *http.Response) {
+	metrics.RecordStatus(integration, resp.StatusCode)
+}
+
+func init() { metrics.Register(&statusMetric{}) }


### PR DESCRIPTION
## Summary
- hook Prometheus metrics via individual builtin plugins
- expose helper functions for metrics handling
- wire metrics handler through the metrics package

## Testing
- `go test ./...`
