### PR TITLE
Require sender fields for SendGrid emails

### DIFF
--- a/app/integrations/plugins/plugins_test.go
+++ b/app/integrations/plugins/plugins_test.go
@@ -80,7 +80,7 @@ func TestPluginCapabilities(t *testing.T) {
 			{"resolve_incident", "/incidents/*", "PUT", nil},
 		},
 		"sendgrid": {
-			{"send_email", "/v3/mail/send", "POST", nil},
+			{"send_email", "/v3/mail/send", "POST", map[string]interface{}{"from": "me@example.com", "replyTo": nil}},
 			{"manage_contacts", "/v3/marketing/contacts", "PUT", nil},
 			{"update_template", "/v3/templates/*", "PATCH", nil},
 		},

--- a/app/integrations/plugins/sendgrid/capabilities.go
+++ b/app/integrations/plugins/sendgrid/capabilities.go
@@ -1,11 +1,25 @@
 package sendgrid
 
-import integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+import (
+	"fmt"
+
+	integrationplugins "github.com/winhowes/AuthTranslator/app/integrations"
+)
 
 func init() {
 	integrationplugins.RegisterCapability("sendgrid", "send_email", integrationplugins.CapabilitySpec{
+		Params: []string{"from", "replyTo"},
 		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
-			rule := integrationplugins.CallRule{Path: "/v3/mail/send", Methods: map[string]integrationplugins.RequestConstraint{"POST": {}}}
+			from, _ := p["from"].(string)
+			if from == "" {
+				return nil, fmt.Errorf("from parameter required")
+			}
+			reply, replyOK := p["replyTo"]
+			body := map[string]interface{}{"from": from, "reply_to": nil}
+			if replyOK {
+				body["reply_to"] = reply
+			}
+			rule := integrationplugins.CallRule{Path: "/v3/mail/send", Methods: map[string]integrationplugins.RequestConstraint{"POST": {Body: body}}}
 			return []integrationplugins.CallRule{rule}, nil
 		},
 	})

--- a/app/integrations/plugins/sendgrid/sendgrid_test.go
+++ b/app/integrations/plugins/sendgrid/sendgrid_test.go
@@ -28,7 +28,11 @@ func TestSendgridCapabilities(t *testing.T) {
 		if !ok {
 			t.Fatalf("%s not registered", tt.name)
 		}
-		rules, err := spec.Generate(nil)
+		params := map[string]interface{}{}
+		if tt.name == "send_email" {
+			params = map[string]interface{}{"from": "me@example.com", "replyTo": nil}
+		}
+		rules, err := spec.Generate(params)
 		if err != nil {
 			t.Fatalf("generate failed: %v", err)
 		}
@@ -39,8 +43,33 @@ func TestSendgridCapabilities(t *testing.T) {
 		if r.Path != tt.path {
 			t.Errorf("%s path mismatch: %s", tt.name, r.Path)
 		}
-		if _, ok := r.Methods[tt.method]; !ok {
+		rc, ok := r.Methods[tt.method]
+		if !ok {
 			t.Errorf("%s missing method %s", tt.name, tt.method)
+			continue
 		}
+		if tt.name == "send_email" {
+			if rc.Body["from"] != "me@example.com" {
+				t.Errorf("from not propagated")
+			}
+			val, exists := rc.Body["reply_to"]
+			if !exists || val != nil {
+				t.Errorf("reply_to not nil when expected")
+			}
+		}
+	}
+
+	spec := caps["send_email"]
+	if _, err := spec.Generate(map[string]interface{}{}); err == nil {
+		t.Errorf("expected error for missing from")
+	}
+
+	rules, err := spec.Generate(map[string]interface{}{"from": "me@example.com", "replyTo": "r@example.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rc := rules[0].Methods["POST"]
+	if rc.Body["reply_to"] != "r@example.com" {
+		t.Errorf("reply_to value not propagated")
 	}
 }

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -41,7 +41,7 @@ Run `go run ./cmd/allowlist list` to list capabilities from your build. For quic
 | pagerduty | trigger_incident | – |
 | pagerduty | resolve_incident | – |
 | sendgrid | manage_contacts | – |
-| sendgrid | send_email | – |
+| sendgrid | send_email | from, replyTo |
 | sendgrid | update_template | – |
 | servicenow | open_ticket | – |
 | servicenow | query_status | – |


### PR DESCRIPTION
## Summary
- enforce `from` and optional `replyTo` params for SendGrid `send_email`
- test SendGrid capability parameter requirements
- adjust plugin capability tests
- document SendGrid `send_email` parameters

## Testing
- `make fmt vet test`
- `make fmt vet lint test` *(fails: can't load golangci-lint config)*

------
https://chatgpt.com/codex/tasks/task_e_6849e0c429488326a6aa761e1c36f7f3