### PR TITLE
Fix empty allowlist handling

### DIFF
--- a/app/allowlist_file_test.go
+++ b/app/allowlist_file_test.go
@@ -47,3 +47,20 @@ func TestLoadAllowlistsUnknownField(t *testing.T) {
 		t.Fatal("expected error for unknown field")
 	}
 }
+
+func TestLoadAllowlistsEmptyFile(t *testing.T) {
+	tmp, err := os.CreateTemp("", "empty*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.Close()
+
+	entries, err := loadAllowlists(tmp.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("expected zero entries, got %d", len(entries))
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -62,6 +63,9 @@ func loadAllowlists(filename string) ([]AllowlistEntry, error) {
 
 	var entries []AllowlistEntry
 	if err := dec.Decode(&entries); err != nil {
+		if errors.Is(err, io.EOF) {
+			return entries, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- gracefully handle empty allowlist files
- test empty allowlist parsing

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6839f67f2c288326a494188f2bec05b5