### PR TITLE
Strip incoming auth credentials

### DIFF
--- a/app/auth/plugins/basic/basic_test.go
+++ b/app/auth/plugins/basic/basic_test.go
@@ -55,6 +55,10 @@ func TestBasicIncomingAuth(t *testing.T) {
 	if id, ok := p.Identify(r, cfg); !ok || id != "user" {
 		t.Fatalf("unexpected identifier %s", id)
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("Authorization"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestBasicIncomingAuthFail(t *testing.T) {

--- a/app/auth/plugins/basic/incoming.go
+++ b/app/auth/plugins/basic/incoming.go
@@ -91,4 +91,13 @@ func (b *BasicAuth) Identify(r *http.Request, p interface{}) (string, bool) {
 	return parts[0], true
 }
 
+// StripAuth removes the Basic auth header from the request.
+func (b *BasicAuth) StripAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&BasicAuth{}) }

--- a/app/auth/plugins/github_signature/github_signature_test.go
+++ b/app/auth/plugins/github_signature/github_signature_test.go
@@ -33,6 +33,10 @@ func TestGitHubSignatureAuth(t *testing.T) {
 	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("X-Hub-Signature-256"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestGitHubSignatureAuthFail(t *testing.T) {

--- a/app/auth/plugins/github_signature/incoming.go
+++ b/app/auth/plugins/github_signature/incoming.go
@@ -72,4 +72,13 @@ func (g *GitHubSignatureAuth) Authenticate(ctx context.Context, r *http.Request,
 	return false
 }
 
+// StripAuth removes the GitHub signature header from the request.
+func (g *GitHubSignatureAuth) StripAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*githubSigParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&GitHubSignatureAuth{}) }

--- a/app/auth/plugins/google_oidc/google_oidc_test.go
+++ b/app/auth/plugins/google_oidc/google_oidc_test.go
@@ -241,6 +241,10 @@ func TestGoogleOIDCIncomingAuth(t *testing.T) {
 	if id, ok := p.Identify(r, cfg); !ok || id != "user1" {
 		t.Fatalf("unexpected identifier %s", id)
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("Authorization"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestGoogleOIDCIncomingAuthFail(t *testing.T) {

--- a/app/auth/plugins/google_oidc/incoming.go
+++ b/app/auth/plugins/google_oidc/incoming.go
@@ -261,4 +261,13 @@ func (g *GoogleOIDCAuth) Identify(r *http.Request, params interface{}) (string, 
 	return sub, true
 }
 
+// StripAuth removes the Authorization header from the request.
+func (g *GoogleOIDCAuth) StripAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*inParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&GoogleOIDCAuth{}) }

--- a/app/auth/plugins/hmac/hmac_test.go
+++ b/app/auth/plugins/hmac/hmac_test.go
@@ -48,6 +48,10 @@ func TestHMACIncomingAuth(t *testing.T) {
 	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("X-Signature"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestHMACIncomingAuthFail(t *testing.T) {

--- a/app/auth/plugins/hmac/incoming.go
+++ b/app/auth/plugins/hmac/incoming.go
@@ -95,4 +95,13 @@ func (h *HMACSignatureAuth) Authenticate(ctx context.Context, r *http.Request, p
 	return false
 }
 
+// StripAuth removes the signature header from the request.
+func (h *HMACSignatureAuth) StripAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*inParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&HMACSignatureAuth{}) }

--- a/app/auth/plugins/jwt/incoming.go
+++ b/app/auth/plugins/jwt/incoming.go
@@ -197,4 +197,13 @@ func (j *JWTAuth) Identify(r *http.Request, p interface{}) (string, bool) {
 	return sub, true
 }
 
+// StripAuth removes the JWT header from the request.
+func (j *JWTAuth) StripAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&JWTAuth{}) }

--- a/app/auth/plugins/jwt/jwt_test.go
+++ b/app/auth/plugins/jwt/jwt_test.go
@@ -50,6 +50,10 @@ func TestJWTAuth(t *testing.T) {
 	if !ok || id != "user1" {
 		t.Fatalf("unexpected identifier %s", id)
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("Authorization"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestJWTAuthFail(t *testing.T) {

--- a/app/auth/plugins/slack_signature/incoming.go
+++ b/app/auth/plugins/slack_signature/incoming.go
@@ -94,6 +94,16 @@ func (s *SlackSignatureAuth) Authenticate(ctx context.Context, r *http.Request, 
 	return false
 }
 
+// StripAuth removes the Slack signature and timestamp headers from the request.
+func (s *SlackSignatureAuth) StripAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*slackSigParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.SigHeader)
+	r.Header.Del(cfg.TimestampHeader)
+}
+
 func abs(i int64) int64 {
 	if i < 0 {
 		if i == math.MinInt64 {

--- a/app/auth/plugins/slack_signature/slack_signature_test.go
+++ b/app/auth/plugins/slack_signature/slack_signature_test.go
@@ -42,6 +42,13 @@ func TestSlackSignatureAuth(t *testing.T) {
 	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed")
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("X-Slack-Signature"); h != "" {
+		t.Fatalf("expected signature header stripped, got %s", h)
+	}
+	if ts := r.Header.Get("X-Slack-Request-Timestamp"); ts != "" {
+		t.Fatalf("expected timestamp header stripped, got %s", ts)
+	}
 }
 
 func TestSlackSignatureAuthOldTimestamp(t *testing.T) {

--- a/app/auth/plugins/token/incoming.go
+++ b/app/auth/plugins/token/incoming.go
@@ -55,4 +55,13 @@ func (t *TokenAuth) Authenticate(ctx context.Context, r *http.Request, p interfa
 	return false
 }
 
+// StripAuth removes the token header from the request.
+func (t *TokenAuth) StripAuth(r *http.Request, p interface{}) {
+	cfg, ok := p.(*inParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
 func init() { authplugins.RegisterIncoming(&TokenAuth{}) }

--- a/app/auth/plugins/token/token_test.go
+++ b/app/auth/plugins/token/token_test.go
@@ -46,6 +46,10 @@ func TestTokenIncomingPrefix(t *testing.T) {
 	if !p.Authenticate(context.Background(), r, cfg) {
 		t.Fatal("expected authentication to succeed with prefix")
 	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("Authorization"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
 }
 
 func TestTokenIncomingPrefixMismatch(t *testing.T) {

--- a/app/auth/registry.go
+++ b/app/auth/registry.go
@@ -22,6 +22,13 @@ type Identifier interface {
 	Identify(r *http.Request, params interface{}) (string, bool)
 }
 
+// AuthStripper is optionally implemented by incoming auth plugins that wish to
+// remove authentication data from the request after it has been verified.
+// The proxy calls this after calling Identify.
+type AuthStripper interface {
+	StripAuth(r *http.Request, params interface{})
+}
+
 // OutgoingAuthPlugin applies authentication to outbound requests.
 type OutgoingAuthPlugin interface {
 	Name() string

--- a/app/main.go
+++ b/app/main.go
@@ -1001,6 +1001,9 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 					rateKey = id
 				}
 			}
+			if stripper, ok := p.(authplugins.AuthStripper); ok {
+				stripper.StripAuth(r, cfg.parsed)
+			}
 		}
 	}
 

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -73,13 +73,20 @@ Adds the configured token to the `X-Api-Key` header on each request.
    [`app/auth/registry.go`](../app/auth/registry.go):
 
    ```go
-   type IncomingAuthPlugin interface {
-       Name() string
-       ParseParams(map[string]interface{}) (interface{}, error)
-       Authenticate(ctx context.Context, r *http.Request, params interface{}) bool
-       RequiredParams() []string
-       OptionalParams() []string
-   }
+type IncomingAuthPlugin interface {
+    Name() string
+    ParseParams(map[string]interface{}) (interface{}, error)
+    Authenticate(ctx context.Context, r *http.Request, params interface{}) bool
+    RequiredParams() []string
+    OptionalParams() []string
+}
+
+// Plugins can optionally implement AuthStripper to remove credentials from the
+// request once verified.
+
+type AuthStripper interface {
+    StripAuth(r *http.Request, params interface{})
+}
 
    type OutgoingAuthPlugin interface {
        Name() string


### PR DESCRIPTION
## Summary
- strip authentication details after verification
- implement optional AuthStripper interface
- document stripping of auth
- test stripped auth headers

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683c5f4497f4832687ec0994bc6ecde0