### PR TITLE
Add metrics plugin unit tests

### DIFF
--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -1,6 +1,7 @@
 package metrics
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -108,5 +109,15 @@ func TestMetricsHandlerAuth(t *testing.T) {
 	Handler(rr, req, "admin", "secret")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("expected 200 for valid creds, got %d", rr.Code)
+	}
+}
+
+func TestCallerContext(t *testing.T) {
+	ctx := WithCaller(context.Background(), "user1")
+	if got := Caller(ctx); got != "user1" {
+		t.Fatalf("expected caller user1, got %q", got)
+	}
+	if Caller(context.Background()) != "" {
+		t.Fatal("expected empty caller for background context")
 	}
 }

--- a/app/metrics/plugins/durationrecorder/plugin.go
+++ b/app/metrics/plugins/durationrecorder/plugin.go
@@ -1,4 +1,4 @@
-package plugins
+package durationrecorder
 
 import (
 	"context"

--- a/app/metrics/plugins/durationrecorder/plugin_test.go
+++ b/app/metrics/plugins/durationrecorder/plugin_test.go
@@ -1,0 +1,29 @@
+package durationrecorder
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+func TestDurationRecorder(t *testing.T) {
+	dr := &durationRecorder{}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	dr.OnRequest("foo", req)
+	time.Sleep(10 * time.Millisecond)
+	dr.OnResponse("foo", "", req, &http.Response{})
+
+	rr := httptest.NewRecorder()
+	metrics.Handler(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil), "", "")
+	body := rr.Body.String()
+	if !strings.Contains(body, `authtranslator_request_duration_seconds_sum{integration="foo"}`) {
+		t.Fatalf("duration histogram missing: %s", body)
+	}
+	if !strings.Contains(body, `authtranslator_request_duration_seconds_count{integration="foo"} 1`) {
+		t.Fatalf("duration count missing: %s", body)
+	}
+}

--- a/app/metrics/plugins/plugins.go
+++ b/app/metrics/plugins/plugins.go
@@ -1,0 +1,7 @@
+package plugins
+
+import (
+	_ "github.com/winhowes/AuthTranslator/app/metrics/plugins/durationrecorder"
+	_ "github.com/winhowes/AuthTranslator/app/metrics/plugins/requestcounter"
+	_ "github.com/winhowes/AuthTranslator/app/metrics/plugins/statusmetric"
+)

--- a/app/metrics/plugins/requestcounter/plugin.go
+++ b/app/metrics/plugins/requestcounter/plugin.go
@@ -1,4 +1,4 @@
-package plugins
+package requestcounter
 
 import (
 	"net/http"

--- a/app/metrics/plugins/requestcounter/plugin_test.go
+++ b/app/metrics/plugins/requestcounter/plugin_test.go
@@ -1,0 +1,22 @@
+package requestcounter
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+func TestRequestCounter(t *testing.T) {
+	rc := &requestCounter{}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	rc.OnRequest("foo", req)
+
+	rr := httptest.NewRecorder()
+	metrics.Handler(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil), "", "")
+	if !strings.Contains(rr.Body.String(), `authtranslator_requests_total{integration="foo"} 1`) {
+		t.Fatalf("request metric missing: %s", rr.Body.String())
+	}
+}

--- a/app/metrics/plugins/statusmetric/plugin.go
+++ b/app/metrics/plugins/statusmetric/plugin.go
@@ -1,4 +1,4 @@
-package plugins
+package statusmetric
 
 import (
 	"net/http"

--- a/app/metrics/plugins/statusmetric/plugin_test.go
+++ b/app/metrics/plugins/statusmetric/plugin_test.go
@@ -1,0 +1,23 @@
+package statusmetric
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+func TestStatusMetric(t *testing.T) {
+	sm := &statusMetric{}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	resp := &http.Response{StatusCode: http.StatusTeapot}
+	sm.OnResponse("foo", "", req, resp)
+
+	rr := httptest.NewRecorder()
+	metrics.Handler(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil), "", "")
+	if !strings.Contains(rr.Body.String(), `authtranslator_upstream_responses_total{integration="foo",code="418"} 1`) {
+		t.Fatalf("status metric missing: %s", rr.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- test caller context helpers
- add unit tests for metrics plugins
- move built-in metric plugins into their own packages

## Testing
- `go vet ./...`
- `go test ./... -coverprofile=coverage.out`
