### PR TITLE
Fix precommit make target from scanning .git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: fmt vet lint test docker precommit
 
-GOFILES := $(shell find . -name '*.go')
+GOFILES := $(shell find . -name '*.go' -not -path './.git/*')
 
 fmt:
 	gofmt -w $(GOFILES)


### PR DESCRIPTION
## Summary
- prevent `make precommit` from scanning `.git`

## Testing
- `go test ./...`
- `make precommit` *(fails: can't load config for golangci-lint)*

------
https://chatgpt.com/codex/tasks/task_e_683abb50917483268d83f34a6e33ff1c