### PR TITLE
Improve error clarity

### DIFF
--- a/app/main_handlers_test.go
+++ b/app/main_handlers_test.go
@@ -64,6 +64,9 @@ func TestMetricsHandlerUnauthorized(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
+	}
 }
 
 func TestMetricsHandlerAuthorized(t *testing.T) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -250,7 +250,7 @@ func TestOpenSourceHTTPStatus(t *testing.T) {
 		rc.Close()
 		t.Fatal("expected error")
 	}
-	want := "remote fetch: 418 I'm a teapot"
+	want := fmt.Sprintf("remote fetch %s: 418 I'm a teapot", srv.URL)
 	if err.Error() != want {
 		t.Fatalf("unexpected error %v", err)
 	}

--- a/app/metrics/builtin.go
+++ b/app/metrics/builtin.go
@@ -166,7 +166,8 @@ func Handler(w http.ResponseWriter, r *http.Request, user, pass string) {
 			subtle.ConstantTimeCompare([]byte(p), []byte(pass)) != 1 {
 			w.Header().Set("WWW-Authenticate", `Basic realm="metrics"`)
 			w.Header().Set("X-AT-Upstream-Error", "false")
-			http.Error(w, "Unauthorized", http.StatusUnauthorized)
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			http.Error(w, "Unauthorized: invalid metrics credentials", http.StatusUnauthorized)
 			return
 		}
 	}

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -93,6 +93,9 @@ func TestMetricsHandlerAuth(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
+	}
 
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)
 	req.SetBasicAuth("admin", "wrong")
@@ -103,6 +106,9 @@ func TestMetricsHandlerAuth(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
 	}
 
 	req = httptest.NewRequest(http.MethodGet, "/metrics", nil)

--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -352,6 +352,9 @@ func TestProxyHandlerNotFound(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
+	}
 }
 
 func TestProxyHandlerAuthFailure(t *testing.T) {
@@ -384,6 +387,9 @@ func TestProxyHandlerAuthFailure(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
+	}
 }
 
 func TestProxyHandlerBadGateway(t *testing.T) {
@@ -410,6 +416,9 @@ func TestProxyHandlerBadGateway(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
+		t.Fatalf("unexpected content type %s", ct)
 	}
 }
 


### PR DESCRIPTION
## Summary
- expand HTTP handler error messages
- clarify metrics auth error
- include source URL in openSource errors
- set Content-Type on all text error responses
- update tests for new headers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840b43ef40c8326885900f5ecd98ab2