### PR TITLE
Fix CLI flag docs

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -54,7 +54,7 @@ go run ./cmd/integrations delete slack -file config.yaml
 
 | Flag       | Default                              | Meaning                    |
 | ---------- | ------------------------------------ | -------------------------- |
-| `--file`   | `config.yaml` | Path to the configuration file. |
+| `-file`   | `config.yaml` | Path to the configuration file. |
 
 ## 3  `allowlist` helper
 
@@ -87,11 +87,11 @@ go run ./cmd/allowlist remove -integration slack \
 
 | Flag            | Default          | Meaning                             |
 | --------------- | ---------------- | ----------------------------------- |
-| `--file`        | `allowlist.yaml` | Path to YAML file for `add`/`remove`. |
-| `--caller`      | –                | Caller ID for `add`/`remove`.       |
-| `--integration` | –                | Integration name for `add`/`remove`. |
-| `--capability`  | –                | Capability name for `add`/`remove`. |
-| `--params`      | ""               | Extra key=value pairs for `add` (optional). |
+| `-file`        | `allowlist.yaml` | Path to YAML file for `add`/`remove`. |
+| `-caller`      | –                | Caller ID for `add`/`remove`.       |
+| `-integration` | –                | Integration name for `add`/`remove`. |
+| `-capability`  | –                | Capability name for `add`/`remove`. |
+| `-params`      | ""               | Extra key=value pairs for `add` (optional). |
 
 ---
 


### PR DESCRIPTION
## Summary
- fix documentation for CLI helper flags

## Testing
- `make precommit` *(fails: unsupported golangci-lint config)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6858a51da9748326bedf7a6fb04635a2