### PR TITLE
Fix docs for metrics auth flags

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -90,7 +90,8 @@ Remember limits are **per callerÂ ID** *and* **per integration**. If your loadâ€
 
 The health endpoint is always enabled. Metrics are exposed by default but you can
 disable them with `-enable-metrics=false` and require HTTP Basic credentials via
-`-metrics-user` and `-metrics-pass`.
+**both** `-metrics-user` **and** `-metrics-pass`. If only one flag is set,
+the proxy refuses to start.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -14,7 +14,8 @@ AuthTranslator surfaces **health probes, Prometheus metrics, and structured logs
 The health endpoint is always available and returns an `X-Last-Reload` header
 showing the most recent configuration reload time. The metrics endpoint is
 exposed by default but can be disabled with `-enable-metrics=false`. Provide
-`-metrics-user` and `-metrics-pass` to require HTTP Basic credentials.
+**both** `-metrics-user` **and** `-metrics-pass` to require HTTP Basic
+credentials – omitting either one causes the service to exit on startup.
 
 ---
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -46,8 +46,8 @@ AuthTranslator exposes several command‑line options:
 | `-version` | print the build version and exit |
 | `-watch` | automatically reload when config or allowlist files change |
 | `-enable-metrics` | expose the `/_at_internal/metrics` endpoint (default `true`) |
-| `-metrics-user` | username required to access `/_at_internal/metrics` |
-| `-metrics-pass` | password required to access `/_at_internal/metrics` |
+| `-metrics-user` | username required to access `/_at_internal/metrics` (must be used with `-metrics-pass`) |
+| `-metrics-pass` | password required to access `/_at_internal/metrics` (must be used with `-metrics-user`) |
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify that both `-metrics-user` and `-metrics-pass` must be supplied
  otherwise the proxy exits
- update docs in observability, FAQ and runtime pages

## Testing
- `make test`