### PR TITLE
Rename Slack capability to post_as

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 | Centralized secret custody | Only the proxy stores integration secrets; developers never see them. |
 | Plug-in everything | Auth types, secret back-ends, metrics, and integration templates are Go plug-ins. |
 | Per-caller / per-integration rate-limits | Backed by Redis or in-memory. |
-| Granular request authorization | Grant callers high-level **capabilities** (e.g. `post_public_as`) or fine-grained filters on path, query, headers, and body. |
+| Granular request authorization | Grant callers high-level **capabilities** (e.g. `post_as`) or fine-grained filters on path, query, headers, and body. |
 | Hot-reload | `SIGHUP` or `-watch` picks up new configs without dropping connections. |
 
 ---

--- a/app/allowlist_validate_test.go
+++ b/app/allowlist_validate_test.go
@@ -91,7 +91,7 @@ func TestValidateAllowlistEntriesCapabilityParamErrors(t *testing.T) {
 		Callers: []CallerConfig{{
 			ID: "c",
 			Capabilities: []integrationplugins.CapabilityConfig{{
-                               Name:   "post_as",
+				Name:   "post_as",
 				Params: map[string]interface{}{"username": "u", "extra": "bad"},
 			}},
 		}},
@@ -105,7 +105,7 @@ func TestValidateAllowlistEntriesCapabilityParamErrors(t *testing.T) {
 		Callers: []CallerConfig{{
 			ID: "c",
 			Capabilities: []integrationplugins.CapabilityConfig{{
-                               Name:   "post_as",
+				Name:   "post_as",
 				Params: map[string]interface{}{"username": ""},
 			}},
 		}},

--- a/app/allowlist_validate_test.go
+++ b/app/allowlist_validate_test.go
@@ -91,7 +91,7 @@ func TestValidateAllowlistEntriesCapabilityParamErrors(t *testing.T) {
 		Callers: []CallerConfig{{
 			ID: "c",
 			Capabilities: []integrationplugins.CapabilityConfig{{
-				Name:   "post_public_as",
+                               Name:   "post_as",
 				Params: map[string]interface{}{"username": "u", "extra": "bad"},
 			}},
 		}},
@@ -105,7 +105,7 @@ func TestValidateAllowlistEntriesCapabilityParamErrors(t *testing.T) {
 		Callers: []CallerConfig{{
 			ID: "c",
 			Capabilities: []integrationplugins.CapabilityConfig{{
-				Name:   "post_public_as",
+                               Name:   "post_as",
 				Params: map[string]interface{}{"username": ""},
 			}},
 		}},

--- a/app/integrations/plugins/slack/capabilities.go
+++ b/app/integrations/plugins/slack/capabilities.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-	integrationplugins.RegisterCapability("slack", "post_public_as", integrationplugins.CapabilitySpec{
+       integrationplugins.RegisterCapability("slack", "post_as", integrationplugins.CapabilitySpec{
 		Params: []string{"username"},
 		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
 			user, _ := p["username"].(string)

--- a/app/integrations/plugins/slack/capabilities.go
+++ b/app/integrations/plugins/slack/capabilities.go
@@ -7,7 +7,7 @@ import (
 )
 
 func init() {
-       integrationplugins.RegisterCapability("slack", "post_as", integrationplugins.CapabilitySpec{
+	integrationplugins.RegisterCapability("slack", "post_as", integrationplugins.CapabilitySpec{
 		Params: []string{"username"},
 		Generate: func(p map[string]interface{}) ([]integrationplugins.CallRule, error) {
 			user, _ := p["username"].(string)

--- a/app/integrations/plugins/slack/slack_test.go
+++ b/app/integrations/plugins/slack/slack_test.go
@@ -14,9 +14,9 @@ func TestSlackCapabilities(t *testing.T) {
 		t.Fatalf("expected 3 capabilities, got %d", len(caps))
 	}
 
-	spec, ok := caps["post_public_as"]
-	if !ok {
-		t.Fatalf("post_public_as not registered")
+       spec, ok := caps["post_as"]
+       if !ok {
+               t.Fatalf("post_as not registered")
 	}
 	rules, err := spec.Generate(map[string]interface{}{"username": "bot"})
 	if err != nil {

--- a/app/integrations/plugins/slack/slack_test.go
+++ b/app/integrations/plugins/slack/slack_test.go
@@ -14,9 +14,9 @@ func TestSlackCapabilities(t *testing.T) {
 		t.Fatalf("expected 3 capabilities, got %d", len(caps))
 	}
 
-       spec, ok := caps["post_as"]
-       if !ok {
-               t.Fatalf("post_as not registered")
+	spec, ok := caps["post_as"]
+	if !ok {
+		t.Fatalf("post_as not registered")
 	}
 	rules, err := spec.Generate(map[string]interface{}{"username": "bot"})
 	if err != nil {

--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -152,9 +152,9 @@ func TestListCapsOutput(t *testing.T) {
 	if !strings.Contains(out, "slack:") {
 		t.Fatalf("missing slack integration in output: %s", out)
 	}
-       if !strings.Contains(out, "post_as (params: username)") {
-               t.Fatalf("missing capability info: %s", out)
-       }
+	if !strings.Contains(out, "post_as (params: username)") {
+		t.Fatalf("missing capability info: %s", out)
+	}
 	if !strings.Contains(out, "post_channels_as (params: username,channels)") {
 		t.Fatalf("missing capability info: %s", out)
 	}

--- a/cmd/allowlist/main_test.go
+++ b/cmd/allowlist/main_test.go
@@ -152,9 +152,9 @@ func TestListCapsOutput(t *testing.T) {
 	if !strings.Contains(out, "slack:") {
 		t.Fatalf("missing slack integration in output: %s", out)
 	}
-	if !strings.Contains(out, "post_public_as (params: username)") {
-		t.Fatalf("missing capability info: %s", out)
-	}
+       if !strings.Contains(out, "post_as (params: username)") {
+               t.Fatalf("missing capability info: %s", out)
+       }
 	if !strings.Contains(out, "post_channels_as (params: username,channels)") {
 		t.Fatalf("missing capability info: %s", out)
 	}

--- a/cmd/allowlist/plugins/registry_test.go
+++ b/cmd/allowlist/plugins/registry_test.go
@@ -15,10 +15,10 @@ func TestRegistryInitialization(t *testing.T) {
 	if !ok {
 		t.Fatalf("slack capabilities missing")
 	}
-	if spec, ok := slack["post_public_as"]; !ok {
-		t.Fatalf("post_public_as capability missing")
-	} else if !reflect.DeepEqual(spec.Params, []string{"username"}) {
-		t.Fatalf("unexpected post_public_as params: %v", spec.Params)
+       if spec, ok := slack["post_as"]; !ok {
+               t.Fatalf("post_as capability missing")
+       } else if !reflect.DeepEqual(spec.Params, []string{"username"}) {
+               t.Fatalf("unexpected post_as params: %v", spec.Params)
 	}
 	if spec, ok := slack["post_channels_as"]; !ok {
 		t.Fatalf("post_channels_as capability missing")

--- a/cmd/allowlist/plugins/registry_test.go
+++ b/cmd/allowlist/plugins/registry_test.go
@@ -15,10 +15,10 @@ func TestRegistryInitialization(t *testing.T) {
 	if !ok {
 		t.Fatalf("slack capabilities missing")
 	}
-       if spec, ok := slack["post_as"]; !ok {
-               t.Fatalf("post_as capability missing")
-       } else if !reflect.DeepEqual(spec.Params, []string{"username"}) {
-               t.Fatalf("unexpected post_as params: %v", spec.Params)
+	if spec, ok := slack["post_as"]; !ok {
+		t.Fatalf("post_as capability missing")
+	} else if !reflect.DeepEqual(spec.Params, []string{"username"}) {
+		t.Fatalf("unexpected post_as params: %v", spec.Params)
 	}
 	if spec, ok := slack["post_channels_as"]; !ok {
 		t.Fatalf("post_channels_as capability missing")

--- a/cmd/allowlist/plugins/slack.go
+++ b/cmd/allowlist/plugins/slack.go
@@ -1,7 +1,7 @@
 package plugins
 
 func init() {
-       RegisterCapability("slack", "post_as", CapabilitySpec{Params: []string{"username"}})
+	RegisterCapability("slack", "post_as", CapabilitySpec{Params: []string{"username"}})
 	RegisterCapability("slack", "post_channels_as", CapabilitySpec{Params: []string{"username", "channels"}})
 	RegisterCapability("slack", "post_channels", CapabilitySpec{Params: []string{"channels"}})
 }

--- a/cmd/allowlist/plugins/slack.go
+++ b/cmd/allowlist/plugins/slack.go
@@ -1,7 +1,7 @@
 package plugins
 
 func init() {
-	RegisterCapability("slack", "post_public_as", CapabilitySpec{Params: []string{"username"}})
+       RegisterCapability("slack", "post_as", CapabilitySpec{Params: []string{"username"}})
 	RegisterCapability("slack", "post_channels_as", CapabilitySpec{Params: []string{"username", "channels"}})
 	RegisterCapability("slack", "post_channels", CapabilitySpec{Params: []string{"channels"}})
 }

--- a/docs/allowlist-config.md
+++ b/docs/allowlist-config.md
@@ -50,7 +50,7 @@ Look for a `capabilities.go` file under `app/integrations/plugins/<integration>/
   callers:
     - id: bot-123
       capabilities:
-        - name: post_public_as
+        - name: post_as
 ```
 Each capability item contains a `name` and optional `params` map.
 
@@ -118,6 +118,6 @@ A request passes if **any** rule (or capability‑expanded rule) matches.
 
 ## 3  Tips & conventions
 
-* **One capability ≈ one business use‑case** (e.g. `post_public_as`).
+* **One capability ≈ one business use‑case** (e.g. `post_as`).
 * Prefer **uppercase** HTTP methods (`GET`, `POST`) for consistency.
 * Log level `debug` will print which rule matched; helpful in staging.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -48,7 +48,7 @@ Run `go run ./cmd/allowlist list` to list capabilities from your build. For quic
 | servicenow | update_ticket | – |
 | slack | post_channels_as | username, channels |
 | slack | post_channels | channels |
-| slack | post_public_as | username |
+| slack | post_as | username |
 | stripe | create_charge | – |
 | stripe | create_customer | – |
 | stripe | refund_charge | – |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -5,7 +5,7 @@ AuthTranslator ships with two small helper binaries under **`cmd/`**:
 | Binary         | Purpose                                       | Typical usage                                     |
 | -------------- | --------------------------------------------- | ------------------------------------------------- |
 | `integrations` | Modify or inspect *config.yaml*. | `go run ./cmd/integrations slack -file config.yaml -token env:SLACK_TOKEN -signing-secret env:SLACK_SIGNING` |
-| `allowlist`    | Modify or inspect *allowlist.yaml*.           | `go run ./cmd/allowlist add -integration slack -caller bot -capability post_public_as` |
+| `allowlist`    | Modify or inspect *allowlist.yaml*.           | `go run ./cmd/allowlist add -integration slack -caller bot -capability post_as` |
 These helpers complement the [Configuration Reference](configuration.md) and [Allowlist Configuration](allowlist-config.md) docs.
 
 > **Heads‑up** Both helpers are thin wrappers around Go structs—check the `--help` output for the definitive flag list because the CLI evolves alongside the schema.
@@ -76,11 +76,11 @@ go run ./cmd/allowlist list
 
 # Grant a caller permission
 go run ./cmd/allowlist add -integration slack \
-  -caller bot-123 -capability post_public_as
+  -caller bot-123 -capability post_as
 
 # Revoke that permission
 go run ./cmd/allowlist remove -integration slack \
-  -caller bot-123 -capability post_public_as
+  -caller bot-123 -capability post_as
 ```
 
 #### Flags

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,7 +92,7 @@ Two ways to authorise a caller:
     - id: demo-user
       # easiest: assign a capability
       capabilities:
-        - name: post_public_as
+        - name: post_as
 
     - id: service‑42
       # granular example

--- a/docs/helm.md
+++ b/docs/helm.md
@@ -67,7 +67,7 @@ allowlist: |
       callers:
         - id: demo
           capabilities:
-            - name: post_public_as
+            - name: post_as
 
 ```
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,7 +5,7 @@ This folder holds **runnable snippets** you can copy‑paste while reading the d
 | File             | Purpose                                                                          |
 | ---------------- | -------------------------------------------------------------------------------- |
 | `config.yaml`    | Defines one Slack integration (destination, outgoing auth, 1‑minute rate‑limit). |
-| `allowlist.yaml` | Grants caller `demo-user` the `post_public_as` capability.              |
+| `allowlist.yaml` | Grants caller `demo-user` the `post_as` capability.              |
 
 ## Quick try‑out
 

--- a/examples/allowlist.yaml
+++ b/examples/allowlist.yaml
@@ -2,6 +2,6 @@
   callers:
     - id: "*"
       capabilities:
-        - name: post_public_as
+        - name: post_as
           params:
             username: AuthTranslator


### PR DESCRIPTION
## Summary
- rename slack capability `post_public_as` to `post_as`
- update docs and examples with the new capability name
- adjust tests for the new capability

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68573c1879608326bb716815ac1fb763