### PR TITLE
Add Slack post_channels capability

### DIFF
--- a/app/integrations/plugins/slack/capabilities.go
+++ b/app/integrations/plugins/slack/capabilities.go
@@ -35,4 +35,20 @@ func init() {
 			return []integrationplugins.CallRule{rule}, nil
 		},
 	})
+
+	integrationplugins.RegisterCapability("slack", "post_channels", integrationplugins.CapabilitySpec{
+		Params: []string{"channels"},
+		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
+			ch, _ := p["channels"].([]interface{})
+			if len(ch) == 0 {
+				return nil, fmt.Errorf("channels required")
+			}
+			allowed := make([]interface{}, len(ch))
+			for i, c := range ch {
+				allowed[i] = c
+			}
+			rule := integrationplugins.CallRule{Path: "/api/chat.postMessage", Methods: map[string]integrationplugins.RequestConstraint{"POST": {Body: map[string]interface{}{"channel": allowed}}}}
+			return []integrationplugins.CallRule{rule}, nil
+		},
+	})
 }

--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -158,6 +158,9 @@ func TestListCapsOutput(t *testing.T) {
 	if !strings.Contains(out, "post_channels_as (params: username,channels)") {
 		t.Fatalf("missing capability info: %s", out)
 	}
+	if !strings.Contains(out, "post_channels (params: channels)") {
+		t.Fatalf("missing capability info: %s", out)
+	}
 }
 
 func TestRemoveEntry(t *testing.T) {

--- a/cmd/allowlist/plugins/registry_test.go
+++ b/cmd/allowlist/plugins/registry_test.go
@@ -25,6 +25,11 @@ func TestRegistryInitialization(t *testing.T) {
 	} else if !reflect.DeepEqual(spec.Params, []string{"username", "channels"}) {
 		t.Fatalf("unexpected post_channels_as params: %v", spec.Params)
 	}
+	if spec, ok := slack["post_channels"]; !ok {
+		t.Fatalf("post_channels capability missing")
+	} else if !reflect.DeepEqual(spec.Params, []string{"channels"}) {
+		t.Fatalf("unexpected post_channels params: %v", spec.Params)
+	}
 
 	github, ok := list["github"]
 	if !ok {

--- a/cmd/allowlist/plugins/slack.go
+++ b/cmd/allowlist/plugins/slack.go
@@ -3,4 +3,5 @@ package plugins
 func init() {
 	RegisterCapability("slack", "post_public_as", CapabilitySpec{Params: []string{"username"}})
 	RegisterCapability("slack", "post_channels_as", CapabilitySpec{Params: []string{"username", "channels"}})
+	RegisterCapability("slack", "post_channels", CapabilitySpec{Params: []string{"channels"}})
 }

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -47,6 +47,7 @@ Run `go run ./cmd/allowlist list` to list capabilities from your build. For quic
 | servicenow | query_status | – |
 | servicenow | update_ticket | – |
 | slack | post_channels_as | username, channels |
+| slack | post_channels | channels |
 | slack | post_public_as | username |
 | stripe | create_charge | – |
 | stripe | create_customer | – |


### PR DESCRIPTION
## Summary
- support posting to specified Slack channels via `post_channels`
- test new capability and CLI listing
- document new capability

## Testing
- `make precommit` *(fails: unsupported version of golangci-lint config)*
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68566e91fefc8326a7f35c1f0151076f