### PR TITLE
Add Google Drive integration

### DIFF
--- a/app/auth/plugins/basic/basic_test.go
+++ b/app/auth/plugins/basic/basic_test.go
@@ -19,7 +19,9 @@ func TestBasicOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("user:pass"))
 	if got := r.Header.Get("Authorization"); got != expected {
 		t.Fatalf("expected %q, got %s", expected, got)
@@ -33,7 +35,9 @@ func TestBasicOutgoingAddAuthMissingSecret(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("Authorization"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
@@ -166,7 +170,9 @@ func TestBasicCustomHeaderAndPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	out.AddAuth(context.Background(), r, ocfg)
+	if err := out.AddAuth(context.Background(), r, ocfg); err != nil {
+		t.Fatal(err)
+	}
 	enc := base64.StdEncoding.EncodeToString([]byte("u:p"))
 	expected := "Pre " + enc
 	if got := r.Header.Get("X-Auth"); got != expected {
@@ -193,11 +199,15 @@ func TestBasicCustomHeaderAndPrefix(t *testing.T) {
 func TestBasicAddAuthInvalidParams(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	out := BasicAuthOut{}
-	out.AddAuth(context.Background(), r, nil)
+	if err := out.AddAuth(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
-	out.AddAuth(context.Background(), r, struct{}{})
+	if err := out.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
@@ -225,7 +235,9 @@ func TestBasicAddAuthSecretError(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	out := BasicAuthOut{}
 	cfg := &outParams{Secrets: []string{"fail:o"}, Header: "Authorization"}
-	out.AddAuth(context.Background(), r, cfg)
+	if err := out.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
@@ -247,7 +259,9 @@ func TestBasicOutgoingAddAuthMultipleSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	got := r.Header.Get("Authorization")
 	exp1 := "Basic " + base64.StdEncoding.EncodeToString([]byte("u1:p1"))
 	exp2 := "Basic " + base64.StdEncoding.EncodeToString([]byte("u2:p2"))

--- a/app/auth/plugins/basic/outgoing.go
+++ b/app/auth/plugins/basic/outgoing.go
@@ -40,17 +40,18 @@ func (b *BasicAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 	return p, nil
 }
 
-func (b *BasicAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
+func (b *BasicAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) error {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
-		return
+		return fmt.Errorf("invalid config")
 	}
 	cred, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
-		return
+		return err
 	}
 	enc := base64.StdEncoding.EncodeToString([]byte(cred))
 	r.Header.Set(cfg.Header, cfg.Prefix+enc)
+	return nil
 }
 
 func init() { authplugins.RegisterOutgoing(&BasicAuthOut{}) }

--- a/app/auth/plugins/gcp_token/gcp_token_test.go
+++ b/app/auth/plugins/gcp_token/gcp_token_test.go
@@ -1,0 +1,108 @@
+package gcptoken
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestGCPTokenAddAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Metadata-Flavor") != "Google" {
+			t.Errorf("missing metadata header")
+		}
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "tok", "expires_in": 10})
+	}))
+	defer ts.Close()
+
+	oldHost := MetadataHost
+	oldClient := HTTPClient
+	MetadataHost = ts.URL
+	HTTPClient = ts.Client()
+	defer func() {
+		MetadataHost = oldHost
+		HTTPClient = oldClient
+		setCachedToken("", time.Time{})
+	}()
+
+	p := GCPToken{}
+	cfg, err := p.ParseParams(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+		t.Fatalf("expected token header, got %s", got)
+	}
+}
+
+func TestGCPTokenCache(t *testing.T) {
+	setCachedToken("c", time.Now().Add(time.Hour))
+	p := GCPToken{}
+	cfg, _ := p.ParseParams(map[string]any{})
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer c" {
+		t.Fatalf("expected cached token, got %s", got)
+	}
+	setCachedToken("", time.Time{})
+}
+
+func TestGCPTokenRefreshEarly(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{"access_token": "new", "expires_in": 10})
+	}))
+	defer ts.Close()
+
+	oldHost := MetadataHost
+	oldClient := HTTPClient
+	MetadataHost = ts.URL
+	HTTPClient = ts.Client()
+	defer func() {
+		MetadataHost = oldHost
+		HTTPClient = oldClient
+		setCachedToken("", time.Time{})
+	}()
+
+	setCachedToken("old", time.Now().Add(30*time.Second))
+	p := GCPToken{}
+	cfg, _ := p.ParseParams(map[string]any{})
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if got := r.Header.Get("Authorization"); got != "Bearer new" {
+		t.Fatalf("expected refreshed token, got %s", got)
+	}
+}
+
+func TestGCPTokenParseDefaults(t *testing.T) {
+	p := GCPToken{}
+	cfg, err := p.ParseParams(map[string]any{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := cfg.(*gcpTokenParams)
+	if c.Header != "Authorization" || c.Prefix != "Bearer " {
+		t.Fatalf("unexpected defaults: %+v", c)
+	}
+}
+
+func TestGCPTokenWrongConfig(t *testing.T) {
+	p := GCPToken{}
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+	if r.Header.Get("Authorization") != "" {
+		t.Fatalf("expected no header")
+	}
+}

--- a/app/auth/plugins/gcp_token/outgoing.go
+++ b/app/auth/plugins/gcp_token/outgoing.go
@@ -1,0 +1,117 @@
+package gcptoken
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	authplugins "github.com/winhowes/AuthTranslator/app/auth"
+)
+
+// gcpTokenParams configures the GCP token plugin.
+type gcpTokenParams struct {
+	Header string `json:"header"`
+	Prefix string `json:"prefix"`
+}
+
+// GCPToken obtains an OAuth access token from the GCP metadata server
+// and attaches it to outgoing requests.
+type GCPToken struct{}
+
+// MetadataHost is the base URL for metadata requests.
+var MetadataHost = "http://metadata.google.internal"
+
+// HTTPClient performs metadata HTTP requests. It can be swapped in tests.
+var HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+type cachedToken struct {
+	token string
+	exp   time.Time
+}
+
+var (
+	mu    sync.Mutex
+	cache cachedToken
+)
+
+func (g *GCPToken) Name() string { return "gcp_token" }
+
+func (g *GCPToken) RequiredParams() []string { return nil }
+
+func (g *GCPToken) OptionalParams() []string { return []string{"header", "prefix"} }
+
+func (g *GCPToken) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[gcpTokenParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if p.Header == "" {
+		p.Header = "Authorization"
+	}
+	if p.Prefix == "" {
+		p.Prefix = "Bearer "
+	}
+	return p, nil
+}
+
+func (g *GCPToken) AddAuth(ctx context.Context, r *http.Request, params interface{}) error {
+	cfg, ok := params.(*gcpTokenParams)
+	if !ok {
+		return fmt.Errorf("invalid config")
+	}
+	tok, exp := getCachedToken()
+	if tok == "" || time.Now().After(exp.Add(-1*time.Minute)) {
+		var err error
+		tok, exp, err = fetchToken()
+		if err != nil {
+			return err
+		}
+		setCachedToken(tok, exp)
+	}
+	r.Header.Set(cfg.Header, cfg.Prefix+tok)
+	return nil
+}
+
+func fetchToken() (string, time.Time, error) {
+	req, err := http.NewRequest("GET", MetadataHost+"/computeMetadata/v1/instance/service-accounts/default/token", nil)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	req.Header.Set("Metadata-Flavor", "Google")
+	resp, err := HTTPClient.Do(req)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return "", time.Time{}, fmt.Errorf("status %s: %s", resp.Status, body)
+	}
+	var tr struct {
+		AccessToken string `json:"access_token"`
+		ExpiresIn   int64  `json:"expires_in"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&tr); err != nil {
+		return "", time.Time{}, err
+	}
+	return tr.AccessToken, time.Now().Add(time.Duration(tr.ExpiresIn) * time.Second), nil
+}
+
+func getCachedToken() (string, time.Time) {
+	mu.Lock()
+	defer mu.Unlock()
+	return cache.token, cache.exp
+}
+
+func setCachedToken(tok string, exp time.Time) {
+	mu.Lock()
+	cache.token = tok
+	cache.exp = exp
+	mu.Unlock()
+}
+
+func init() { authplugins.RegisterOutgoing(&GCPToken{}) }

--- a/app/auth/plugins/google_oidc/google_oidc_test.go
+++ b/app/auth/plugins/google_oidc/google_oidc_test.go
@@ -45,7 +45,9 @@ func TestGoogleOIDCAddAuth(t *testing.T) {
 	}
 
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
 		t.Fatalf("expected 'Bearer tok123', got %s", got)
 	}
@@ -70,7 +72,9 @@ func TestGoogleOIDCDefaults(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authorization"); got != "Bearer tok" {
 		t.Fatalf("unexpected header %s", got)
 	}
@@ -95,7 +99,9 @@ func TestGoogleOIDCAddAuthFailure(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("Authorization"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
@@ -136,7 +142,9 @@ func TestGoogleOIDCAddAuthCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authorization"); got != "Bearer cachedtok" {
 		t.Fatalf("unexpected header %s", got)
 	}
@@ -175,7 +183,9 @@ func TestGoogleOIDCAddAuthExpiredCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if !called {
 		t.Fatal("expected HTTP call for expired cache")
 	}
@@ -667,7 +677,9 @@ func TestVerifyRS256DecodeError(t *testing.T) {
 func TestGoogleOIDCAddAuthWrongConfigType(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	p := GoogleOIDC{}
-	p.AddAuth(context.Background(), r, 5)
+	if err := p.AddAuth(context.Background(), r, 5); err == nil {
+		t.Fatal("expected error")
+	}
 	if val := r.Header.Get("Authorization"); val != "" {
 		t.Fatalf("expected no header set, got %s", val)
 	}

--- a/app/auth/plugins/jwt/jwt_test.go
+++ b/app/auth/plugins/jwt/jwt_test.go
@@ -81,7 +81,9 @@ func TestJWTOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authorization"); got != "Bearer tok123" {
 		t.Fatalf("expected 'Bearer tok123', got %s", got)
 	}
@@ -208,19 +210,25 @@ func TestJWTOutgoingEdgeCases(t *testing.T) {
 	p := JWTAuthOut{}
 	r := &http.Request{Header: http.Header{}}
 	// bad params type
-	p.AddAuth(context.Background(), r, struct{}{})
+	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
 	// missing secrets
 	r = &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, &outParams{})
+	if err := p.AddAuth(context.Background(), r, &outParams{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
 	// secret load error
 	r = &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, &outParams{Secrets: []string{"fail:oops"}})
+	if err := p.AddAuth(context.Background(), r, &outParams{Secrets: []string{"fail:oops"}}); err == nil {
+		t.Fatal("expected error")
+	}
 	if h := r.Header.Get("Authorization"); h != "" {
 		t.Fatalf("expected empty header, got %s", h)
 	}
@@ -228,7 +236,9 @@ func TestJWTOutgoingEdgeCases(t *testing.T) {
 	t.Setenv("TOK", "t1")
 	r = &http.Request{Header: http.Header{}}
 	cfg := &outParams{Secrets: []string{"env:TOK"}, Header: "Authz", Prefix: "pre "}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authz"); got != "pre t1" {
 		t.Fatalf("expected 'pre t1', got %s", got)
 	}
@@ -381,7 +391,9 @@ func TestJWTOutgoingAddAuthMultipleSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	got := r.Header.Get("Authorization")
 	if got != "Bearer tok1" && got != "Bearer tok2" {
 		t.Fatalf("unexpected header %s", got)

--- a/app/auth/plugins/jwt/outgoing.go
+++ b/app/auth/plugins/jwt/outgoing.go
@@ -39,16 +39,17 @@ func (j *JWTAuthOut) ParseParams(m map[string]interface{}) (interface{}, error) 
 	return p, nil
 }
 
-func (j *JWTAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
+func (j *JWTAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) error {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
-		return
+		return fmt.Errorf("invalid config")
 	}
 	tok, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
-		return
+		return err
 	}
 	r.Header.Set(cfg.Header, cfg.Prefix+tok)
+	return nil
 }
 
 func init() { authplugins.RegisterOutgoing(&JWTAuthOut{}) }

--- a/app/auth/plugins/mtls/mtls_test.go
+++ b/app/auth/plugins/mtls/mtls_test.go
@@ -85,7 +85,9 @@ func TestMTLSOutgoingParse(t *testing.T) {
 		t.Fatalf("unexpected config %+v", cfg)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "client" {
 		t.Fatalf("expected client CN header, got %s", got)
 	}
@@ -111,7 +113,9 @@ func TestMTLSOutgoingAddAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	r := &http.Request{Header: http.Header{}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "client" {
 		t.Fatalf("expected client CN header, got %s", got)
 	}
@@ -268,11 +272,15 @@ func TestMTLSOutgoingParseMissingFields(t *testing.T) {
 func TestMTLSOutgoingAddAuthInvalidCfg(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	p := MTLSAuthOut{}
-	p.AddAuth(context.Background(), r, nil)
+	if err := p.AddAuth(context.Background(), r, nil); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
-	p.AddAuth(context.Background(), r, &outParams{})
+	if err := p.AddAuth(context.Background(), r, &outParams{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
@@ -307,7 +315,9 @@ func TestMTLSOutgoingAddAuthBadCert(t *testing.T) {
 	cfg := &outParams{transport: &http.Transport{TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{{Certificate: [][]byte{[]byte("bad")}}}}}}
 	r := &http.Request{Header: http.Header{}}
 	p := MTLSAuthOut{}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
@@ -317,7 +327,9 @@ func TestMTLSOutgoingAddAuthNoCerts(t *testing.T) {
 	cfg := &outParams{transport: &http.Transport{TLSClientConfig: &tls.Config{}}}
 	r := &http.Request{Header: http.Header{}}
 	p := MTLSAuthOut{}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("X-TLS-Client-CN"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}

--- a/app/auth/plugins/mtls/outgoing.go
+++ b/app/auth/plugins/mtls/outgoing.go
@@ -51,19 +51,20 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 // AddAuth exposes the configured client certificate's common name to the backend
 // via the "X-TLS-Client-CN" header. This allows upstream services to easily
 // identify the client certificate used for the mTLS connection.
-func (m *MTLSAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
+func (m *MTLSAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) error {
 	cfg, ok := p.(*outParams)
 	if !ok || cfg.transport == nil || cfg.transport.TLSClientConfig == nil {
-		return
+		return fmt.Errorf("invalid config")
 	}
 	if len(cfg.transport.TLSClientConfig.Certificates) == 0 || len(cfg.transport.TLSClientConfig.Certificates[0].Certificate) == 0 {
-		return
+		return fmt.Errorf("missing cert")
 	}
 	cert, err := x509.ParseCertificate(cfg.transport.TLSClientConfig.Certificates[0].Certificate[0])
 	if err != nil {
-		return
+		return err
 	}
 	r.Header.Set("X-TLS-Client-CN", cert.Subject.CommonName)
+	return nil
 }
 
 // Transport exposes the configured mTLS transport for integration usage.

--- a/app/auth/plugins/passthrough/outgoing.go
+++ b/app/auth/plugins/passthrough/outgoing.go
@@ -23,8 +23,9 @@ func (p *PassThruAuthOut) ParseParams(m map[string]interface{}) (interface{}, er
 	return struct{}{}, nil
 }
 
-func (p *PassThruAuthOut) AddAuth(ctx context.Context, r *http.Request, _ interface{}) {
+func (p *PassThruAuthOut) AddAuth(ctx context.Context, r *http.Request, _ interface{}) error {
 	// No-op
+	return nil
 }
 
 func init() { authplugins.RegisterOutgoing(&PassThruAuthOut{}) }

--- a/app/auth/plugins/passthrough/passthrough_test.go
+++ b/app/auth/plugins/passthrough/passthrough_test.go
@@ -25,7 +25,9 @@ func TestPassThruOutgoingNoop(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("X-Test"); got != "value" {
 		t.Fatalf("expected header to remain unchanged, got %s", got)
 	}

--- a/app/auth/plugins/plugins.go
+++ b/app/auth/plugins/plugins.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/basic"
+	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/gcp_token"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/github_signature"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/google_oidc"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/hmac"

--- a/app/auth/plugins/token/outgoing.go
+++ b/app/auth/plugins/token/outgoing.go
@@ -35,16 +35,17 @@ func (t *TokenAuthOut) ParseParams(m map[string]interface{}) (interface{}, error
 	return p, nil
 }
 
-func (t *TokenAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
+func (t *TokenAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) error {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
-		return
+		return fmt.Errorf("invalid config")
 	}
 	token, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
-		return
+		return err
 	}
 	r.Header.Set(cfg.Header, cfg.Prefix+token)
+	return nil
 }
 
 func init() { authplugins.RegisterOutgoing(&TokenAuthOut{}) }

--- a/app/auth/plugins/token/token_test.go
+++ b/app/auth/plugins/token/token_test.go
@@ -16,7 +16,9 @@ func TestTokenOutgoingPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("Authorization"); got != "Bearer secret" {
 		t.Fatalf("expected 'Bearer secret', got %s", got)
 	}
@@ -29,7 +31,9 @@ func TestTokenOutgoingMissingSecret(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if got := r.Header.Get("H"); got != "" {
 		t.Fatalf("expected empty header, got %s", got)
 	}
@@ -94,7 +98,9 @@ func TestTokenAddAuthDefaultPrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.Header.Get("H"); got != "tok" {
 		t.Fatalf("expected token, got %s", got)
 	}
@@ -121,7 +127,9 @@ func TestTokenAddAuthWrongConfigType(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	p := TokenAuthOut{}
 	// pass wrong config type; should not panic or set header
-	p.AddAuth(context.Background(), r, struct{}{})
+	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if val := r.Header.Get("Authorization"); val != "" {
 		t.Fatalf("expected no header set, got %s", val)
 	}
@@ -147,7 +155,9 @@ func TestTokenAddAuthMultipleSecrets(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	got := r.Header.Get("H")
 	if got != "a" && got != "b" {
 		t.Fatalf("expected one of the secrets, got %s", got)
@@ -223,7 +233,9 @@ func TestTokenAddAuthNoSecrets(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	p := TokenAuthOut{}
 	cfg := &outParams{Header: "H"}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if val := r.Header.Get("H"); val != "" {
 		t.Fatalf("expected no header set, got %s", val)
 	}

--- a/app/auth/plugins/urlpath/outgoing.go
+++ b/app/auth/plugins/urlpath/outgoing.go
@@ -32,14 +32,14 @@ func (u *URLPathAuthOut) ParseParams(m map[string]interface{}) (interface{}, err
 	return p, nil
 }
 
-func (u *URLPathAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) {
+func (u *URLPathAuthOut) AddAuth(ctx context.Context, r *http.Request, p interface{}) error {
 	cfg, ok := p.(*outParams)
 	if !ok || len(cfg.Secrets) == 0 {
-		return
+		return fmt.Errorf("invalid config")
 	}
 	sec, err := secrets.LoadRandomSecret(ctx, cfg.Secrets)
 	if err != nil {
-		return
+		return err
 	}
 	if !strings.HasSuffix(r.URL.Path, "/") {
 		r.URL.Path += "/" + sec
@@ -47,6 +47,7 @@ func (u *URLPathAuthOut) AddAuth(ctx context.Context, r *http.Request, p interfa
 		r.URL.Path += sec
 	}
 	r.RequestURI = r.URL.RequestURI()
+	return nil
 }
 
 func init() { authplugins.RegisterOutgoing(&URLPathAuthOut{}) }

--- a/app/auth/plugins/urlpath/urlpath_test.go
+++ b/app/auth/plugins/urlpath/urlpath_test.go
@@ -19,7 +19,9 @@ func TestURLPathOutgoingAddAuth(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.URL.Path; got != "/api/secret" {
 		t.Fatalf("expected '/api/secret', got %s", got)
 	}
@@ -72,7 +74,9 @@ func TestURLPathTrailingSlash(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
 	if got := r.URL.Path; got != "/api/s" {
 		t.Fatalf("expected '/api/s', got %s", got)
 	}
@@ -117,20 +121,26 @@ func TestURLPathOutgoingEdgeCases(t *testing.T) {
 	p := URLPathAuthOut{}
 	// invalid params type
 	r := &http.Request{URL: &url.URL{Path: "/api"}}
-	p.AddAuth(context.Background(), r, struct{}{})
+	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if r.URL.Path != "/api" {
 		t.Fatalf("path changed for invalid params: %s", r.URL.Path)
 	}
 	// missing secrets
 	r = &http.Request{URL: &url.URL{Path: "/api"}}
-	p.AddAuth(context.Background(), r, &outParams{})
+	if err := p.AddAuth(context.Background(), r, &outParams{}); err == nil {
+		t.Fatal("expected error")
+	}
 	if r.URL.Path != "/api" {
 		t.Fatalf("path changed for empty secrets: %s", r.URL.Path)
 	}
 	// secret loading error
 	r = &http.Request{URL: &url.URL{Path: "/api"}}
 	cfg := &outParams{Secrets: []string{"fail:oops"}}
-	p.AddAuth(context.Background(), r, cfg)
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
 	if r.URL.Path != "/api" {
 		t.Fatalf("path changed on load failure: %s", r.URL.Path)
 	}

--- a/app/auth/registry.go
+++ b/app/auth/registry.go
@@ -33,7 +33,7 @@ type AuthStripper interface {
 type OutgoingAuthPlugin interface {
 	Name() string
 	ParseParams(map[string]interface{}) (interface{}, error)
-	AddAuth(ctx context.Context, r *http.Request, params interface{})
+	AddAuth(ctx context.Context, r *http.Request, params interface{}) error
 	RequiredParams() []string
 	OptionalParams() []string
 }

--- a/app/auth/registry_test.go
+++ b/app/auth/registry_test.go
@@ -18,11 +18,11 @@ func (testIncoming) OptionalParams() []string                                   
 // minimal outgoing plugin
 type testOutgoing struct{ name string }
 
-func (p testOutgoing) Name() string                                          { return p.name }
-func (testOutgoing) ParseParams(map[string]interface{}) (interface{}, error) { return nil, nil }
-func (testOutgoing) AddAuth(context.Context, *http.Request, interface{})     {}
-func (testOutgoing) RequiredParams() []string                                { return nil }
-func (testOutgoing) OptionalParams() []string                                { return nil }
+func (p testOutgoing) Name() string                                            { return p.name }
+func (testOutgoing) ParseParams(map[string]interface{}) (interface{}, error)   { return nil, nil }
+func (testOutgoing) AddAuth(context.Context, *http.Request, interface{}) error { return nil }
+func (testOutgoing) RequiredParams() []string                                  { return nil }
+func (testOutgoing) OptionalParams() []string                                  { return nil }
 
 func TestRegistryIncomingOutgoing(t *testing.T) {
 	// Save original registries and restore after test

--- a/cmd/integrations/plugins/gdrive.go
+++ b/cmd/integrations/plugins/gdrive.go
@@ -1,0 +1,28 @@
+package plugins
+
+import "flag"
+
+// GDrive returns an Integration configured for the Google Drive API.
+func GDrive(name string) Integration {
+	return Integration{
+		Name:         name,
+		Destination:  "https://www.googleapis.com/drive/v3",
+		InRateLimit:  100,
+		OutRateLimit: 100,
+		OutgoingAuth: []AuthPluginConfig{{
+			Type:   "gcp_token",
+			Params: map[string]interface{}{},
+		}},
+	}
+}
+
+func init() { Register("gdrive", gdriveBuilder) }
+
+func gdriveBuilder(args []string) (Integration, error) {
+	fs := flag.NewFlagSet("gdrive", flag.ContinueOnError)
+	name := fs.String("name", "gdrive", "integration name")
+	if err := fs.Parse(args); err != nil {
+		return Integration{}, err
+	}
+	return GDrive(*name), nil
+}

--- a/cmd/integrations/plugins/gdrive_test.go
+++ b/cmd/integrations/plugins/gdrive_test.go
@@ -1,0 +1,13 @@
+package plugins
+
+import "testing"
+
+func TestGDriveIntegration(t *testing.T) {
+	i := GDrive("d")
+	if i.Destination != "https://www.googleapis.com/drive/v3" {
+		t.Fatalf("unexpected destination: %s", i.Destination)
+	}
+	if len(i.OutgoingAuth) != 1 || i.OutgoingAuth[0].Type != "gcp_token" {
+		t.Fatalf("missing gcp_token auth")
+	}
+}

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -28,6 +28,7 @@ AuthTranslator’s behaviour is extended by **plugins** – small Go packages th
 | Inbound   | `passthrough`      | Accepts every request with no authentication. |
 | Outbound  | `basic`            | Adds HTTP Basic credentials to the upstream request. |
 | Outbound  | `google_oidc`      | Attaches a Google identity token from the metadata service. |
+| Outbound  | `gcp_token`        | Uses a metadata service access token. |
 | Outbound  | `hmac_signature`   | Computes an HMAC for the request. |
 | Outbound  | `jwt`              | Adds a signed JWT to the request. |
 | Outbound  | `mtls`             | Sends a client certificate and exposes the CN via header. |
@@ -89,10 +90,10 @@ type AuthStripper interface {
     StripAuth(r *http.Request, params interface{})
 }
 
-   type OutgoingAuthPlugin interface {
+type OutgoingAuthPlugin interface {
        Name() string
        ParseParams(map[string]interface{}) (interface{}, error)
-       AddAuth(ctx context.Context, r *http.Request, params interface{})
+       AddAuth(ctx context.Context, r *http.Request, params interface{}) error
        RequiredParams() []string
        OptionalParams() []string
    }

--- a/docs/integration-plugins.md
+++ b/docs/integration-plugins.md
@@ -29,6 +29,7 @@ Think of it as a *cookie‑cutter* that stamps out a ready‑to‑run block in y
 | `sendgrid` | `https://api.sendgrid.com` | `token` |
 | `servicenow` | `https://api.servicenow.com` | `token` |
 | `slack` | `https://slack.com/` | `token` |
+| `gdrive` | `https://www.googleapis.com/drive/v3` | `gcp_token` |
 | `stripe` | `https://api.stripe.com` | `token` |
 | `trufflehog` | `https://trufflehog.cloud/api` | `token` |
 | `twilio` | `https://api.twilio.com` | `basic` |


### PR DESCRIPTION
## Summary
- add `gcp_token` auth plugin to fetch OAuth tokens from the metadata server
- register new plugin and create tests
- add Google Drive integration plugin using `gcp_token`
- document new plugins in auth and integration docs
- refresh tokens one minute early and return errors from auth

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_684c911dfa2883268de3e9ec5720edd8