### PR TITLE
Add HTTP server timeout flags

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -86,6 +86,8 @@ var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout f
 var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS; disables InsecureSkipVerify")
 var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies (0 to disable)")
 var secretRefresh = flag.Duration("secret-refresh", 0, "refresh interval for cached secrets (0 disables)")
+var readTimeout = flag.Duration("read-timeout", 0, "HTTP server read timeout")
+var writeTimeout = flag.Duration("write-timeout", 0, "HTTP server write timeout")
 var showVersion = flag.Bool("version", false, "print version and exit")
 var watch = flag.Bool("watch", false, "watch config and allowlist files for changes")
 var metricsUser = flag.String("metrics-user", "", "username for metrics endpoint")
@@ -1098,6 +1100,14 @@ func serve(s server, cert, key string) error {
 	}
 }
 
+func newHTTPServer(addr string) *http.Server {
+	return &http.Server{
+		Addr:         addr,
+		ReadTimeout:  *readTimeout,
+		WriteTimeout: *writeTimeout,
+	}
+}
+
 func main() {
 	flag.Usage = usage
 	flag.Parse()
@@ -1133,7 +1143,7 @@ func main() {
 
 	http.HandleFunc("/", proxyHandler)
 
-	srv := &http.Server{Addr: *addr}
+	srv := newHTTPServer(*addr)
 	var h3srv *http3.Server
 
 	go func() {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -80,6 +80,40 @@ func TestHTTP3FlagSet(t *testing.T) {
 	}
 }
 
+func TestReadTimeoutFlagDefault(t *testing.T) {
+	if *readTimeout != 0 {
+		t.Fatalf("expected default 0, got %v", *readTimeout)
+	}
+}
+
+func TestReadTimeoutFlagSet(t *testing.T) {
+	old := *readTimeout
+	t.Cleanup(func() { flag.Set("read-timeout", old.String()) })
+	if err := flag.Set("read-timeout", "5s"); err != nil {
+		t.Fatal(err)
+	}
+	if *readTimeout != 5*time.Second {
+		t.Fatalf("expected 5s, got %v", *readTimeout)
+	}
+}
+
+func TestWriteTimeoutFlagDefault(t *testing.T) {
+	if *writeTimeout != 0 {
+		t.Fatalf("expected default 0, got %v", *writeTimeout)
+	}
+}
+
+func TestWriteTimeoutFlagSet(t *testing.T) {
+	old := *writeTimeout
+	t.Cleanup(func() { flag.Set("write-timeout", old.String()) })
+	if err := flag.Set("write-timeout", "6s"); err != nil {
+		t.Fatal(err)
+	}
+	if *writeTimeout != 6*time.Second {
+		t.Fatalf("expected 6s, got %v", *writeTimeout)
+	}
+}
+
 type stubServer struct{ tls bool }
 
 func (s *stubServer) ListenAndServe() error                    { return nil }
@@ -129,6 +163,42 @@ func TestServeNoTLS(t *testing.T) {
 	}
 	if srv.tls {
 		t.Fatal("unexpected TLS start")
+	}
+}
+
+func TestNewHTTPServerTimeouts(t *testing.T) {
+	oldR := *readTimeout
+	oldW := *writeTimeout
+	t.Cleanup(func() {
+		flag.Set("read-timeout", oldR.String())
+		flag.Set("write-timeout", oldW.String())
+	})
+	flag.Set("read-timeout", "2s")
+	flag.Set("write-timeout", "3s")
+	srv := newHTTPServer("localhost:0")
+	if srv.ReadTimeout != 2*time.Second {
+		t.Fatalf("expected 2s read timeout, got %v", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 3*time.Second {
+		t.Fatalf("expected 3s write timeout, got %v", srv.WriteTimeout)
+	}
+}
+
+func TestNewHTTPServerDefaultTimeouts(t *testing.T) {
+	oldR := *readTimeout
+	oldW := *writeTimeout
+	t.Cleanup(func() {
+		flag.Set("read-timeout", oldR.String())
+		flag.Set("write-timeout", oldW.String())
+	})
+	flag.Set("read-timeout", "0")
+	flag.Set("write-timeout", "0")
+	srv := newHTTPServer("localhost:0")
+	if srv.ReadTimeout != 0 {
+		t.Fatalf("expected 0 read timeout, got %v", srv.ReadTimeout)
+	}
+	if srv.WriteTimeout != 0 {
+		t.Fatalf("expected 0 write timeout, got %v", srv.WriteTimeout)
 	}
 }
 

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -41,6 +41,8 @@ AuthTranslator exposes several command‑line options:
 | `-redis-timeout` | timeout for dialing Redis (default `5s`) |
 | `-max_body_size` | maximum bytes buffered from request bodies; use `0` to disable |
 | `-secret-refresh` | refresh interval for cached secrets; `0` disables expiry |
+| `-read-timeout` | HTTP server read timeout (default `0` - disabled) |
+| `-write-timeout` | HTTP server write timeout (default `0` - disabled) |
 | `-log-level` | log verbosity (`DEBUG`, `INFO`, `WARN`, `ERROR`) |
 | `-log-format` | log output format (`text` or `json`) |
 | `-version` | print the build version and exit |


### PR DESCRIPTION
## Summary
- add `-read-timeout` and `-write-timeout` flags
- wire new flags to the HTTP server
- document new options in runtime guide
- test flags and server construction in `main_test.go`
- run `go fmt ./...`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_683fb0c04d2c8326826bf724981ea005