### PR TITLE
Document X-AT-Int header routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker run --rm -p 8080:8080 \
 # 2. Curl through the proxy
 curl -H "Host: slack" -H "X-Auth: <short‑lived>" \
      http://localhost:8080/api/chat.postMessage
+# alternatively set `X-AT-Int: slack` if you can’t change the Host header
 ```
 
 ```bash

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,6 +52,7 @@ curl -H "Host: slack" \                               # tells the proxy which in
 If everything is wired up you’ll get back Slack’s normal JSON response and your message appears in **#general**.
 
 In production deployments AuthTranslator is typically reached via a wildcard DNS entry like `*.auth.example.com` with a matching wildcard TLS certificate. The `Host` header (or subdomain) selects which integration handles each request.
+If you can’t modify the `Host` header, set an `X-AT-Int` header with the integration name. This override is enabled by default but can be disabled with `-disable_x_at_int` or restricted using `-x_at_int_host`.
 
 ---
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -51,6 +51,19 @@ AuthTranslator exposes several command‑line options:
 
 ---
 
+## Integration routing
+
+By default the proxy chooses an integration by matching the request's `Host`
+header to the names declared in `config.yaml`.  When clients cannot change the
+`Host` header, they may supply an `X-AT-Int` header instead.  Its value is treated
+the same as a host name and looked up case-insensitively.
+
+The header is ignored when the service starts with `-disable_x_at_int`.  Use
+`-x_at_int_host` to allow overrides only when the incoming `Host` matches a
+specific value.
+
+---
+
 ## Running tests
 
 Use the Makefile helpers before committing changes:


### PR DESCRIPTION
## Summary
- document how X-AT-Int header overrides the Host
- mention header override in the getting started guide and README

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`