### PR TITLE
Update CI workflow with golangci-lint action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,13 +26,12 @@ jobs:
         run: go mod download
       - name: Vet code
         run: go vet ./...
-      - name: Lint (optional)
-        run: |
-          if command -v golangci-lint >/dev/null 2>&1; then
-            golangci-lint run
-          else
-            echo "golangci-lint not installed, skipping"
-          fi
+      - name: Install golangci-lint
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: v1.55.2
+      - name: Lint
+        run: golangci-lint run
       - name: Check formatting
         run: test -z "$(gofmt -l .)"
       - name: Run tests with coverage


### PR DESCRIPTION
## Summary
- add golangci-lint action to CI workflow
- simplify lint step to run golangci-lint directly

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683fded5a0a88326aeead69c327a7070