### PR TITLE
Add more coverage for GCP token plugin

### DIFF
--- a/app/auth/plugins/gcp_token/gcp_token_test.go
+++ b/app/auth/plugins/gcp_token/gcp_token_test.go
@@ -3,6 +3,7 @@ package gcptoken
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -101,6 +102,83 @@ func TestGCPTokenWrongConfig(t *testing.T) {
 	r := &http.Request{Header: http.Header{}}
 	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
 		t.Fatal("expected error")
+	}
+	if r.Header.Get("Authorization") != "" {
+		t.Fatalf("expected no header")
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestGCPTokenHTTPErrors(t *testing.T) {
+	p := GCPToken{}
+	cfg, _ := p.ParseParams(map[string]any{})
+
+	oldClient := HTTPClient
+	HTTPClient = &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("fail")
+	})}
+	defer func() { HTTPClient = oldClient }()
+
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error on http failure")
+	}
+	if r.Header.Get("Authorization") != "" {
+		t.Fatalf("expected no header set")
+	}
+}
+
+func TestGCPTokenStatusError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "bad", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	oldHost := MetadataHost
+	oldClient := HTTPClient
+	MetadataHost = ts.URL
+	HTTPClient = ts.Client()
+	defer func() {
+		MetadataHost = oldHost
+		HTTPClient = oldClient
+		setCachedToken("", time.Time{})
+	}()
+
+	p := GCPToken{}
+	cfg, _ := p.ParseParams(map[string]any{})
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected status error")
+	}
+	if r.Header.Get("Authorization") != "" {
+		t.Fatalf("expected no header")
+	}
+}
+
+func TestGCPTokenDecodeError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("notjson"))
+	}))
+	defer ts.Close()
+
+	oldHost := MetadataHost
+	oldClient := HTTPClient
+	MetadataHost = ts.URL
+	HTTPClient = ts.Client()
+	defer func() {
+		MetadataHost = oldHost
+		HTTPClient = oldClient
+		setCachedToken("", time.Time{})
+	}()
+
+	p := GCPToken{}
+	cfg, _ := p.ParseParams(map[string]any{})
+	r := &http.Request{Header: http.Header{}}
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected decode error")
 	}
 	if r.Header.Get("Authorization") != "" {
 		t.Fatalf("expected no header")


### PR DESCRIPTION
## Summary
- expand gcp_token plugin tests to cover error paths

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68589ed5a6648326833dcfc93c28bdc2