### PR TITLE
Fix metrics plugin clearing response body

### DIFF
--- a/app/metrics/body.go
+++ b/app/metrics/body.go
@@ -1,0 +1,23 @@
+package metrics
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+)
+
+// GetResponseBody returns the response body bytes and resets resp.Body so it can
+// be read again. It closes the original body to allow connection reuse.
+func GetResponseBody(resp *http.Response) ([]byte, error) {
+	if resp == nil || resp.Body == nil {
+		return nil, nil
+	}
+	data, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	resp.Body = io.NopCloser(bytes.NewReader(data))
+	resp.ContentLength = int64(len(data))
+	return data, nil
+}

--- a/app/metrics/body_test.go
+++ b/app/metrics/body_test.go
@@ -1,0 +1,33 @@
+package metrics
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestGetResponseBody(t *testing.T) {
+	body := "hello"
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+	data, err := GetResponseBody(resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != body {
+		t.Fatalf("expected body %q, got %q", body, string(data))
+	}
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("unexpected error reading reset body: %v", err)
+	}
+	if string(b) != body {
+		t.Fatalf("expected reset body %q, got %q", body, string(b))
+	}
+}
+
+func TestGetResponseBodyNil(t *testing.T) {
+	if b, err := GetResponseBody(nil); err != nil || b != nil {
+		t.Fatalf("expected nil body, nil err; got %v, %v", b, err)
+	}
+}

--- a/app/metrics/plugins/example/README.md
+++ b/app/metrics/plugins/example/README.md
@@ -7,3 +7,7 @@ usage from the OpenAI API. It is excluded from normal builds with a
 Build or run the proxy with `-tags example` to include this plugin. The
 `WriteProm` hook emits a per-caller `authtranslator_tokens_total` counter which
 shows up in the `/_at_internal/metrics` endpoint.
+
+Because it reads the upstream response body to count tokens, the plugin uses
+`metrics.GetResponseBody` to copy the bytes and reset `resp.Body` before
+returning so the client still receives the full payload.

--- a/app/metrics/plugins/example/plugin.go
+++ b/app/metrics/plugins/example/plugin.go
@@ -22,12 +22,16 @@ func (t *tokenCounter) OnResponse(integ, caller string, r *http.Request, resp *h
 	if integ != "openai" {
 		return
 	}
+	data, err := metrics.GetResponseBody(resp)
+	if err != nil {
+		return
+	}
 	var body struct {
 		Usage struct {
 			TotalTokens int `json:"total_tokens"`
 		} `json:"usage"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+	if err := json.Unmarshal(data, &body); err != nil {
 		return
 	}
 	t.mu.Lock()

--- a/app/metrics/plugins/example/plugin_test.go
+++ b/app/metrics/plugins/example/plugin_test.go
@@ -1,0 +1,38 @@
+//go:build example
+
+package example
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/metrics"
+)
+
+func TestTokenCounter(t *testing.T) {
+	metrics.Reset()
+	tc := &tokenCounter{}
+	metrics.Register(tc)
+
+	body := `{"usage":{"total_tokens":42}}`
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(body))}
+	req, _ := http.NewRequest(http.MethodGet, "/", nil)
+	tc.OnResponse("openai", "caller", req, resp)
+
+	b, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read response body: %v", err)
+	}
+	if string(b) != body {
+		t.Fatalf("expected body %q, got %q", body, string(b))
+	}
+
+	rr := httptest.NewRecorder()
+	metrics.Handler(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil), "", "")
+	if !strings.Contains(rr.Body.String(), `authtranslator_tokens_total{caller="caller"} 42`) {
+		t.Fatalf("token metric missing: %s", rr.Body.String())
+	}
+}

--- a/docs/metrics-plugins.md
+++ b/docs/metrics-plugins.md
@@ -2,7 +2,9 @@
 
 AuthTranslator exposes basic Prometheus metrics out of the box. When you need extra
 counters or histograms, write a small **metrics plugin**. Plugins see every
-request and response but never mutate them.
+request and response but never mutate them. If you need to read the response body,
+use `metrics.GetResponseBody` to copy the bytes and reset `resp.Body` so the proxy
+can still send it upstream.
 
 ---
 
@@ -67,12 +69,16 @@ func (t *tokenCounter) OnResponse(integ, caller string, r *http.Request, resp *h
     if integ != "openai" {
         return
     }
+    data, err := metrics.GetResponseBody(resp)
+    if err != nil {
+        return
+    }
     var body struct {
         Usage struct {
             TotalTokens int `json:"total_tokens"`
         } `json:"usage"`
     }
-    if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+    if err := json.Unmarshal(data, &body); err != nil {
         return
     }
     t.mu.Lock()


### PR DESCRIPTION
## Summary
- keep the example metrics plugin from consuming the response body
- document how to safely read `resp.Body` in a metrics plugin
- mention body handling in the example plugin README
- add tests for the example plugin
- add helper to read response body and use it

## Testing
- `go test ./... -tags example`

------
https://chatgpt.com/codex/tasks/task_e_683d626454148326af10928dfc9225f8