### PR TITLE
Add tests for matchBodyMapReason

### DIFF
--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -198,3 +198,36 @@ func TestToFloatVariousTypes(t *testing.T) {
 		}
 	}
 }
+
+func TestMatchBodyMapReasonSuccess(t *testing.T) {
+	data := map[string]interface{}{
+		"a":   "b",
+		"arr": []interface{}{float64(1), float64(2)},
+	}
+	rule := map[string]interface{}{
+		"a":   "b",
+		"arr": []interface{}{float64(1)},
+	}
+	ok, reason := matchBodyMapReason(data, rule)
+	if !ok || reason != "" {
+		t.Fatalf("expected success, got ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestMatchBodyMapReasonMissingField(t *testing.T) {
+	data := map[string]interface{}{"a": "b"}
+	rule := map[string]interface{}{"a": "b", "c": "d"}
+	ok, reason := matchBodyMapReason(data, rule)
+	if ok || reason != "missing body field c" {
+		t.Fatalf("expected missing field failure, got ok=%v reason=%q", ok, reason)
+	}
+}
+
+func TestMatchBodyMapReasonNestedMismatch(t *testing.T) {
+	data := map[string]interface{}{"a": map[string]interface{}{"b": "c"}}
+	rule := map[string]interface{}{"a": map[string]interface{}{"b": "d"}}
+	ok, reason := matchBodyMapReason(data, rule)
+	if ok || reason != "body field a.b value mismatch" {
+		t.Fatalf("expected mismatch failure, got ok=%v reason=%q", ok, reason)
+	}
+}


### PR DESCRIPTION
## Summary
- increase coverage for allowlist matching helpers

## Testing
- `go test ./... -count=1`
- `go test ./... -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_683fe6c042a8832680f0749e96be2345