### PR TITLE
Fix Slack base URL in docs

### DIFF
--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -26,7 +26,7 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | `openai` | `https://api.openai.com` | `token` |
 | `sendgrid` | `https://api.sendgrid.com` | `token` |
 | `servicenow` | `https://api.servicenow.com` | `token` |
-| `slack` | `https://slack.com/api` | `token` |
+| `slack` | `https://slack.com/` | `token` |
 | `stripe` | `https://api.stripe.com` | `token` |
 | `trufflehog` | `https://trufflehog.cloud/api` | `token` |
 | `twilio` | `https://api.twilio.com` | `basic` |


### PR DESCRIPTION
## Summary
- correct Slack integration base URL

## Testing
- `make precommit` *(fails: unsupported golangci-lint configuration)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fe0c81ae48326a8e075adfd50a4be