### PR TITLE
Fix docs on HTTP method case

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -73,7 +73,13 @@ func SetAllowlist(name string, callers []CallerConfig) error {
 	m := make(map[string]CallerConfig, len(callers))
 	for _, c := range callers {
 		for ri := range c.Rules {
-			c.Rules[ri].Segments = splitPath(c.Rules[ri].Path)
+			r := &c.Rules[ri]
+			r.Segments = splitPath(r.Path)
+			methods := make(map[string]RequestConstraint, len(r.Methods))
+			for mth, cons := range r.Methods {
+				methods[strings.ToUpper(mth)] = cons
+			}
+			r.Methods = methods
 		}
 		id := c.ID
 		if id == "" {

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -130,3 +130,18 @@ func TestSetAllowlistDuplicateRule(t *testing.T) {
 		t.Fatal("expected error for duplicate rule")
 	}
 }
+
+func TestSetAllowlistLowercaseMethod(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	if err := SetAllowlist("case", []CallerConfig{{ID: "*", Rules: []CallRule{{Path: "/ok", Methods: map[string]RequestConstraint{"get": {}}}}}}); err != nil {
+		t.Fatalf("failed to set allowlist: %v", err)
+	}
+
+	integ := &Integration{Name: "case"}
+	if _, ok := findConstraint(integ, "*", "/ok", http.MethodGet); !ok {
+		t.Fatal("expected match for uppercase method")
+	}
+}

--- a/app/allowlist_validate.go
+++ b/app/allowlist_validate.go
@@ -54,17 +54,25 @@ func validateAllowlistEntry(name string, callers []CallerConfig) error {
 				return fmt.Errorf("caller %q rule %d has no methods", id, ri)
 			}
 			for m := range r.Methods {
-				if m == "" || strings.ToUpper(m) != m {
-					return fmt.Errorf("caller %q rule %d invalid method %s", id, ri, m)
+				if strings.TrimSpace(m) == "" {
+					return fmt.Errorf("caller %q rule %d invalid method %q", id, ri, m)
 				}
 			}
 		}
 	}
 	copyCallers := make([]CallerConfig, len(callers))
 	for i, c := range callers {
+		rules := append([]CallRule(nil), c.Rules...)
+		for ri := range rules {
+			methods := make(map[string]RequestConstraint, len(rules[ri].Methods))
+			for m, cons := range rules[ri].Methods {
+				methods[strings.ToUpper(m)] = cons
+			}
+			rules[ri].Methods = methods
+		}
 		copyCallers[i] = CallerConfig{
 			ID:           c.ID,
-			Rules:        append([]CallRule(nil), c.Rules...),
+			Rules:        rules,
 			Capabilities: append([]integrationplugins.CapabilityConfig(nil), c.Capabilities...),
 		}
 	}

--- a/app/allowlist_validate_test.go
+++ b/app/allowlist_validate_test.go
@@ -75,13 +75,13 @@ func TestValidateAllowlistEntriesMissingPath(t *testing.T) {
 	}
 }
 
-func TestValidateAllowlistEntriesInvalidMethodCase(t *testing.T) {
+func TestValidateAllowlistEntriesMethodCaseIgnored(t *testing.T) {
 	entries := []AllowlistEntry{{
 		Integration: "test",
 		Callers:     []CallerConfig{{ID: "c", Rules: []CallRule{{Path: "/x", Methods: map[string]RequestConstraint{"get": {}}}}}},
 	}}
-	if err := validateAllowlistEntries(entries); err == nil {
-		t.Fatal("expected error for invalid method case")
+	if err := validateAllowlistEntries(entries); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -91,7 +91,7 @@ which requests are permitted.
 | Request part | Matching logic                                                                                      |
 | ------------ | --------------------------------------------------------------------------------------------------- |
 | Path         | Must match the pattern **entirely**. `*` matches one segment; `**` matches the rest.                 |
-| Method       | Case‑insensitive string compare. Each method key contains its own constraints. |
+| Method       | Case-insensitive string compare. Each method key contains its own constraints. |
 | Query params | In `methods.<HTTP_METHOD>.query`, each key maps to allowed value list. Extra params allowed. Values match exactly.
 | Headers      | In `methods.<HTTP_METHOD>.headers`, each key has required values; an empty list only checks for presence. Values match exactly.
 | Body         | `methods.<HTTP_METHOD>.body` must be a recursive subset of the request body (JSON or form). Arrays matched unordered. Detection relies on the `Content-Type` header; if it's neither JSON nor form, body checks are skipped.


### PR DESCRIPTION
## Summary
- clarify allowlist docs to mention case-insensitive HTTP method matching
- normalize method keys to uppercase when loading allowlist
- update validation to accept any casing
- test lowercase method in allowlist

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`
