### PR TITLE
Add remote config sources

### DIFF
--- a/app/allowlist_file_test.go
+++ b/app/allowlist_file_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 )
@@ -62,5 +64,20 @@ func TestLoadAllowlistsEmptyFile(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected zero entries, got %d", len(entries))
+	}
+}
+
+func TestLoadAllowlistsURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`[{"integration":"test","callers":[]}]`))
+	}))
+	defer srv.Close()
+
+	entries, err := loadAllowlists(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(entries) != 1 || entries[0].Integration != "test" {
+		t.Fatalf("unexpected entries %+v", entries)
 	}
 }

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -79,5 +81,20 @@ func TestLoadConfigExample(t *testing.T) {
 	}
 	if len(cfg.Integrations) == 0 {
 		t.Fatal("expected at least one integration in example config")
+	}
+}
+
+func TestLoadConfigURL(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"integrations":[{"name":"remote","destination":"http://ex"}]}`))
+	}))
+	defer srv.Close()
+
+	cfg, err := loadConfig(srv.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Integrations) != 1 || cfg.Integrations[0].Name != "remote" {
+		t.Fatalf("unexpected config %+v", cfg)
 	}
 }

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -32,7 +32,9 @@ AuthTranslator exposes several command‑line options:
 | ---- | ----------- |
 | `-addr` | listen address (default `:8080`) |
 | `-config` | path to the configuration file (`config.yaml` by default) |
+| `-config-url` | URL for a remote configuration file |
 | `-allowlist` | path to the allowlist file (`allowlist.yaml` by default) |
+| `-allowlist-url` | URL for a remote allowlist file |
 | `-disable_x_at_int` | ignore the `X-AT-Int` header |
 | `-x_at_int_host` | only respect `X-AT-Int` when this host is requested |
 | `-tls-cert` and `-tls-key` | TLS certificate and key to serve HTTPS |


### PR DESCRIPTION
## Summary
- support configuration from remote URLs
- add `-config-url` and `-allowlist-url` flags
- skip file watching for remote configs
- document new flags
- test loading configs and allowlists over HTTP

## Testing
- `make precommit` *(fails: can't load golangci-lint config)*
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fe2fa5cd4832683330c183ab3f94c