### PR TITLE
Fix findConstraint to honor caller capabilities

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -479,6 +479,9 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 	allowlists.RUnlock()
 
 	if ok {
+		if len(c.Capabilities) > 0 {
+			c = integrationplugins.ExpandCapabilities(i.Name, []CallerConfig{c})[0]
+		}
 		for _, r := range c.Rules {
 			if matchSegments(r.Segments, segments) {
 				if m, ok := r.Methods[method]; ok {
@@ -488,6 +491,9 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 		}
 	}
 	if hasWildcard {
+		if len(wildcard.Capabilities) > 0 {
+			wildcard = integrationplugins.ExpandCapabilities(i.Name, []CallerConfig{wildcard})[0]
+		}
 		for _, r := range wildcard.Rules {
 			if matchSegments(r.Segments, segments) {
 				if m, ok := r.Methods[method]; ok {


### PR DESCRIPTION
## Summary
- check caller capabilities when matching allowlist rules
- test capability-based matching

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683bf9f8bffc8326a943469882711344