### PR TITLE
Add Datadog plugin

### DIFF
--- a/app/integrations/plugins/datadog/capabilities.go
+++ b/app/integrations/plugins/datadog/capabilities.go
@@ -1,0 +1,19 @@
+package datadog
+
+import integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+
+func init() {
+	integrationplugins.RegisterCapability("datadog", "post_event", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v2/events", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+
+	integrationplugins.RegisterCapability("datadog", "submit_metrics", integrationplugins.CapabilitySpec{
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			rule := integrationplugins.CallRule{Path: "/api/v2/series", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
+}

--- a/app/integrations/plugins/datadog/datadog_test.go
+++ b/app/integrations/plugins/datadog/datadog_test.go
@@ -1,0 +1,45 @@
+package datadog_test
+
+import (
+	"testing"
+
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/datadog"
+)
+
+func TestDatadogCapabilities(t *testing.T) {
+	caps := integrationplugins.CapabilitiesFor("datadog")
+	if len(caps) != 2 {
+		t.Fatalf("expected 2 capabilities, got %d", len(caps))
+	}
+
+	tests := []struct {
+		name   string
+		path   string
+		method string
+	}{
+		{"post_event", "/api/v2/events", "POST"},
+		{"submit_metrics", "/api/v2/series", "POST"},
+	}
+
+	for _, tt := range tests {
+		spec, ok := caps[tt.name]
+		if !ok {
+			t.Fatalf("%s not registered", tt.name)
+		}
+		rules, err := spec.Generate(nil)
+		if err != nil {
+			t.Fatalf("generate failed: %v", err)
+		}
+		if len(rules) != 1 {
+			t.Fatalf("expected 1 rule for %s", tt.name)
+		}
+		r := rules[0]
+		if r.Path != tt.path {
+			t.Errorf("%s path mismatch: %s", tt.name, r.Path)
+		}
+		if _, ok := r.Methods[tt.method]; !ok {
+			t.Errorf("%s missing method %s", tt.name, tt.method)
+		}
+	}
+}

--- a/app/integrations/plugins/plugins.go
+++ b/app/integrations/plugins/plugins.go
@@ -3,6 +3,7 @@ package plugins
 import (
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/asana"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/confluence"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/datadog"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/ghe"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/github"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/gitlab"

--- a/app/integrations/plugins/plugins_test.go
+++ b/app/integrations/plugins/plugins_test.go
@@ -5,6 +5,7 @@ import (
 
 	integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/asana"
+	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/datadog"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/ghe"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/github"
 	_ "github.com/winhowes/AuthTranslator/app/integrations/plugins/gitlab"
@@ -34,6 +35,10 @@ func TestPluginCapabilities(t *testing.T) {
 			{"create_task", "/tasks", "POST", nil},
 			{"update_status", "/tasks/*", "PUT", nil},
 			{"add_comment", "/tasks/*/stories", "POST", nil},
+		},
+		"datadog": {
+			{"post_event", "/api/v2/events", "POST", nil},
+			{"submit_metrics", "/api/v2/series", "POST", nil},
 		},
 		"ghe": {
 			{"comment", "/repos/r/issues/*/comments", "POST", map[string]interface{}{"repo": "r"}},

--- a/cmd/integrations/plugins/builders_test.go
+++ b/cmd/integrations/plugins/builders_test.go
@@ -19,6 +19,7 @@ func TestBuilders(t *testing.T) {
 		{"jira", []string{"-name", "j2", "-domain", "jira.example.com", "-token", "tok"}, Jira("j2", "tok", "jira.example.com")},
 		{"confluence", []string{"-name", "c1", "-token", "tok"}, Confluence("c1", "tok", "api.atlassian.com")},
 		{"confluence", []string{"-name", "c2", "-domain", "confluence.example.com", "-token", "tok"}, Confluence("c2", "tok", "confluence.example.com")},
+		{"datadog", []string{"-name", "dd", "-api-key", "ak", "-app-key", "app"}, Datadog("dd", "ak", "app")},
 		{"linear", []string{"-name", "lin", "-token", "tok"}, Linear("lin", "tok")},
 		{"monday", []string{"-name", "mon", "-token", "tok"}, Monday("mon", "tok")},
 		{"okta", []string{"-name", "ok", "-domain", "okta.example.com", "-token", "tok"}, Okta("ok", "okta.example.com", "tok")},
@@ -71,6 +72,7 @@ func TestBuilderErrors(t *testing.T) {
 		{"jira", []string{}},
 		{"okta", []string{"-token", "t"}},
 		{"linear", []string{}},
+		{"datadog", []string{}},
 		{"stripe", []string{}},
 		{"trufflehog", []string{}},
 		{"zendesk", []string{}},
@@ -95,7 +97,7 @@ func TestBuilderErrors(t *testing.T) {
 
 func TestBuilderParseError(t *testing.T) {
 	names := []string{
-		"asana", "confluence", "ghe", "github", "gitlab", "jira",
+		"asana", "confluence", "datadog", "ghe", "github", "gitlab", "jira",
 		"linear", "monday", "okta", "openai", "pagerduty", "sendgrid", "servicenow",
 		"slack", "stripe", "trufflehog", "twilio", "workday", "zendesk",
 	}

--- a/cmd/integrations/plugins/datadog.go
+++ b/cmd/integrations/plugins/datadog.go
@@ -1,0 +1,48 @@
+package plugins
+
+import (
+	"flag"
+	"fmt"
+)
+
+// Datadog returns an Integration configured for the Datadog API.
+func Datadog(name, apiKeyRef, appKeyRef string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://api.datadoghq.com",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{
+			{
+				Type: "token",
+				Params: map[string]interface{}{
+					"secrets": []string{apiKeyRef},
+					"header":  "DD-API-KEY",
+				},
+			},
+			{
+				Type: "token",
+				Params: map[string]interface{}{
+					"secrets": []string{appKeyRef},
+					"header":  "DD-APPLICATION-KEY",
+				},
+			},
+		},
+	}
+}
+
+func init() { Register("datadog", datadogBuilder) }
+
+func datadogBuilder(args []string) (Integration, error) {
+	fs := flag.NewFlagSet("datadog", flag.ContinueOnError)
+	name := fs.String("name", "datadog", "integration name")
+	api := fs.String("api-key", "", "secret reference for API key")
+	app := fs.String("app-key", "", "secret reference for application key")
+	if err := fs.Parse(args); err != nil {
+		return Integration{}, err
+	}
+	if *api == "" || *app == "" {
+		return Integration{}, fmt.Errorf("-api-key and -app-key are required")
+	}
+	return Datadog(*name, *api, *app), nil
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -12,6 +12,8 @@ Run `go run ./cmd/allowlist list` to list capabilities from your build. For quic
 | confluence | add_comment | – |
 | confluence | create_page | – |
 | confluence | update_page | – |
+| datadog | post_event | – |
+| datadog | submit_metrics | – |
 | ghe | comment | repo |
 | ghe | create_issue | repo |
 | ghe | update_issue | repo |

--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -16,6 +16,7 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | ---- | ----------------- | -------------------- |
 | `asana` | `https://app.asana.com/api/1.0` | `token` |
 | `confluence` | `https://api.atlassian.com` (configurable) | `token` |
+| `datadog` | `https://api.datadoghq.com` | `token` |
 | `ghe` | `https://<domain>/api/v3` | `token` |
 | `github` | `https://api.github.com` | `token` |
 | `gitlab` | `https://gitlab.com/api/v4` | `token` |


### PR DESCRIPTION
## Summary
- add Datadog integration plugin and builder
- document Datadog integration
- expose Datadog capabilities and tests

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6843fd7ea3bc832698c61e4d740ff807