### PR TITLE
Fix HTTP/3 docs

### DIFF
--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -48,7 +48,7 @@ AuthTranslator exposes several command‑line options:
 | `-version` | print the build version and exit |
 | `-watch` | automatically reload when config or allowlist files change |
 | `-enable-metrics` | expose the `/_at_internal/metrics` endpoint (default `true`) |
-| `-enable-http3` | serve HTTP/3 in addition to HTTP/1 and HTTP/2 |
+| `-enable-http3` | serve HTTP/3 in addition to HTTP/1 and HTTP/2 (requires `-tls-cert` and `-tls-key`) |
 | `-metrics-user` | username required to access `/_at_internal/metrics` (must be used with `-metrics-pass`) |
 | `-metrics-pass` | password required to access `/_at_internal/metrics` (must be used with `-metrics-user`) |
 


### PR DESCRIPTION
## Summary
- clarify that enabling HTTP/3 also needs TLS certs in service flags docs

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fda9626088326adb31574d03d4701