### PR TITLE
Align docs with example configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@
 ```bash
 # 1. Run the proxy (Docker)
 docker run --rm -p 8080:8080 \
-  -e SLACK_TOKEN=xxxxx -e SLACK_SIGNING=yyyyy \
-  -v $(pwd)/conf:/conf \
+  -e SLACK_TOKEN=xxxxx \
+  -v $(pwd)/examples:/conf \
   ghcr.io/winhowes/authtranslator:latest \
     -config /conf/config.yaml -allowlist /conf/allowlist.yaml
 
 # 2. Curl through the proxy
-curl -H "Host: slack" -H "X-Auth: <short‑lived>" \
+curl -H "Host: slack" -H "X-Auth: demo-user" \
      http://localhost:8080/api/chat.postMessage
 # alternatively set `X-AT-Int: slack` if you can’t change the Host header
 ```

--- a/docs/docker-compose.md
+++ b/docs/docker-compose.md
@@ -21,7 +21,6 @@ services:
     environment:
       # Secret URIs resolve env: …
       SLACK_TOKEN: "xoxb‑REPLACE"
-      SLACK_SIGNING: "8f2b‑REPLACE"
       # Optional: enable Redis-backed rate limits
     volumes:
       - ./conf:/conf:ro            # bind‑mount configs for hot reload

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,6 @@ Welcome to **AuthTranslator**! In a couple of minutes you’ll have a running pr
 | ------------------------------------------ | ------------------------------------------------------------------------- |
 | **Docker ≥ 24**                            | Easiest way to run the proxy without installing Go.                       |
 | **Slack app token** (`SLACK_TOKEN`)        | Long‑lived token with `chat:write` scope.                                 |
-| **Slack signing secret** (`SLACK_SIGNING`) | Lets the proxy verify inbound Slack requests (if you later use webhooks). |
 | *(Optional)* **Go 1.24+**                  | Only needed if you’d like to run from source.                             |
 
 > **Tip** A personal workspace app is fine for testing.
@@ -21,11 +20,9 @@ Welcome to **AuthTranslator**! In a couple of minutes you’ll have a running pr
 
 ```bash
 export SLACK_TOKEN="xoxb‑123…"
-export SLACK_SIGNING="8f2b…"
-
 docker run --rm -p 8080:8080 \
-  -e SLACK_TOKEN -e SLACK_SIGNING \
-  -v $(pwd)/conf:/conf \
+  -e SLACK_TOKEN \
+  -v $(pwd)/examples:/conf \
   ghcr.io/winhowes/authtranslator:latest \
     -config /conf/config.yaml \
     -allowlist /conf/allowlist.yaml
@@ -67,7 +64,7 @@ go run ./app \
   -allowlist examples/allowlist.yaml
 ```
 
-Make sure `$SLACK_TOKEN` and `$SLACK_SIGNING` are still in your environment.
+Make sure `$SLACK_TOKEN` is still in your environment.
 
 ---
 

--- a/examples/allowlist.yaml
+++ b/examples/allowlist.yaml
@@ -1,9 +1,7 @@
-- integration: example
+- integration: slack
   callers:
-    - id: sample
-      rules:
-        - path: /search
-          methods:
-            GET:
-              query:
-                q: ["example"]
+    - id: demo-user
+      capabilities:
+        - name: post_public_as
+          params:
+            username: AuthTranslator

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,20 +1,19 @@
 integrations:
-  - name: example
-    destination: http://backend.example.com
+  - name: slack
+    destination: https://slack.com/api
     in_rate_limit: 100
-    out_rate_limit: 1000
+    out_rate_limit: 100
     rate_limit_window: 1m
-    max_idle_conns: 100
-    max_idle_conns_per_host: 20
     incoming_auth:
       - type: token
         params:
           secrets:
-            - env:IN_TOKEN
+            - env:SLACK_TOKEN
           header: X-Auth
     outgoing_auth:
       - type: token
         params:
           secrets:
-            - env:OUT_TOKEN
-          header: X-Auth
+            - env:SLACK_TOKEN
+          header: Authorization
+          prefix: "Bearer "

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     environment:
       # Secret URIs resolve env: …
       SLACK_TOKEN: "xoxb-REPLACE"
-      SLACK_SIGNING: "8f2b-REPLACE"
       # Optional: enable Redis-backed rate limits
     volumes:
       - ./conf:/conf:ro            # bind-mount configs for hot reload


### PR DESCRIPTION
## Summary
- switch quick-start docs to mount `examples` folder
- remove Slack signing secret from example setup
- update README curl example for `demo-user`
- revert `conf/` configs to original example content

## Testing
- `make precommit` *(fails: unsupported version of the configuration)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_683bdeab20108326bdc0ff7ae57e1724