### PR TITLE
Add test for Retry-After on outer rate limit

### DIFF
--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -299,6 +299,38 @@ func TestProxyHandlerRateLimiterUsesIP(t *testing.T) {
 	}
 }
 
+func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
+	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer backend.Close()
+
+	integ := Integration{Name: "rl-out", Destination: backend.URL, InRateLimit: 10, OutRateLimit: 1, RateLimitWindow: "2s"}
+	if err := AddIntegration(&integ); err != nil {
+		t.Fatalf("failed to add integration: %v", err)
+	}
+	t.Cleanup(func() { integ.inLimiter.Stop(); integ.outLimiter.Stop() })
+
+	req1 := httptest.NewRequest(http.MethodGet, "http://rl-out/", nil)
+	req1.Host = "rl-out"
+	rr1 := httptest.NewRecorder()
+	proxyHandler(rr1, req1)
+	if rr1.Code != http.StatusOK {
+		t.Fatalf("first request got %d", rr1.Code)
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "http://rl-out/", nil)
+	req2.Host = "rl-out"
+	rr2 := httptest.NewRecorder()
+	proxyHandler(rr2, req2)
+	if rr2.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected rate limit rejection, got %d", rr2.Code)
+	}
+	if rr2.Header().Get("Retry-After") == "" {
+		t.Fatal("missing Retry-After header")
+	}
+}
+
 func TestProxyHandlerNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://missing/", nil)
 	req.Host = "missing"


### PR DESCRIPTION
## Summary
- add a regression test to verify Retry-After header for exceeded outer rate limit

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6839fa60fa388326b6067a7bc4b35d89