### PR TITLE
Fix docs cross-link

### DIFF
--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -54,7 +54,7 @@ Look for a `capabilities.go` file under `app/integrations/plugins/<integration>/
 ```
 Each capability item contains a `name` and optional `params` map.
 
-> **Discovering capabilities** Run the CLI helper:
+> **Discovering capabilities** Run the CLI helper (see [Command-Line Helpers](cli.md)):
 >
 > ```bash
 > go run ./cmd/allowlist list


### PR DESCRIPTION
## Summary
- link the CLI docs from the allowlist config guide

## Testing
- `make precommit` *(fails: unsupported version of the configuration)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68408f1174588326a619a6dbedce6bfe