### PR TITLE
Update allowlist terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ graph LR
 ```
 
 1. **Auth plug‑in** validates + strips caller credential → forwards request allowing your services to use short lived credentials when sending requests to or receiving requests from 3rd parties.
-2. Allow‑list enforces either capability‑based rules or precise filters on path, method, query params, headers, and JSON‑body or form‑data keys.
+2. The allowlist enforces either capability‑based rules or precise filters on path, method, query params, headers, and JSON‑body or form‑data keys.
 
 ---
 
@@ -97,7 +97,7 @@ go run ./cmd/integrations slack \
   -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING
 ```
 
-Also see [`cmd/allowlist`](cmd/allowlist) for CRUD operations on the allow‑list.
+Also see [`cmd/allowlist`](cmd/allowlist) for CRUD operations on the allowlist.
 
 ---
 

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -1,6 +1,6 @@
 # `allowlist.yaml` – Caller Permissions
 
-The **allow‑list** answers a single question:
+The **allowlist** answers a single question:
 
 > *Given this caller ID and integration, is the request allowed?*
 

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -2,11 +2,11 @@
 
 AuthTranslator’s behaviour is extended by **plugins** – small Go packages that validate the *incoming* caller credential or inject the *outgoing* credential expected by an upstream service.
 
-* **Incoming plugins** run **before** any allow‑list checks. They must either
+* **Incoming plugins** run **before** any allowlist checks. They must either
 
   1. **Accept**: return a `callerID` string; the request continues, or
   2. **Reject**: return an error → the proxy replies **401/403**.
-* **Outgoing plugins** run **after** the allow‑list passes. They mutate the request (headers, query or body) so the upstream authenticates it.
+* **Outgoing plugins** run **after** the allowlist passes. They mutate the request (headers, query or body) so the upstream authenticates it.
 
 > **Tip** Any plugin can be swapped at runtime – just edit `config.yaml` and send `SIGHUP` (or run with `-watch`).
 
@@ -104,7 +104,7 @@ A minimal example lives in [`app/auth/plugins/example`](../app/auth/plugins/exam
 
 ### Caller identifiers
 
-Incoming plugins that want to feed the **allow‑list** and **rate‑limiter** should satisfy the `auth.Identifier` interface:
+Incoming plugins that want to feed the **allowlist** and **rate‑limiter** should satisfy the `auth.Identifier` interface:
 
 ```go
 type Identifier interface {


### PR DESCRIPTION
## Summary
- clarify README intro about the allowlist
- fix docs to consistently use **allowlist** instead of allow‑list

## Testing
- `make test`