### PR TITLE
Use shared httpClient for downloads

### DIFF
--- a/app/main_test.go
+++ b/app/main_test.go
@@ -1073,7 +1073,7 @@ func TestMainMetricsDisabled(t *testing.T) {
 		t.Fatalf("start failed: %v", err)
 	}
 	time.Sleep(200 * time.Millisecond)
-	resp, err := http.Get("http://" + addr + "/_at_internal/metrics")
+	resp, err := httpClient.Get("http://" + addr + "/_at_internal/metrics")
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -1106,7 +1106,7 @@ func TestMainMetricsEnabled(t *testing.T) {
 		t.Fatalf("start failed: %v", err)
 	}
 	time.Sleep(200 * time.Millisecond)
-	resp, err := http.Get("http://" + addr + "/_at_internal/metrics")
+	resp, err := httpClient.Get("http://" + addr + "/_at_internal/metrics")
 	if err != nil {
 		t.Fatalf("request failed: %v", err)
 	}
@@ -1172,7 +1172,7 @@ func TestMainWatchReload(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	getReload := func() string {
-		resp, err := http.Get("http://" + addr + "/_at_internal/healthz")
+		resp, err := httpClient.Get("http://" + addr + "/_at_internal/healthz")
 		if err != nil {
 			t.Fatalf("request failed: %v", err)
 		}
@@ -1305,7 +1305,7 @@ func TestMainHTTP3NoTLS(t *testing.T) {
 	time.Sleep(200 * time.Millisecond)
 
 	// HTTP/1 request should succeed
-	resp, err := http.Get("http://" + addr + "/_at_internal/healthz")
+	resp, err := httpClient.Get("http://" + addr + "/_at_internal/healthz")
 	if err != nil {
 		t.Fatalf("http1 request failed: %v", err)
 	}

--- a/docs/runtime.md
+++ b/docs/runtime.md
@@ -13,7 +13,7 @@ This guide explains how AuthTranslator behaves at runtime and lists the service 
 
 ## Hot reload
 
-Send `SIGHUP` or run with `-watch` to reload the configuration and allowlist files without dropping connections. The watcher re-adds itself when files are replaced so edits trigger a reload automatically.
+Send `SIGHUP` or run with `-watch` to reload the configuration and allowlist files without dropping connections. The watcher re-adds itself when files are replaced so edits trigger a reload automatically. Remote configuration URLs are fetched with a 10&nbsp;second HTTP timeout.
 
 ---
 


### PR DESCRIPTION
## Summary
- add a package-level HTTP client with timeout
- fetch remote config using the client
- update tests to use the client
- mention the timeout in runtime docs

## Testing
- `make precommit` *(fails: can't load config: unsupported version of the configuration)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6856691820d08326814c5d0de7cadb2d