### PR TITLE
Add HTTP server timeout flags

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -86,6 +86,8 @@ var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout f
 var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS; disables InsecureSkipVerify")
 var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies (0 to disable)")
 var secretRefresh = flag.Duration("secret-refresh", 0, "refresh interval for cached secrets (0 disables)")
+var readTimeout = flag.Duration("read-timeout", 0, "HTTP server read timeout")
+var writeTimeout = flag.Duration("write-timeout", 0, "HTTP server write timeout")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
 var metricsUser = flag.String("metrics-user", "", "username for metrics endpoint")
@@ -1098,6 +1100,14 @@ func serve(s server, cert, key string) error {
 	}
 }
 
+func newHTTPServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:         addr,
+		ReadTimeout:  *readTimeout,
+		WriteTimeout: *writeTimeout,
+	}
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()
@@ -1133,7 +1143,7 @@ func main() {
 
 	http.HandleFunc("/", proxyHandler)
 
-	srv := &http.Server{Addr: *addr}
+	srv := newHTTPServer(*addr)
 	var h3srv *http3.Server
 
 	go func() {

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -41,6 +41,8 @@ AuthTranslator exposes several command‑line options:
 | `-redis-timeout` | timeout for dialing Redis (default `5s`) |
 | `-max_body_size` | maximum bytes buffered from request bodies; use `0` to disable |
 | `-secret-refresh` | refresh interval for cached secrets; `0` disables expiry |
+| `-read-timeout` | HTTP server read timeout (default `0` - disabled) |
+| `-write-timeout` | HTTP server write timeout (default `0` - disabled) |
 | `-log-level` | log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 | `-log-format` | log output format (`text` or `json`) |
 | `-version` | print the build version and exit |


### PR DESCRIPTION
## Summary
- add `-read-timeout` and `-write-timeout` flags
- wire new flags to the HTTP server via `newHTTPServer`
- document new options in runtime guide
- test flags and server construction in `main_test.go`
- remove README mention per feedback

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fb0c04d2c8326826bf724981ea005