### PR TITLE
Fix global capability validation

### DIFF
--- a/app/allowlist_validate.go
+++ b/app/allowlist_validate.go
@@ -83,7 +83,12 @@ func validateAllowlistEntry(name string, callers []CallerConfig) error {
 func validateCapability(integration string, cap integrationplugins.CapabilityConfig) error {
 	spec, ok := integrationplugins.CapabilitiesFor(integration)[cap.Name]
 	if !ok {
-		return fmt.Errorf("unknown capability %s", cap.Name)
+		// Check for globally registered capabilities such as
+		// DangerouslyAllowFullAccess.
+		spec, ok = integrationplugins.CapabilitiesFor(integrationplugins.GlobalIntegration)[cap.Name]
+		if !ok {
+			return fmt.Errorf("unknown capability %s", cap.Name)
+		}
 	}
 	for p := range cap.Params {
 		valid := false

--- a/app/allowlist_validate_test.go
+++ b/app/allowlist_validate_test.go
@@ -191,3 +191,18 @@ func TestValidateAllowlistEntriesDoesNotModifyInput(t *testing.T) {
 		t.Fatalf("input modified: %#v", entries)
 	}
 }
+
+func TestValidateAllowlistEntriesGlobalCapability(t *testing.T) {
+	entries := []AllowlistEntry{{
+		Integration: "slack",
+		Callers: []CallerConfig{{
+			ID: "c",
+			Capabilities: []integrationplugins.CapabilityConfig{{
+				Name: integrationplugins.DangerouslyAllowFullAccess,
+			}},
+		}},
+	}}
+	if err := validateAllowlistEntries(entries); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- ensure allowlist validation recognizes capabilities registered for `*`
- test that global capabilities like `dangerously_allow_full_access` pass validation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687d6fe54b8c8326ade2f9b66341981c