### PR TITLE
Fix config parsing in integrations CLI

### DIFF
--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"flag"
 	"fmt"
 	"os"
@@ -162,7 +163,9 @@ func readConfig() ([]plugins.Integration, error) {
 	var cfg struct {
 		Integrations []plugins.Integration `yaml:"integrations"`
 	}
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(&cfg); err != nil {
 		return nil, err
 	}
 	return cfg.Integrations, nil

--- a/cmd/integrations/main_test.go
+++ b/cmd/integrations/main_test.go
@@ -151,6 +151,18 @@ func TestReadConfigInvalidYAML(t *testing.T) {
 	}
 }
 
+func TestReadConfigUnknownField(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "cfg.yaml")
+	os.WriteFile(cfg, []byte("{foo: 1}"), 0644)
+	old := *file
+	*file = cfg
+	t.Cleanup(func() { *file = old })
+	if _, err := readConfig(); err == nil {
+		t.Fatalf("expected error for unknown field")
+	}
+}
+
 func TestReadConfigError(t *testing.T) {
 	dir := t.TempDir()
 	cfg := filepath.Join(dir, "cfg.yaml")


### PR DESCRIPTION
## Summary
- ensure integrations CLI rejects unknown fields
- test for unknown field error

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fe0beedbc8326b80744725cd9bad6