### PR TITLE
Add Twilio signature auth plugin

### DIFF
--- a/app/auth/plugins/plugins.go
+++ b/app/auth/plugins/plugins.go
@@ -11,5 +11,6 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/passthrough"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/slack_signature"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/token"
+	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/twilio_signature"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/urlpath"
 )

--- a/app/auth/plugins/twilio_signature/incoming.go
+++ b/app/auth/plugins/twilio_signature/incoming.go
@@ -1,0 +1,102 @@
+package twiliosignature
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"sort"
+
+	"github.com/winhowes/AuthTranslator/app/auth"
+	"github.com/winhowes/AuthTranslator/app/secrets"
+)
+
+// twilioSigParams configures Twilio webhook signature validation.
+type twilioSigParams struct {
+	Secrets []string `json:"secrets"`
+	Header  string   `json:"header"`
+}
+
+type TwilioSignatureAuth struct{}
+
+func (t *TwilioSignatureAuth) Name() string { return "twilio_signature" }
+
+func (t *TwilioSignatureAuth) RequiredParams() []string { return []string{"secrets"} }
+
+func (t *TwilioSignatureAuth) OptionalParams() []string { return []string{"header"} }
+
+func (t *TwilioSignatureAuth) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[twilioSigParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if len(p.Secrets) == 0 {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	if p.Header == "" {
+		p.Header = "X-Twilio-Signature"
+	}
+	return p, nil
+}
+
+func canonicalString(r *http.Request) string {
+	// Use the full URL including query string as seen by the proxy
+	base := r.URL.String()
+	// Include POST form parameters sorted by key
+	if err := r.ParseForm(); err == nil {
+		keys := make([]string, 0, len(r.PostForm))
+		for k := range r.PostForm {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, k := range keys {
+			vals := r.PostForm[k]
+			for _, v := range vals {
+				base += k + v
+			}
+		}
+	}
+	return base
+}
+
+func (t *TwilioSignatureAuth) Authenticate(ctx context.Context, r *http.Request, params interface{}) bool {
+	cfg, ok := params.(*twilioSigParams)
+	if !ok {
+		return false
+	}
+	sig := r.Header.Get(cfg.Header)
+	if sig == "" {
+		return false
+	}
+	// Ensure body is read and restored for ParseForm
+	if _, err := authplugins.GetBody(r); err != nil {
+		return false
+	}
+	base := canonicalString(r)
+	for _, ref := range cfg.Secrets {
+		secret, err := secrets.LoadSecret(ctx, ref)
+		if err != nil {
+			continue
+		}
+		mac := hmac.New(sha1.New, []byte(secret))
+		mac.Write([]byte(base))
+		expected := base64.StdEncoding.EncodeToString(mac.Sum(nil))
+		if hmac.Equal([]byte(expected), []byte(sig)) {
+			return true
+		}
+	}
+	return false
+}
+
+// StripAuth removes the Twilio signature header from the request.
+func (t *TwilioSignatureAuth) StripAuth(r *http.Request, params interface{}) {
+	cfg, ok := params.(*twilioSigParams)
+	if !ok {
+		return
+	}
+	r.Header.Del(cfg.Header)
+}
+
+func init() { authplugins.RegisterIncoming(&TwilioSignatureAuth{}) }

--- a/app/auth/plugins/twilio_signature/twilio_signature_test.go
+++ b/app/auth/plugins/twilio_signature/twilio_signature_test.go
@@ -1,0 +1,171 @@
+package twiliosignature
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha1"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"testing"
+
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
+)
+
+func sign(urlStr string, form url.Values, secret string) string {
+	keys := make([]string, 0, len(form))
+	for k := range form {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	base := urlStr
+	for _, k := range keys {
+		for _, v := range form[k] {
+			base += k + v
+		}
+	}
+	mac := hmac.New(sha1.New, []byte(secret))
+	mac.Write([]byte(base))
+	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func TestTwilioSignatureAuth(t *testing.T) {
+	form := url.Values{"Body": []string{"hello"}}
+	urlStr := "/path"
+	sig := sign(urlStr, form, "tok")
+	body := form.Encode()
+	r := &http.Request{Method: "POST", URL: &url.URL{Path: urlStr}, Header: http.Header{
+		"X-Twilio-Signature": []string{sig},
+		"Content-Type":       []string{"application/x-www-form-urlencoded"},
+	}, Body: io.NopCloser(strings.NewReader(body))}
+
+	p := TwilioSignatureAuth{}
+	t.Setenv("TOK", "tok")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to succeed")
+	}
+	p.StripAuth(r, cfg)
+	if h := r.Header.Get("X-Twilio-Signature"); h != "" {
+		t.Fatalf("expected header stripped, got %s", h)
+	}
+}
+
+func TestTwilioSignatureAuthFail(t *testing.T) {
+	form := url.Values{"Foo": []string{"bar"}}
+	urlStr := "/cb"
+	sig := sign(urlStr, form, "bad")
+	body := form.Encode()
+	r := &http.Request{Method: "POST", URL: &url.URL{Path: urlStr}, Header: http.Header{
+		"X-Twilio-Signature": []string{sig},
+		"Content-Type":       []string{"application/x-www-form-urlencoded"},
+	}, Body: io.NopCloser(strings.NewReader(body))}
+	p := TwilioSignatureAuth{}
+	t.Setenv("TOK", "good")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to fail")
+	}
+}
+
+func TestTwilioSignatureDefaults(t *testing.T) {
+	p := TwilioSignatureAuth{}
+	t.Setenv("S", "x")
+	cfgI, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:S"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	cfg, ok := cfgI.(*twilioSigParams)
+	if !ok {
+		t.Fatalf("wrong type %T", cfgI)
+	}
+	if cfg.Header != "X-Twilio-Signature" {
+		t.Fatalf("unexpected header %s", cfg.Header)
+	}
+}
+
+func TestTwilioSignatureMissingHeader(t *testing.T) {
+	r := &http.Request{Header: http.Header{}, URL: &url.URL{Path: "/p"}, Body: io.NopCloser(strings.NewReader(""))}
+	p := TwilioSignatureAuth{}
+	t.Setenv("S", "tok")
+	cfg, _ := p.ParseParams(map[string]interface{}{"secrets": []string{"env:S"}})
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected failure without header")
+	}
+}
+
+func TestTwilioSignatureParseParamsMissingSecrets(t *testing.T) {
+	p := TwilioSignatureAuth{}
+	if _, err := p.ParseParams(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestTwilioSignatureRequiredParams(t *testing.T) {
+	p := TwilioSignatureAuth{}
+	if got := p.RequiredParams(); len(got) != 1 || got[0] != "secrets" {
+		t.Fatalf("unexpected required params %v", got)
+	}
+}
+
+func TestTwilioSignatureOptionalParams(t *testing.T) {
+	p := TwilioSignatureAuth{}
+	if got := p.OptionalParams(); len(got) != 1 || got[0] != "header" {
+		t.Fatalf("unexpected optional params %v", got)
+	}
+}
+
+func TestTwilioSignatureInvalidParams(t *testing.T) {
+	r := &http.Request{Header: http.Header{"X-Twilio-Signature": []string{"sig"}}, URL: &url.URL{Path: "/"}, Body: io.NopCloser(strings.NewReader(""))}
+	p := TwilioSignatureAuth{}
+	if p.Authenticate(context.Background(), r, nil) {
+		t.Fatal("expected false for nil params")
+	}
+	if p.Authenticate(context.Background(), r, struct{}{}) {
+		t.Fatal("expected false for wrong type")
+	}
+}
+
+func TestTwilioSignatureStripAuthInvalidParams(t *testing.T) {
+	r := &http.Request{Header: http.Header{"X-Twilio-Signature": []string{"sig"}}}
+	p := TwilioSignatureAuth{}
+	p.StripAuth(r, nil)
+	if r.Header.Get("X-Twilio-Signature") == "" {
+		t.Fatal("header should remain when params nil")
+	}
+	p.StripAuth(r, struct{}{})
+	if r.Header.Get("X-Twilio-Signature") == "" {
+		t.Fatal("header should remain when params wrong type")
+	}
+}
+
+func TestTwilioSignatureMultipleSecrets(t *testing.T) {
+	form := url.Values{"A": []string{"b"}}
+	urlStr := "/m"
+	sig := sign(urlStr, form, "good")
+	body := form.Encode()
+	r := &http.Request{Method: "POST", URL: &url.URL{Path: urlStr}, Header: http.Header{
+		"X-Twilio-Signature": []string{sig},
+		"Content-Type":       []string{"application/x-www-form-urlencoded"},
+	}, Body: io.NopCloser(strings.NewReader(body))}
+
+	p := TwilioSignatureAuth{}
+	t.Setenv("BAD", "bad")
+	t.Setenv("GOOD", "good")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:BAD", "env:GOOD"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected auth using second secret")
+	}
+}

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -23,6 +23,7 @@ AuthTranslator’s behaviour is extended by **plugins** – small Go packages th
 | Inbound   | `jwt`              | Verifies JWTs with provided keys. |
 | Inbound   | `mtls`             | Requires a trusted client certificate. |
 | Inbound   | `slack_signature`  | Validates Slack request signatures. |
+| Inbound   | `twilio_signature`  | Validates Twilio webhook signatures. |
 | Inbound   | `token`            | Compares a shared token header. |
 | Inbound   | `url_path`         | Checks a token embedded in the request path. |
 | Inbound   | `passthrough`      | Accepts every request with no authentication. |


### PR DESCRIPTION
## Summary
- implement `twilio_signature` inbound auth plugin
- register plugin
- document the new plugin
- test Twilio signature authentication

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68566e5bd7188326b06b7d2578be3b6b