### PR TITLE
Replace ioutil.TempFile in tests

### DIFF
--- a/app/allowlist_file_test.go
+++ b/app/allowlist_file_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -16,7 +15,7 @@ func TestLoadAllowlistsInvalidFile(t *testing.T) {
 }
 
 func TestLoadAllowlistsInvalidYAML(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "bad*.yaml")
+	tmp, err := os.CreateTemp("", "bad*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -34,7 +33,7 @@ func TestLoadAllowlistsInvalidYAML(t *testing.T) {
 }
 
 func TestLoadAllowlistsUnknownField(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "unknown*.yaml")
+	tmp, err := os.CreateTemp("", "unknown*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/app/config_test.go
+++ b/app/config_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,7 +16,7 @@ func TestLoadConfigInvalidFile(t *testing.T) {
 }
 
 func TestLoadConfigInvalidYAML(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "bad*.yaml")
+	tmp, err := os.CreateTemp("", "bad*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -35,7 +34,7 @@ func TestLoadConfigInvalidYAML(t *testing.T) {
 }
 
 func TestLoadConfigUnknownField(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "unknown*.yaml")
+	tmp, err := os.CreateTemp("", "unknown*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,7 +51,7 @@ func TestLoadConfigUnknownField(t *testing.T) {
 }
 
 func TestLoadConfigValid(t *testing.T) {
-	tmp, err := ioutil.TempFile("", "good*.yaml")
+	tmp, err := os.CreateTemp("", "good*.yaml")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Summary
- update tests to use `os.CreateTemp`
- remove deprecated `io/ioutil` imports

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6856695413248326b9c92dc44e18f29e