### PR TITLE
Fix goreleaser asset conflict handling

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,7 @@ release:
   github:
     owner: winhowes
     name: AuthTranslator
+    allow_upload_conflicts: true
 
 builds:
   - id: authtranslator


### PR DESCRIPTION
## Summary
- set `allow_upload_conflicts` so goreleaser does not fail when assets exist

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683bb599d97c8326970a3f3aa3de23c3