### PR TITLE
Fix getting-started log snippet

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,11 +30,7 @@ docker run --rm -p 8080:8080 \
 `config.yaml` defines which integrations are available, while
 `allowlist.yaml` controls which callers may use them.
 
-You should see a log line like:
-
-```text
-INFO  authtranslator started  addr=0.0.0.0:8080 integrations=1
-```
+When the service starts it prints its version and log level to standard output.
 
 ---
 


### PR DESCRIPTION
## Summary
- correct startup log section in Getting Started guide

## Testing
- `make precommit` *(fails: unsupported golangci-lint version)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_683febb558d08326842995ca097f5102