### PR TITLE
Fix empty config handling

### DIFF
--- a/app/config_test.go
+++ b/app/config_test.go
@@ -97,3 +97,20 @@ func TestLoadConfigURL(t *testing.T) {
 		t.Fatalf("unexpected config %+v", cfg)
 	}
 }
+
+func TestLoadConfigEmptyFile(t *testing.T) {
+	tmp, err := os.CreateTemp("", "emptycfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(tmp.Name())
+	tmp.Close()
+
+	cfg, err := loadConfig(tmp.Name())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(cfg.Integrations) != 0 {
+		t.Fatalf("expected zero integrations, got %d", len(cfg.Integrations))
+	}
+}

--- a/app/main.go
+++ b/app/main.go
@@ -150,6 +150,9 @@ func loadConfig(filename string) (*Config, error) {
 
 	var config Config
 	if err := dec.Decode(&config); err != nil {
+		if errors.Is(err, io.EOF) {
+			return &Config{}, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Summary
- allow empty config files when parsing YAML
- test loading an empty config

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6858a50fc8448326bc105ea425595aa2