### PR TITLE
Add response source headers

### DIFF
--- a/app/allowlist_case_test.go
+++ b/app/allowlist_case_test.go
@@ -43,4 +43,7 @@ func TestAllowlistCaseInsensitive(t *testing.T) {
 	if rr.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr.Code)
 	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -55,6 +55,9 @@ func TestAllowlist(t *testing.T) {
 	if rr2.Code != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", rr2.Code)
 	}
+	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }
 
 func TestSetAllowlistIndexing(t *testing.T) {

--- a/app/integration.go
+++ b/app/integration.go
@@ -179,6 +179,9 @@ func prepareIntegration(i *Integration) error {
 	i.proxy.ModifyResponse = func(resp *http.Response) error {
 		caller := metrics.Caller(resp.Request.Context())
 		metrics.OnResponse(i.Name, caller, resp.Request, resp)
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= 300 {
+			resp.Header.Set("X-AT-Upstream-Error", "true")
+		}
 		return nil
 	}
 

--- a/app/main.go
+++ b/app/main.go
@@ -974,6 +974,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		logger.Warn("no integration configured", "host", host)
 		metrics.IncRequest("unknown")
+		w.Header().Set("X-AT-Upstream-Error", "false")
 		http.Error(w, "Not Found", http.StatusNotFound)
 		return
 	}
@@ -990,6 +991,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			if !p.Authenticate(r.Context(), r, cfg.parsed) {
 				logger.Warn("authentication failed", "host", host, "remote", r.RemoteAddr)
 				metrics.IncAuthFailure(integ.Name)
+				w.Header().Set("X-AT-Upstream-Error", "false")
 				http.Error(w, "Unauthorized", http.StatusUnauthorized)
 				return
 			}
@@ -1016,6 +1018,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Header().Set("Retry-After", strconv.Itoa(secs))
 		}
+		w.Header().Set("X-AT-Upstream-Error", "false")
 		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 		return
 	}
@@ -1029,6 +1032,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Header().Set("Retry-After", strconv.Itoa(secs))
 		}
+		w.Header().Set("X-AT-Upstream-Error", "false")
 		http.Error(w, "Too Many Requests", http.StatusTooManyRequests)
 		return
 	}
@@ -1037,10 +1041,12 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if len(callers) > 0 {
 		cons, ok := findConstraint(integ, callerID, r.URL.Path, r.Method)
 		if !ok {
+			w.Header().Set("X-AT-Upstream-Error", "false")
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
 		if !validateRequest(r, cons) {
+			w.Header().Set("X-AT-Upstream-Error", "false")
 			http.Error(w, "Forbidden", http.StatusForbidden)
 			return
 		}
@@ -1054,6 +1060,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if integ.proxy == nil {
+		w.Header().Set("X-AT-Upstream-Error", "false")
 		http.Error(w, "Bad Gateway", http.StatusBadGateway)
 		return
 	}

--- a/app/main_handlers_test.go
+++ b/app/main_handlers_test.go
@@ -61,6 +61,9 @@ func TestMetricsHandlerUnauthorized(t *testing.T) {
 	if rr.Header().Get("WWW-Authenticate") == "" {
 		t.Fatal("missing WWW-Authenticate header")
 	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }
 
 func TestMetricsHandlerAuthorized(t *testing.T) {

--- a/app/metrics/builtin.go
+++ b/app/metrics/builtin.go
@@ -158,6 +158,7 @@ func Handler(w http.ResponseWriter, r *http.Request, user, pass string) {
 		if !ok || subtle.ConstantTimeCompare([]byte(u), []byte(user)) != 1 ||
 			subtle.ConstantTimeCompare([]byte(p), []byte(pass)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="metrics"`)
+			w.Header().Set("X-AT-Upstream-Error", "false")
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -94,6 +94,9 @@ func TestMetricsHandlerAuth(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for missing creds, got %d", rr.Code)
 	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	req.SetBasicAuth("admin", "wrong")
@@ -101,6 +104,9 @@ func TestMetricsHandlerAuth(t *testing.T) {
 	Handler(rr, req, "admin", "secret")
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401 for bad creds, got %d", rr.Code)
+	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/app/metrics_hook_test.go
+++ b/app/metrics_hook_test.go
@@ -46,6 +46,10 @@ func TestMetricsHooks(t *testing.T) {
 	rr := httptest.NewRecorder()
 	proxyHandler(rr, req)
 
+	if rr.Header().Get("X-AT-Upstream-Error") != "true" {
+		t.Fatal("missing upstream error header")
+	}
+
 	if hp.req != 1 {
 		t.Fatalf("expected request hook 1, got %d", hp.req)
 	}

--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -55,6 +55,9 @@ func TestProxyHandlerPrefersHeader(t *testing.T) {
 	if rr.Code != http.StatusTeapot {
 		t.Fatalf("expected status from header integration, got %d", rr.Code)
 	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "true" {
+		t.Fatal("missing upstream error header")
+	}
 }
 
 func TestProxyHandlerUsesHost(t *testing.T) {
@@ -297,6 +300,9 @@ func TestProxyHandlerRateLimiterUsesIP(t *testing.T) {
 	if rr2.Header().Get("Retry-After") == "" {
 		t.Fatal("missing Retry-After header")
 	}
+	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }
 
 func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
@@ -329,6 +335,9 @@ func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
 	if rr2.Header().Get("Retry-After") == "" {
 		t.Fatal("missing Retry-After header")
 	}
+	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }
 
 func TestProxyHandlerNotFound(t *testing.T) {
@@ -338,6 +347,9 @@ func TestProxyHandlerNotFound(t *testing.T) {
 	proxyHandler(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
 	}
 }
 
@@ -368,6 +380,9 @@ func TestProxyHandlerAuthFailure(t *testing.T) {
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rr.Code)
 	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
+	}
 }
 
 func TestProxyHandlerBadGateway(t *testing.T) {
@@ -391,5 +406,8 @@ func TestProxyHandlerBadGateway(t *testing.T) {
 	proxyHandler(rr, req)
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502, got %d", rr.Code)
+	}
+	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
+		t.Fatal("missing auth error header")
 	}
 }

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -17,6 +17,10 @@ exposed by default but can be disabled with `-enable-metrics=false`. Provide
 **both** `-metrics-user` **and** `-metrics-pass` to require HTTP Basic
 credentials – omitting either one causes the service to exit on startup.
 
+Any non‑2xx response includes an `X-AT-Upstream-Error` header. `true` means
+the error came from the upstream service. `false` indicates AuthTranslator
+generated the response, typically due to authentication or rate limiting.
+
 ---
 
 ## 2  Metrics cheat‑sheet


### PR DESCRIPTION
## Summary
- tag upstream responses with `X-AT-Upstream-Error: true`
- tag AuthTranslator generated errors with `X-AT-Upstream-Error: false`
- document the new header

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683bf2f262b0832680e47b4180be9650