### PR TITLE
Fix capability docs

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -30,7 +30,7 @@ If no matching caller key exists – or a matched caller fails rule constraints 
 
 | Style              | When to use                                                    | YAML field                          |
 | ------------------ | -------------------------------------------------------------- | ----------------------------------- |
-| **Capabilities**   | You want a friendly, reusable label ("post public Slack msg"). | `capabilities:` *(list of strings)* |
+| **Capabilities**   | You want a friendly, reusable label ("post public Slack msg"). | `capabilities:` *(list of objects)* |
 | **Granular rules** | You need fine‑grained filters (path, query, header, body).     | `rules:` *(list of Rule objects)*   |
 
 You can mix both—capabilities first, fall back to granular.
@@ -49,8 +49,10 @@ Look for a `capabilities.go` file under `app/integrations/plugins/<integration>/
 - integration: slack
   callers:
     - id: bot-123
-      capabilities: [post_public_as]
+      capabilities:
+        - name: post_public_as
 ```
+Each capability item contains a `name` and optional `params` map.
 
 > **Discovering capabilities** Run the CLI helper:
 >

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,7 +90,8 @@ Two ways to authorise a caller:
   callers:
     - id: demo-user
       # easiest: assign a capability
-      capabilities: [post_public_as]
+      capabilities:
+        - name: post_public_as
 
     - id: service‑42
       # granular example
@@ -126,7 +127,7 @@ Regular expressions are not supported.
 
 | Field          | Type       | Notes                                                   |
 | -------------- | ---------- | ------------------------------------------------------- |
-| `capabilities` | `[]string` | Shortcut labels → expand to rules.                      |
+| `capabilities` | `[]Capability` | Each item has `name` and optional `params`; expands to rules. |
 | `rules`        | `[]Rule`   | Evaluated in order; first match authorises the request. |
 
 #### `Rule`


### PR DESCRIPTION
## Summary
- correct allowlist documentation to reflect capability objects
- fix configuration guide examples

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683fe2540f9883268b9d5191cdb3887b