### PR TITLE
Fix allowlist docs syntax

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -12,7 +12,7 @@ Unknown top‑level keys cause a validation error.
 - integration: <integration-name>
   callers:
     - id: <callerID>
-      [capabilities: [ ... ] | rules: [ ... ]]
+      [capabilities: [{ name: <capability> }] | rules: [ ... ]]
 ```
 
 ---

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -62,10 +62,11 @@ config: |
             prefix: "Bearer "
 
 allowlist: |
-  - integration: slack
-    callers:
-      - id: demo
-        capabilities: [post_public_as]
+    - integration: slack
+      callers:
+        - id: demo
+          capabilities:
+            - name: post_public_as
 
 ```
 


### PR DESCRIPTION
## Summary
- update docs/allowlist-config example to show object syntax
- fix Helm values example to use capability object

## Testing
- `make precommit` *(fails: can't load config for golangci-lint)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fe3d4c30c8326ac051b7675b3bb04