### PR TITLE
Fix JWT plugin docs

### DIFF
--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -44,9 +44,10 @@ AuthTranslator’s behaviour is extended by **plugins** – small Go packages th
 incoming_auth:
   - type: jwt
     params:
+      secrets:
+        - env:JWT_KEY
       issuer:   https://auth.example.com
       audience: slack-proxy
-      jwks_url: https://auth.example.com/.well-known/jwks.json
 ```
 
 *Verifies* the JWT’s signature and sets `callerID` to the token's `sub` claim.


### PR DESCRIPTION
## Summary
- correct inbound JWT example to match code

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fe653abe8832694d13ca05b4717e1