### PR TITLE
Handle empty config in integrations CLI

### DIFF
--- a/cmd/integrations/main.go
+++ b/cmd/integrations/main.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"bytes"
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -166,6 +168,9 @@ func readConfig() ([]plugins.Integration, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
 	if err := dec.Decode(&cfg); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	return cfg.Integrations, nil

--- a/cmd/integrations/main_test.go
+++ b/cmd/integrations/main_test.go
@@ -139,6 +139,24 @@ func TestReadConfigNonexistent(t *testing.T) {
 	}
 }
 
+func TestReadConfigEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	cfg := filepath.Join(dir, "cfg.yaml")
+	if err := os.WriteFile(cfg, nil, 0644); err != nil {
+		t.Fatalf("setup write error: %v", err)
+	}
+	old := *file
+	*file = cfg
+	t.Cleanup(func() { *file = old })
+	list, err := readConfig()
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %v", list)
+	}
+}
+
 func TestReadConfigInvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	cfg := filepath.Join(dir, "cfg.yaml")


### PR DESCRIPTION
## Summary
- tolerate empty config files when parsing integrations config
- test empty file behavior

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_683fe43cf80c8326b723ec7aee6952c3