### PR TITLE
Fix GoReleaser workflow token usage

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -22,5 +22,6 @@ jobs:
         with:
           version: latest
           args: release --clean
+          token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set `token` input when invoking the `goreleaser` action

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683b4999c25883269197ed356d4176b3