### PR TITLE
Fix variable shadowing in k8s secret plugin

### DIFF
--- a/app/secrets/plugins/k8s/plugin.go
+++ b/app/secrets/plugins/k8s/plugin.go
@@ -69,8 +69,8 @@ func (k8sPlugin) Load(ctx context.Context, id string) (string, error) {
 		client = &http.Client{Transport: &http.Transport{TLSClientConfig: &tls.Config{RootCAs: pool}}, Timeout: client.Timeout}
 	}
 
-	url := fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/secrets/%s", host, port, namespace, name)
-	req, err := newRequest(ctx, "GET", url, nil)
+	apiURL := fmt.Sprintf("https://%s:%s/api/v1/namespaces/%s/secrets/%s", host, port, namespace, name)
+	req, err := newRequest(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## Summary
- avoid shadowing the `net/url` import in the kubernetes secrets plugin

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68589eb25ab48326a8edb9efeacb1b70