### PR TITLE
Improve docs cross-linking

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -6,6 +6,7 @@ AuthTranslator ships with two small helper binaries under **`cmd/`**:
 | -------------- | --------------------------------------------- | ------------------------------------------------- |
 | `integrations` | Modify or inspect *config.yaml*. | `go run ./cmd/integrations slack -file config.yaml -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING` |
 | `allowlist`    | Modify or inspect *allowlist.yaml*.           | `go run ./cmd/allowlist add -integration slack -caller bot -capability post_public_as` |
+These helpers complement the [Configuration Reference](configuration.md) and [Allowlist Configuration](allowlist-config.md) docs.
 
 > **Heads‑up** Both helpers are thin wrappers around Go structs—check the `--help` output for the definitive flag list because the CLI evolves alongside the schema.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -13,6 +13,7 @@ Running without an allowlist effectively gives all authenticated callers unrestr
 The proxy currently infers its schema directly from Go structs. Unknown top‑level keys cause a validation error.
 
 > **Tip** The Go YAML parser accepts JSON too, so curl pipes / CI steps can build your config in whichever syntax is easier to template.
+For command-line tooling, see the [Command-Line Helpers](cli.md) guide.
 
 ---
 

--- a/docs/secret-backends.md
+++ b/docs/secret-backends.md
@@ -2,6 +2,7 @@
 
 AuthTranslator never expects you to paste raw API keys into a YAML file. Instead, any plugin parameter that contains a credential can use a **secret URI**. At runtime the proxy resolves that URI via a pluggable back‑end and injects the value.
 
+For full config examples, see the [Configuration Reference](configuration.md).
 ```yaml
 outgoing_auth:
   - type: token


### PR DESCRIPTION
## Summary
- add reference to configuration docs in secret backend guide
- mention CLI helper docs in configuration reference
- link configuration and allowlist docs from the CLI guide

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6841e5ecdd7c8326bd716faf7d6ff1f4