### PR TITLE
Fix docs cross-linking

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,5 +83,8 @@ AuthTranslator is extensible via three types of plugins:
 * Dive into [Auth Plugins](auth-plugins.md) to wire up other services.
 * Add rate‑limits with the [Rate‑Limiting](rate-limiting.md) guide.
 * Ship to Kubernetes via the [Helm guide](helm.md).
+* Spin up everything locally with [Docker Compose](docker-compose.md).
+* Review common questions in the [FAQ](faq.md).
+* Tweak flags and service behaviour via [Runtime & Operations](runtime.md).
 
 Happy translating! 🎉


### PR DESCRIPTION
## Summary
- link Docker Compose, FAQ, and Runtime docs from Getting Started

## Testing
- `go test ./...` *(fails: TestRateLimiterRedisFallback)*

------
https://chatgpt.com/codex/tasks/task_e_684220b54560832691918c81cf5d2fb3