### PR TITLE
Improve test coverage

### DIFF
--- a/app/integrations/registry_test.go
+++ b/app/integrations/registry_test.go
@@ -74,3 +74,22 @@ func TestExpandCapabilitiesGenerateError(t *testing.T) {
 		t.Fatalf("capabilities not cleared")
 	}
 }
+
+func TestCapabilitiesHelpers(t *testing.T) {
+	// Save registry and restore after test
+	orig := capabilityRegistry
+	capabilityRegistry = map[string]map[string]CapabilitySpec{}
+	t.Cleanup(func() { capabilityRegistry = orig })
+
+	spec := CapabilitySpec{Generate: func(map[string]interface{}) ([]CallRule, error) { return nil, nil }}
+	RegisterCapability("foo", "bar", spec)
+
+	if got := CapabilitiesFor("foo"); len(got) != 1 || got["bar"].Generate == nil {
+		t.Fatalf("CapabilitiesFor returned %#v", got)
+	}
+
+	all := AllCapabilities()
+	if len(all) != 1 || len(all["foo"]) != 1 {
+		t.Fatalf("AllCapabilities returned %#v", all)
+	}
+}

--- a/app/metrics/plugins/requestcounter/plugin_test.go
+++ b/app/metrics/plugins/requestcounter/plugin_test.go
@@ -20,3 +20,11 @@ func TestRequestCounter(t *testing.T) {
 		t.Fatalf("request metric missing: %s", rr.Body.String())
 	}
 }
+
+func TestRequestCounterOnResponse(t *testing.T) {
+	rc := &requestCounter{}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	resp := &http.Response{}
+	rc.OnResponse("foo", "", req, resp)
+	// Nothing to assert - function is a no-op, just ensure it doesn't panic
+}

--- a/app/metrics/plugins/statusmetric/plugin_test.go
+++ b/app/metrics/plugins/statusmetric/plugin_test.go
@@ -21,3 +21,10 @@ func TestStatusMetric(t *testing.T) {
 		t.Fatalf("status metric missing: %s", rr.Body.String())
 	}
 }
+
+func TestStatusMetricOnRequest(t *testing.T) {
+	sm := &statusMetric{}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	sm.OnRequest("foo", req)
+	// No metrics are recorded on request; ensure no panic
+}

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -92,7 +92,7 @@ func TestBuilderErrors(t *testing.T) {
 }
 
 func TestBuilderParseError(t *testing.T) {
-	for _, name := range []string{"asana", "openai", "confluence", "jira"} {
+	for _, name := range []string{"asana", "openai", "confluence", "jira", "slack"} {
 		b := Get(name)
 		if b == nil {
 			t.Fatalf("%s builder missing", name)


### PR DESCRIPTION
## Summary
- add helper tests for listing integration capabilities
- cover no-op callbacks for metric plugins
- verify builder parse error for slack plugin

## Testing
- `go test ./... -coverprofile=coverage.out`