### PR TITLE
Increase test coverage

### DIFF
--- a/app/allowlist_match_test.go
+++ b/app/allowlist_match_test.go
@@ -231,3 +231,25 @@ func TestMatchBodyMapReasonNestedMismatch(t *testing.T) {
 		t.Fatalf("expected mismatch failure, got ok=%v reason=%q", ok, reason)
 	}
 }
+
+func TestMatchBodyMapSuccess(t *testing.T) {
+	data := map[string]interface{}{
+		"a":   "b",
+		"arr": []interface{}{float64(1), float64(2)},
+	}
+	rule := map[string]interface{}{
+		"a":   "b",
+		"arr": []interface{}{float64(1)},
+	}
+	if !matchBodyMap(data, rule) {
+		t.Fatal("expected matchBodyMap to succeed")
+	}
+}
+
+func TestMatchBodyMapFailure(t *testing.T) {
+	data := map[string]interface{}{"a": "b"}
+	rule := map[string]interface{}{"a": "b", "c": "d"}
+	if matchBodyMap(data, rule) {
+		t.Fatal("expected matchBodyMap to fail")
+	}
+}

--- a/app/auth/body_test.go
+++ b/app/auth/body_test.go
@@ -123,3 +123,10 @@ func TestGetBodyPreservesClose(t *testing.T) {
 		t.Fatal("underlying body not closed")
 	}
 }
+
+func TestReadCloseMultiNilCloser(t *testing.T) {
+	rcm := readCloseMulti{}
+	if err := rcm.Close(); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add tests for matchBodyMap helper
- cover readCloseMulti.Close nil case

## Testing
- `go test ./...`
- `go test ./... -coverprofile=coverage.out -covermode=atomic`


------
https://chatgpt.com/codex/tasks/task_e_6840e791a7088326b07a62093c3d3615