### PR TITLE
Fix allowlist CLI param parsing

### DIFF
--- a/cmd/allowlist/main.go
+++ b/cmd/allowlist/main.go
@@ -67,9 +67,15 @@ func addEntry(args []string) {
 	if *paramList != "" {
 		params = make(map[string]interface{})
 		for _, kv := range strings.Split(*paramList, ",") {
+			kv = strings.TrimSpace(kv)
+			if kv == "" {
+				continue
+			}
 			parts := strings.SplitN(kv, "=", 2)
 			if len(parts) == 2 {
-				params[parts[0]] = parts[1]
+				k := strings.TrimSpace(parts[0])
+				v := strings.TrimSpace(parts[1])
+				params[k] = v
 			}
 		}
 	}

--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -370,6 +370,30 @@ func TestAddEntryDuplicateCapability(t *testing.T) {
 	}
 }
 
+func TestAddEntryParamTrim(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "allow.yaml")
+
+	old := *file
+	*file = path
+	t.Cleanup(func() { *file = old })
+
+	addEntry([]string{"-integration", "foo", "-caller", "u1", "-capability", "cap", "-params", "k=v1, bar = baz "})
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed reading file: %v", err)
+	}
+	var entries []plugins.AllowlistEntry
+	if err := yaml.Unmarshal(data, &entries); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	params := entries[0].Callers[0].Capabilities[0].Params
+	if params["k"] != "v1" || params["bar"] != "baz" {
+		t.Fatalf("params not trimmed: %#v", params)
+	}
+}
+
 func TestAddEntryMissingArgs(t *testing.T) {
 	tmpDir := t.TempDir()
 	path := filepath.Join(tmpDir, "allow.yaml")


### PR DESCRIPTION
## Summary
- trim whitespace when parsing capability params in allowlist CLI
- test param trimming behaviour

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68408e5730988326bcd16efccde7303a