### PR TITLE
Fix local file detection in config loader

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -113,11 +113,13 @@ func usage() {
 }
 
 func isRemote(path string) bool {
-	u, err := url.Parse(path)
-	return err == nil && u.Scheme != "" && u.Scheme != "file"
+	return strings.Contains(path, "://")
 }
 
 func openSource(path string) (io.ReadCloser, error) {
+	if strings.HasPrefix(path, "file://") {
+		return os.Open(strings.TrimPrefix(path, "file://"))
+	}
 	if isRemote(path) {
 		req, err := http.NewRequestWithContext(context.Background(), "GET", path, nil)
 		if err != nil {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -263,6 +263,38 @@ func TestOpenSourceHTTPDialError(t *testing.T) {
 	}
 }
 
+func TestOpenSourceFileURL(t *testing.T) {
+	f, err := os.CreateTemp("", "src*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	if _, err := f.WriteString("ok"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer os.Remove(name)
+
+	rc, err := openSource("file://" + name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("unexpected body %q", data)
+	}
+}
+
+func TestIsRemoteWindowsPath(t *testing.T) {
+	if isRemote("C:\\path\\to\\file.yaml") {
+		t.Fatal("windows path detected as remote")
+	}
+}
+
 type errServer struct{}
 
 func (e *errServer) ListenAndServe() error                    { return fmt.Errorf("plain err") }


### PR DESCRIPTION
## Summary
- handle `file://` paths correctly and avoid misclassifying Windows paths as remote
- add tests for `openSource` with `file://` URLs and Windows paths

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68589eb25ab48326a8edb9efeacb1b70