### PR TITLE
Increase gcp_token test coverage

### DIFF
--- a/app/auth/plugins/gcp_token/gcp_token_test.go
+++ b/app/auth/plugins/gcp_token/gcp_token_test.go
@@ -184,3 +184,30 @@ func TestGCPTokenDecodeError(t *testing.T) {
 		t.Fatalf("expected no header")
 	}
 }
+
+func TestGCPTokenRequiredOptional(t *testing.T) {
+	p := GCPToken{}
+	if p.RequiredParams() != nil {
+		t.Fatalf("expected nil required params")
+	}
+	opts := p.OptionalParams()
+	if len(opts) != 2 || opts[0] != "header" || opts[1] != "prefix" {
+		t.Fatalf("unexpected optional params: %v", opts)
+	}
+}
+
+func TestGCPTokenParseParamsError(t *testing.T) {
+	p := GCPToken{}
+	if _, err := p.ParseParams(map[string]any{"unknown": true}); err == nil {
+		t.Fatal("expected parse error")
+	}
+}
+
+func TestFetchTokenRequestError(t *testing.T) {
+	oldHost := MetadataHost
+	MetadataHost = ":"
+	defer func() { MetadataHost = oldHost }()
+	if _, _, err := fetchToken(); err == nil {
+		t.Fatal("expected error from bad url")
+	}
+}


### PR DESCRIPTION
## Summary
- cover remaining branches in gcp_token auth plugin
- ensure RequiredParams and OptionalParams are checked
- validate ParseParams errors and fetchToken request failures

## Testing
- `go test -cover`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6858a3b286788326a6b0bc14ec3d3ea5