### PR TITLE
Fix metrics reset

### DIFF
--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -16,19 +16,8 @@ func (*promPlugin) OnRequest(string, *http.Request)                          {}
 func (*promPlugin) OnResponse(string, string, *http.Request, *http.Response) {}
 func (*promPlugin) WriteProm(w http.ResponseWriter)                          { fmt.Fprintln(w, "custom_metric 1") }
 
-func resetMetrics() {
-	requestCounts.Init()
-	rateLimitCounts.Init()
-	authFailureCounts.Init()
-	upstreamStatusCounts.Init()
-	durationHistsMu.Lock()
-	durationHists = make(map[string]*histogram)
-	durationHistsMu.Unlock()
-	requestDurations.Init()
-}
-
 func TestMetricsHandlerEmpty(t *testing.T) {
-	resetMetrics()
+	Reset()
 	req := httptest.NewRequest(http.MethodGet, "/_at_internal/metrics", nil)
 	rr := httptest.NewRecorder()
 	Handler(rr, req, "", "")
@@ -42,7 +31,7 @@ func TestMetricsHandlerEmpty(t *testing.T) {
 }
 
 func TestMetricsHandlerOutput(t *testing.T) {
-	resetMetrics()
+	Reset()
 	IncRequest("foo")
 	IncRequest("foo")
 	IncRateLimit("foo")
@@ -94,7 +83,7 @@ func TestMetricsHandlerOutput(t *testing.T) {
 }
 
 func TestMetricsHandlerAuth(t *testing.T) {
-	resetMetrics()
+	Reset()
 	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	rr := httptest.NewRecorder()
 	Handler(rr, req, "admin", "secret")
@@ -136,7 +125,7 @@ func TestCallerContext(t *testing.T) {
 }
 
 func TestWritePromPlugins(t *testing.T) {
-	resetMetrics()
+	Reset()
 	mu.Lock()
 	saved := plugins
 	mu.Unlock()

--- a/app/metrics/plugins/example/plugin.go
+++ b/app/metrics/plugins/example/plugin.go
@@ -52,4 +52,11 @@ func (t *tokenCounter) WriteProm(w http.ResponseWriter) {
 	}
 }
 
+// ResetMetrics clears the in-memory counters. Mainly used in tests.
+func (t *tokenCounter) ResetMetrics() {
+	t.mu.Lock()
+	t.totals = nil
+	t.mu.Unlock()
+}
+
 func init() { metrics.Register(&tokenCounter{}) }

--- a/docs/metrics-plugins.md
+++ b/docs/metrics-plugins.md
@@ -109,3 +109,5 @@ Use the `totals` map to expose custom Prometheus counters or logs as needed.
 their `WriteProm` method, so anything printed here will appear in the
 `/_at_internal/metrics` endpoint. The plugin itself is responsible for storing
 any counters; they live in memory and reset on restart.
+`metrics.Reset()` will also call `ResetMetrics()` on any registered plugin
+that implements the method so tests can start from a clean slate.


### PR DESCRIPTION
## Summary
- ensure metrics.Reset clears expvar maps
- invoke Reset for every metrics test
- call `ResetMetrics` on custom plugins

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683faccb3f188326a20d392d81e4ac1b