### PR TITLE
Add error reason header

### DIFF
--- a/app/allowlist_case_test.go
+++ b/app/allowlist_case_test.go
@@ -46,4 +46,7 @@ func TestAllowlistCaseInsensitive(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if rr.Header().Get("X-AT-Error-Reason") == "" {
+		t.Fatal("missing X-AT-Error-Reason header")
+	}
 }

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -61,6 +61,9 @@ func TestAllowlist(t *testing.T) {
 	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if rr2.Header().Get("X-AT-Error-Reason") == "" {
+		t.Fatal("missing X-AT-Error-Reason header")
+	}
 }
 
 func TestSetAllowlistIndexing(t *testing.T) {

--- a/app/main.go
+++ b/app/main.go
@@ -1007,6 +1007,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		logger.Warn("no integration configured", "host", host)
 		metrics.IncRequest("unknown")
 		w.Header().Set("X-AT-Upstream-Error", "false")
+		w.Header().Set("X-AT-Error-Reason", "integration not found")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		http.Error(w, fmt.Sprintf("integration for host %s not found", host), http.StatusNotFound)
 		return
@@ -1025,6 +1026,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 				logger.Warn("authentication failed", "host", host, "remote", r.RemoteAddr)
 				metrics.IncAuthFailure(integ.Name)
 				w.Header().Set("X-AT-Upstream-Error", "false")
+				w.Header().Set("X-AT-Error-Reason", "authentication failed")
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 				http.Error(w, fmt.Sprintf("Unauthorized: authentication failed for integration %s", integ.Name), http.StatusUnauthorized)
 				return
@@ -1056,6 +1058,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", strconv.Itoa(secs))
 		}
 		w.Header().Set("X-AT-Upstream-Error", "false")
+		w.Header().Set("X-AT-Error-Reason", "caller rate limited")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		http.Error(w, fmt.Sprintf("Too Many Requests: caller %s exceeded rate limit", rateKey), http.StatusTooManyRequests)
 		return
@@ -1071,6 +1074,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Retry-After", strconv.Itoa(secs))
 		}
 		w.Header().Set("X-AT-Upstream-Error", "false")
+		w.Header().Set("X-AT-Error-Reason", "integration rate limited")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		http.Error(w, fmt.Sprintf("Too Many Requests: host %s exceeded rate limit", host), http.StatusTooManyRequests)
 		return
@@ -1107,6 +1111,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 
 	if integ.proxy == nil {
 		w.Header().Set("X-AT-Upstream-Error", "false")
+		w.Header().Set("X-AT-Error-Reason", "no proxy configured")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
 		http.Error(w, fmt.Sprintf("Bad Gateway: no proxy configured for integration %s", integ.Name), http.StatusBadGateway)
 		return

--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -304,6 +304,9 @@ func TestProxyHandlerRateLimiterUsesIP(t *testing.T) {
 	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if rr2.Header().Get("X-AT-Error-Reason") != "caller rate limited" {
+		t.Fatalf("unexpected error reason: %s", rr2.Header().Get("X-AT-Error-Reason"))
+	}
 }
 
 func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
@@ -339,6 +342,9 @@ func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
 	if rr2.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if rr2.Header().Get("X-AT-Error-Reason") != "integration rate limited" {
+		t.Fatalf("unexpected error reason: %s", rr2.Header().Get("X-AT-Error-Reason"))
+	}
 }
 
 func TestProxyHandlerNotFound(t *testing.T) {
@@ -351,6 +357,9 @@ func TestProxyHandlerNotFound(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
+	}
+	if rr.Header().Get("X-AT-Error-Reason") != "integration not found" {
+		t.Fatalf("unexpected error reason: %s", rr.Header().Get("X-AT-Error-Reason"))
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)
@@ -387,6 +396,9 @@ func TestProxyHandlerAuthFailure(t *testing.T) {
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
 	}
+	if rr.Header().Get("X-AT-Error-Reason") != "authentication failed" {
+		t.Fatalf("unexpected error reason: %s", rr.Header().Get("X-AT-Error-Reason"))
+	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)
 	}
@@ -416,6 +428,9 @@ func TestProxyHandlerBadGateway(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Upstream-Error") != "false" {
 		t.Fatal("missing auth error header")
+	}
+	if rr.Header().Get("X-AT-Error-Reason") != "no proxy configured" {
+		t.Fatalf("unexpected error reason: %s", rr.Header().Get("X-AT-Error-Reason"))
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -22,7 +22,7 @@ Unknown top‑level keys cause a validation error.
 * **Exact ID** `user-123`, `service-A`, `spiffe://tenant/worker`
 * **Wildcard** `"*"` – used when the incoming auth plugin did **not** return an ID. Handy for anonymous webhooks.
 
-If no matching caller key exists – or a matched caller fails rule constraints – the proxy returns **403 Forbidden** and sets an `X-AT-Error-Reason` header describing the first mismatch.
+If no matching caller key exists – or a matched caller fails rule constraints – the proxy returns **403 Forbidden** and sets an `X-AT-Error-Reason` header describing the first mismatch. Every 4xx/5xx error from the proxy includes this header with a brief phrase explaining the reason.
 
 ---
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -19,7 +19,9 @@ credentials – omitting either one causes the service to exit on startup.
 
 Any non‑2xx response includes an `X-AT-Upstream-Error` header. `true` means
 the error came from the upstream service. `false` indicates AuthTranslator
-generated the response, typically due to authentication or rate limiting.
+generated the response. When the proxy generates a 4xx or 5xx reply it also
+sets `X-AT-Error-Reason` with a short explanation such as "integration not found",
+"authentication failed", "caller rate limited", "integration rate limited", or "no proxy configured".
 
 ---
 


### PR DESCRIPTION
## Summary
- set `X-AT-Error-Reason` for all proxy-generated error responses
- update tests to validate the new header
- document the header in `observability.md` and `allowlist-config.md`

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6840e04a8b9c8326b054e031db4cfc27