### PR TITLE
Fix Slack capability name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Centralised secret custody | Only the proxy stores integration secrets; developers never see them. |
 | Plug-in everything | Auth types, secret back-ends and integration templates are Go plug-ins. |
 | Per-caller / per-integration rate-limits | Backed by Redis or in-memory. |
-| Granular request authorization | Grant callers high-level **capabilities** (e.g. `slack.chat.write.public`) or fine-grained filters on path, query, headers and body. |
+| Granular request authorization | Grant callers high-level **capabilities** (e.g. `post_public_as`) or fine-grained filters on path, query, headers and body. |
 | Hot-reload | `SIGHUP` or `-watch` picks up new configs without dropping connections. |
 
 ---

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -49,7 +49,7 @@ Look for a `capabilities.go` file under `app/integrations/plugins/<integration>/
 - integration: slack
   callers:
     - id: bot-123
-      capabilities: [slack.chat.write.public]
+      capabilities: [post_public_as]
 ```
 
 > **Discovering capabilities** Run the CLI helper:
@@ -116,6 +116,6 @@ A request passes if **any** rule (or capability‑expanded rule) matches.
 
 ## 3  Tips & conventions
 
-* **One capability ≈ one business use‑case** (e.g. `slack.chat.write.public`).
+* **One capability ≈ one business use‑case** (e.g. `post_public_as`).
 * Prefer **uppercase** HTTP methods (`GET`, `POST`) for consistency.
 * Log level `debug` will print which rule matched; helpful in staging.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,7 @@ Two ways to authorise a caller:
   callers:
     - id: demo-user
       # easiest: assign a capability
-      capabilities: [slack.chat.write.public]
+      capabilities: [post_public_as]
 
     - id: service‑42
       # granular example

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -65,7 +65,7 @@ allowlist: |
   - integration: slack
     callers:
       - id: demo
-        capabilities: [slack.chat.write.public]
+        capabilities: [post_public_as]
 
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This folder holds **runnable snippets** you can copy‑paste while reading the d
 | File             | Purpose                                                                          |
 | ---------------- | -------------------------------------------------------------------------------- |
 | `config.yaml`    | Defines one Slack integration (destination, outgoing auth, 1‑minute rate‑limit). |
-| `allowlist.yaml` | Grants caller `demo-user` the `slack.chat.write.public` capability.              |
+| `allowlist.yaml` | Grants caller `demo-user` the `post_public_as` capability.              |
 
 ## Quick try‑out
 


### PR DESCRIPTION
## Summary
- update documentation to use the correct Slack capability name `post_public_as`
- adjust examples and Helm guide

## Testing
- `make precommit` *(fails: unknown field Server)*
- `make test` *(fails: unknown field Server)*

------
https://chatgpt.com/codex/tasks/task_e_6839f5801d6883268c8d1f1ff67e63d7