### PR TITLE
Fix Helm docs

### DIFF
--- a/docs/helm.md
+++ b/docs/helm.md
@@ -33,6 +33,7 @@ This:
 | `image.pullPolicy` | `IfNotPresent`                    | Image pull policy.                                                 |
 | `redisAddress`     | `""`                              | Address passed to `-redis-addr` – either `host:port` or a `redis://`/`rediss://` URL. |
 | `redisCA`          | `""`                              | CA file verifying Redis TLS passed to `-redis-ca`. |
+| `secretRefresh`    | `""`                              | Value passed to `-secret-refresh`. |
 | `resources`        | *(object)*                        | Pod resource requests/limits. |
 | `imagePullSecrets` | `[]`                              | Names of image pull secrets. |
 | `serviceAccountName` | `""`                            | Pod service account name. |


### PR DESCRIPTION
## Summary
- document `secretRefresh` option in helm docs

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684090e5fc7883268f6bff27eebfcb8a