### PR TITLE
Fix GoReleaser token

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -25,3 +25,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GORELEASER_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- set `GORELEASER_GITHUB_TOKEN` in workflow to avoid missing token error

## Testing
- `make test`
- `make precommit` *(fails: unsupported golangci-lint config version)*

------
https://chatgpt.com/codex/tasks/task_e_683b57fe074c8326bbd2738b0dd2cac7