### PR TITLE
Update observability docs

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -34,6 +34,8 @@ generated the response, typically due to authentication or rate limiting.
 | `authtranslator_request_duration_seconds` | histogram | `integration`         | Histogram of upstream request latency.           |
 | `authtranslator_rate_limit_events_total`  | counter   | `integration`         | Incremented when a request is rejected with 429. |
 | `authtranslator_auth_failures_total`      | counter   | `integration`         | Authentication plugin failures.                  |
+| `authtranslator_last_reload`             | gauge     | –
+| Timestamp of the most recent configuration reload. |
 
 Missing a metric? Write a small **metrics plugin** to hook into requests and responses or open a PR—new counters are easy to wire in. `WriteProm` calls every registered plugin's own `WriteProm` method so any custom counters you output will appear alongside the built‑in ones. Plugins must manage their own state (typically in memory). See [Metrics Plugins](metrics-plugins.md) for a primer.
 


### PR DESCRIPTION
## Summary
- document `authtranslator_last_reload` metric in observability guide

## Testing
- `go test ./...` *(fails: TestRateLimiterRedisFallback)*

------
https://chatgpt.com/codex/tasks/task_e_68409bba7b788326bcabb3de5b808add