### PR TITLE
Increase main.go test coverage

### DIFF
--- a/app/main_test.go
+++ b/app/main_test.go
@@ -289,6 +289,32 @@ func TestOpenSourceFileURL(t *testing.T) {
 	}
 }
 
+func TestOpenSourceLocalPath(t *testing.T) {
+	f, err := os.CreateTemp("", "src*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	name := f.Name()
+	if _, err := f.WriteString("ok"); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+	defer os.Remove(name)
+
+	rc, err := openSource(name)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	data, err := io.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		t.Fatalf("read error: %v", err)
+	}
+	if string(data) != "ok" {
+		t.Fatalf("unexpected body %q", data)
+	}
+}
+
 func TestIsRemoteWindowsPath(t *testing.T) {
 	if isRemote("C:\\path\\to\\file.yaml") {
 		t.Fatal("windows path detected as remote")

--- a/app/watch_files_test.go
+++ b/app/watch_files_test.go
@@ -150,3 +150,37 @@ func TestWatchFilesRenameAddError(t *testing.T) {
 	cancel()
 	<-done
 }
+
+func TestWatchFilesCreateAddError(t *testing.T) {
+	mw := &mockWatcher{events: make(chan fsnotify.Event, 1), errors: make(chan error), addErr: fmt.Errorf("boom")}
+	old := newWatcher
+	newWatcher = func() (fileWatcher, error) { return mw, nil }
+	defer func() { newWatcher = old }()
+
+	ch := make(chan struct{}, 1)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { watchFiles(ctx, []string{"f"}, ch); close(done) }()
+	mw.events <- fsnotify.Event{Name: "f", Op: fsnotify.Create}
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timeout waiting for create event")
+	}
+	cancel()
+	<-done
+}
+
+func TestWatchFilesNewWatcherError(t *testing.T) {
+	old := newWatcher
+	newWatcher = func() (fileWatcher, error) { return nil, fmt.Errorf("fail") }
+	defer func() { newWatcher = old }()
+
+	done := make(chan struct{})
+	go func() { watchFiles(context.Background(), nil, make(chan struct{})); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("watchFiles did not exit on watcher error")
+	}
+}


### PR DESCRIPTION
## Summary
- add more watchFiles tests for error conditions
- test openSource with a local file path

## Testing
- `go test ./...`
- `go test ./app -coverprofile=coverage.out`


------
https://chatgpt.com/codex/tasks/task_e_6858a60ca4408326a2c3d9583a342b42