### PR TITLE
Fix nil request body panic

### DIFF
--- a/app/auth/body.go
+++ b/app/auth/body.go
@@ -38,6 +38,9 @@ func GetBody(r *http.Request) ([]byte, error) {
 	}
 
 	orig := r.Body
+	if orig == nil {
+		orig = http.NoBody
+	}
 	var reader io.Reader = orig
 	if MaxBodySize > 0 {
 		reader = io.LimitReader(orig, MaxBodySize+1)

--- a/app/auth/body_test.go
+++ b/app/auth/body_test.go
@@ -130,3 +130,14 @@ func TestReadCloseMultiNilCloser(t *testing.T) {
 		t.Fatalf("expected nil error, got %v", err)
 	}
 }
+
+func TestGetBodyNilBody(t *testing.T) {
+	r := &http.Request{Method: http.MethodGet, URL: &url.URL{Scheme: "http", Host: "example.com"}}
+	b, err := GetBody(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(b) != 0 {
+		t.Fatalf("expected empty body, got %q", string(b))
+	}
+}


### PR DESCRIPTION
## Summary
- prevent a panic when `GetBody` is called with a nil request body
- add a regression test for nil body handling

## Testing
- `make lint` *(fails: unsupported configuration version)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6840fe9b5cc08326801119c13915f50d