### PR TITLE
Improve logging for allowlist failures

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -1037,10 +1037,15 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if len(callers) > 0 {
 		cons, ok := findConstraint(integ, callerID, r.URL.Path, r.Method)
 		if !ok {
+			reason := "no allowlist match"
+			logger.Warn("request blocked", "integration", integ.Name, "caller_id", callerID, "reason", reason)
+			w.Header().Set("X-AT-Error-Reason", reason)
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
-		if !validateRequest(r, cons) {
+		if ok2, reason := validateRequestReason(r, cons); !ok2 {
+			logger.Warn("request failed constraints", "integration", integ.Name, "caller_id", callerID, "reason", reason)
+			w.Header().Set("X-AT-Error-Reason", reason)
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
## Summary
- log and return specific constraint failure reasons
- expose matchFormReason and matchBodyMapReason helpers
- use `X-AT-Error-Reason` header for detailed failure info
- test for missing header reason

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683bf2c3f67c8326a94f5acb55fab30c