### PR TITLE
Fix status tracking on ReadFrom

### DIFF
--- a/app/statusrecorder.go
+++ b/app/statusrecorder.go
@@ -36,6 +36,9 @@ func (r *statusRecorder) CloseNotify() <-chan bool {
 }
 
 func (r *statusRecorder) ReadFrom(src io.Reader) (int64, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
 	if rf, ok := r.ResponseWriter.(io.ReaderFrom); ok {
 		return rf.ReadFrom(src)
 	}

--- a/app/statusrecorder_test.go
+++ b/app/statusrecorder_test.go
@@ -193,6 +193,21 @@ func TestStatusRecorderReadFromFallback(t *testing.T) {
 	}
 }
 
+func TestStatusRecorderReadFromDefaultStatus(t *testing.T) {
+	rr := &readerFromRecorder{ResponseRecorder: httptest.NewRecorder()}
+	rec := &statusRecorder{ResponseWriter: rr}
+
+	if _, err := rec.ReadFrom(strings.NewReader("ok")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if rec.status != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, rec.status)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("response writer code %d", rr.Code)
+	}
+}
+
 // pushableRecorder records whether Push was called.
 type pushableRecorder struct {
 	*httptest.ResponseRecorder


### PR DESCRIPTION
## Summary
- ensure statusRecorder updates the status when using `ReadFrom`
- test ReadFrom default status behavior

## Testing
- `make test`