### PR TITLE
Add PagerDuty integration plugin

### DIFF
--- a/app/integrations/plugins/pagerduty/capabilities.go
+++ b/app/integrations/plugins/pagerduty/capabilities.go
@@ -1,0 +1,19 @@
+package pagerduty
+
+import integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+
+func init() {
+	integrationplugins.RegisterCapability("pagerduty", "trigger_incident", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/incidents", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("pagerduty", "resolve_incident", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/incidents/*", Methods: map[string]integrationplugins.RequestConstraint{"PUT": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrations/plugins/pagerduty/pagerduty_test.go
+++ b/app/integrations/plugins/pagerduty/pagerduty_test.go
@@ -1,0 +1,45 @@
+package pagerduty_test
+
+import (
+	"testing"
+
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/pagerduty"
+)
+
+func TestPagerDutyCapabilities(t *testing.T) {
+	caps := integrationplugins.CapabilitiesFor("pagerduty")
+	if len(caps) != 2 {
+		t.Fatalf("expected 2 capabilities, got %d", len(caps))
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		method string
+	}{
+		{"trigger_incident", "/incidents", "POST"},
+		{"resolve_incident", "/incidents/*", "PUT"},
+	}
+
+	for _, tt := range tests {
+		spec, ok := caps[tt.name]
+		if !ok {
+			t.Fatalf("%s not registered", tt.name)
+		}
+		rules, err := spec.Generate(nil)
+		if err != nil {
+			t.Fatalf("generate failed: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("expected 1 rule for %s", tt.name)
+		}
+		r := rules[0]
+		if r.Path != tt.path {
+			t.Errorf("%s path mismatch: %s", tt.name, r.Path)
+		}
+		if _, ok := r.Methods[tt.method]; !ok {
+			t.Errorf("%s missing method %s", tt.name, tt.method)
+		}
+	}
+}

--- a/app/integrations/plugins/plugins.go
+++ b/app/integrations/plugins/plugins.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/monday"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/okta"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/openai"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/pagerduty"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/sendgrid"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/servicenow"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/slack"

--- a/app/integrations/plugins/plugins_test.go
+++ b/app/integrations/plugins/plugins_test.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/monday"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/okta"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/openai"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/pagerduty"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/sendgrid"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/servicenow"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/stripe"
@@ -68,6 +69,10 @@ func TestPluginCapabilities(t *testing.T) {
 			{"chat_completion", "/v1/chat/completions", "POST", nil},
 			{"list_models", "/v1/models", "GET", nil},
 			{"create_embedding", "/v1/embeddings", "POST", nil},
+		},
+		"pagerduty": {
+			{"trigger_incident", "/incidents", "POST", nil},
+			{"resolve_incident", "/incidents/*", "PUT", nil},
 		},
 		"sendgrid": {
 			{"send_email", "/v3/mail/send", "POST", nil},

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -30,6 +30,7 @@ func TestBuilders(t *testing.T) {
 		{"twilio", []string{"-name", "tw", "-token", "tok"}, Twilio("tw", "tok")},
 		{"workday", []string{"-name", "wd", "-domain", "work.example.com", "-token", "tok"}, Workday("wd", "work.example.com", "tok")},
 		{"openai", []string{"-name", "oa", "-token", "tok"}, OpenAI("oa", "tok")},
+		{"pagerduty", []string{"-name", "pd", "-token", "tok"}, PagerDuty("pd", "tok")},
 		{"zendesk", []string{"-name", "zd", "-token", "tok"}, Zendesk("zd", "tok")},
 	}
 
@@ -73,6 +74,7 @@ func TestBuilderErrors(t *testing.T) {
 		{"stripe", []string{}},
 		{"trufflehog", []string{}},
 		{"zendesk", []string{}},
+		{"pagerduty", []string{}},
 	}
 	for _, tt := range tests {
 		b := Get(tt.name)
@@ -94,7 +96,7 @@ func TestBuilderErrors(t *testing.T) {
 func TestBuilderParseError(t *testing.T) {
 	names := []string{
 		"asana", "confluence", "ghe", "github", "gitlab", "jira",
-		"linear", "monday", "okta", "openai", "sendgrid", "servicenow",
+		"linear", "monday", "okta", "openai", "pagerduty", "sendgrid", "servicenow",
 		"slack", "stripe", "trufflehog", "twilio", "workday", "zendesk",
 	}
 	for _, name := range names {

--- a/cmd/integrations/plugins/pagerduty.go
+++ b/cmd/integrations/plugins/pagerduty.go
@@ -1,0 +1,39 @@
+package plugins
+
+import (
+	"flag"
+	"fmt"
+)
+
+// PagerDuty returns an Integration configured for the PagerDuty API.
+func PagerDuty(name, tokenRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.pagerduty.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type: "token",
+			Params: map[string]interface{}{
+				"secrets": []string{tokenRef},
+				"header":  "Authorization",
+				"prefix":  "Token token=",
+			},
+		}},
+	}
+}
+
+func init() { Register("pagerduty", pagerdutyBuilder) }
+
+func pagerdutyBuilder(args []string) (Integration, error) {
+	fs := flag.NewFlagSet("pagerduty", flag.ContinueOnError)
+	name := fs.String("name", "pagerduty", "integration name")
+	token := fs.String("token", "", "secret reference for API token")
+	if err := fs.Parse(args); err != nil {
+		return Integration{}, err
+	}
+	if *token == "" {
+		return Integration{}, fmt.Errorf("-token is required")
+	}
+	return PagerDuty(*name, *token), nil
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -36,6 +36,8 @@ Run `go run ./cmd/allowlist list` to list capabilities from your build. For quic
 | openai | chat_completion | – |
 | openai | create_embedding | – |
 | openai | list_models | – |
+| pagerduty | trigger_incident | – |
+| pagerduty | resolve_incident | – |
 | sendgrid | manage_contacts | – |
 | sendgrid | send_email | – |
 | sendgrid | update_template | – |

--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -24,6 +24,7 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | `monday` | `https://api.monday.com/v2` | `token` |
 | `okta` | `https://<domain>/api/v1` | `token` |
 | `openai` | `https://api.openai.com` | `token` |
+| `pagerduty` | `https://api.pagerduty.com` | `token` |
 | `sendgrid` | `https://api.sendgrid.com` | `token` |
 | `servicenow` | `https://api.servicenow.com` | `token` |
 | `slack` | `https://slack.com/` | `token` |


### PR DESCRIPTION
## Summary
- add PagerDuty integration builder
- register PagerDuty capabilities
- test PagerDuty integration and builder
- document PagerDuty in integrations and capabilities tables

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683fe7758f5c8326b3516b5f21c11fc8