### PR TITLE
Cross-link docs to Helm guide

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,6 +85,6 @@ AuthTranslator is extensible via three types of plugins:
 
 * Dive into [Auth Plugins](auth-plugins.md) to wire up other services.
 * Add rate‑limits with the [Rate‑Limiting](rate-limiting.md) guide.
-* Ship to Kubernetes via the [Helm chart](../charts/authtranslator).
+* Ship to Kubernetes via the [Helm guide](helm.md).
 
 Happy translating! 🎉


### PR DESCRIPTION
## Summary
- tweak docs to link the Helm guide from Getting Started

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fdad577508326aa20a4b9126fd48d