### PR TITLE
Fix case-insensitive plugin lookup

### DIFF
--- a/cmd/integrations/plugins/registry.go
+++ b/cmd/integrations/plugins/registry.go
@@ -1,15 +1,17 @@
 package plugins
 
+import "strings"
+
 // Builder defines a function that parses CLI args into an Integration.
 type Builder func(args []string) (Integration, error)
 
 var registry = map[string]Builder{}
 
 // Register adds a plugin builder to the registry.
-func Register(name string, b Builder) { registry[name] = b }
+func Register(name string, b Builder) { registry[strings.ToLower(name)] = b }
 
 // Get retrieves a registered builder by name.
-func Get(name string) Builder { return registry[name] }
+func Get(name string) Builder { return registry[strings.ToLower(name)] }
 
 // List returns the registered plugin names.
 func List() []string {

--- a/cmd/integrations/plugins/registry_test.go
+++ b/cmd/integrations/plugins/registry_test.go
@@ -39,3 +39,12 @@ func TestRegisterAndGet(t *testing.T) {
 	}
 	delete(registry, "dummy")
 }
+
+func TestGetCaseInsensitive(t *testing.T) {
+	dummy := func(args []string) (Integration, error) { return Integration{Name: "ci"}, nil }
+	Register("Ci", dummy)
+	t.Cleanup(func() { delete(registry, "ci") })
+	if Get("cI") == nil {
+		t.Fatal("case-insensitive Get failed")
+	}
+}


### PR DESCRIPTION
## Summary
- normalize plugin names in integration registry
- add test for case-insensitive lookup

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6839f0187db483269764f36e26a7e351