### PR TITLE
Add find_replace auth plugin

### DIFF
--- a/app/auth/plugins/findreplace/findreplace_test.go
+++ b/app/auth/plugins/findreplace/findreplace_test.go
@@ -1,0 +1,147 @@
+package findreplace
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/winhowes/AuthTranslator/app/secrets"
+	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
+)
+
+func TestFindReplaceAddAuth(t *testing.T) {
+	r := &http.Request{
+		URL:    &url.URL{Scheme: "http", Host: "host", Path: "/PLACE", RawQuery: "q=PLACE"},
+		Header: http.Header{"H-PLACE": []string{"val PLACE"}},
+		Body:   io.NopCloser(strings.NewReader("body PLACE")),
+		Host:   "host",
+	}
+	p := FindReplace{}
+	t.Setenv("FIND", "PLACE")
+	t.Setenv("REP", "SECRET")
+	cfg, err := p.ParseParams(map[string]interface{}{"find_secret": "env:FIND", "replace_secret": "env:REP"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if r.URL.Path != "/SECRET" || r.URL.RawQuery != "q=SECRET" {
+		t.Fatalf("unexpected url %s?%s", r.URL.Path, r.URL.RawQuery)
+	}
+	if v := r.Header.Get("H-SECRET"); v != "val SECRET" {
+		t.Fatalf("unexpected header value %s", v)
+	}
+	if _, ok := r.Header["H-PLACE"]; ok {
+		t.Fatal("old header still present")
+	}
+	body, _ := io.ReadAll(r.Body)
+	if string(body) != "body SECRET" {
+		t.Fatalf("unexpected body %q", string(body))
+	}
+}
+
+func TestFindReplaceAddAuthNoMatch(t *testing.T) {
+	r := &http.Request{URL: &url.URL{Path: "/foo"}, Header: http.Header{}, Body: io.NopCloser(strings.NewReader("bar"))}
+	p := FindReplace{}
+	t.Setenv("F", "x")
+	t.Setenv("R", "y")
+	cfg, err := p.ParseParams(map[string]interface{}{"find_secret": "env:F", "replace_secret": "env:R"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if r.URL.Path != "/foo" || r.URL.RawQuery != "" {
+		t.Fatalf("url changed: %s?%s", r.URL.Path, r.URL.RawQuery)
+	}
+	if len(r.Header) != 0 {
+		t.Fatalf("headers changed: %v", r.Header)
+	}
+	b, _ := io.ReadAll(r.Body)
+	if string(b) != "bar" {
+		t.Fatalf("body changed: %q", string(b))
+	}
+}
+
+type failPlugin struct{}
+
+func (failPlugin) Prefix() string                               { return "fail" }
+func (failPlugin) Load(context.Context, string) (string, error) { return "", io.EOF }
+
+type errReadCloser struct{}
+
+func (errReadCloser) Read([]byte) (int, error) { return 0, io.ErrUnexpectedEOF }
+func (errReadCloser) Close() error             { return nil }
+
+func TestFindReplaceEdgeCases(t *testing.T) {
+	secrets.Register(failPlugin{})
+	p := FindReplace{}
+	t.Setenv("FIND", "a")
+	t.Setenv("REP", "b")
+	cfg := &outParams{FindSecret: "env:FIND", ReplaceSecret: "env:REP"}
+
+	// invalid params type
+	r := &http.Request{URL: &url.URL{Path: "/"}, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(""))}
+	if err := p.AddAuth(context.Background(), r, struct{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+	// missing secrets
+	if err := p.AddAuth(context.Background(), r, &outParams{}); err == nil {
+		t.Fatal("expected error")
+	}
+	// secret load error
+	badCfg := &outParams{FindSecret: "fail:x", ReplaceSecret: "env:REP"}
+	if err := p.AddAuth(context.Background(), r, badCfg); err == nil {
+		t.Fatal("expected error")
+	}
+	badCfg = &outParams{FindSecret: "env:FIND", ReplaceSecret: "fail:x"}
+	if err := p.AddAuth(context.Background(), r, badCfg); err == nil {
+		t.Fatal("expected error")
+	}
+	// body read error
+	r.Body = errReadCloser{}
+	if err := p.AddAuth(context.Background(), r, cfg); err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestFindReplaceParseParams(t *testing.T) {
+	p := FindReplace{}
+	t.Setenv("F", "a")
+	t.Setenv("R", "b")
+	cfg, err := p.ParseParams(map[string]interface{}{"find_secret": "env:F", "replace_secret": "env:R"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if c := cfg.(*outParams); c.FindSecret != "env:F" || c.ReplaceSecret != "env:R" {
+		t.Fatalf("unexpected cfg %#v", c)
+	}
+	if _, err := p.ParseParams(map[string]interface{}{}); err == nil {
+		t.Fatal("expected error")
+	}
+	if _, err := p.ParseParams(map[string]interface{}{"find_secret": 1, "replace_secret": "env:R"}); err == nil {
+		t.Fatal("expected type error")
+	}
+	if _, err := p.ParseParams(map[string]interface{}{"find_secret": "env:F", "replace_secret": "env:R", "extra": true}); err == nil {
+		t.Fatal("expected unknown field error")
+	}
+}
+
+func TestFindReplaceMethods(t *testing.T) {
+	p := FindReplace{}
+	if p.Name() != "find_replace" {
+		t.Fatalf("unexpected name %s", p.Name())
+	}
+	rp := p.RequiredParams()
+	if len(rp) != 2 || rp[0] != "find_secret" || rp[1] != "replace_secret" {
+		t.Fatalf("unexpected required params %v", rp)
+	}
+	if op := p.OptionalParams(); op != nil {
+		t.Fatalf("unexpected optional params %v", op)
+	}
+}

--- a/app/auth/plugins/findreplace/outgoing.go
+++ b/app/auth/plugins/findreplace/outgoing.go
@@ -1,0 +1,95 @@
+package findreplace
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	authplugins "github.com/winhowes/AuthTranslator/app/auth"
+	"github.com/winhowes/AuthTranslator/app/secrets"
+)
+
+// outParams configures the find and replace plugin.
+type outParams struct {
+	FindSecret    string `json:"find_secret"`
+	ReplaceSecret string `json:"replace_secret"`
+}
+
+type FindReplace struct{}
+
+func (f *FindReplace) Name() string             { return "find_replace" }
+func (f *FindReplace) RequiredParams() []string { return []string{"find_secret", "replace_secret"} }
+func (f *FindReplace) OptionalParams() []string { return nil }
+
+func (f *FindReplace) ParseParams(m map[string]interface{}) (interface{}, error) {
+	p, err := authplugins.ParseParams[outParams](m)
+	if err != nil {
+		return nil, err
+	}
+	if p.FindSecret == "" || p.ReplaceSecret == "" {
+		return nil, fmt.Errorf("missing secrets")
+	}
+	return p, nil
+}
+
+func replaceAll(s, find, repl string) string {
+	if strings.Contains(s, find) {
+		return strings.ReplaceAll(s, find, repl)
+	}
+	return s
+}
+
+func (f *FindReplace) AddAuth(ctx context.Context, r *http.Request, params interface{}) error {
+	cfg, ok := params.(*outParams)
+	if !ok || cfg.FindSecret == "" || cfg.ReplaceSecret == "" {
+		return fmt.Errorf("invalid config")
+	}
+	findVal, err := secrets.LoadSecret(ctx, cfg.FindSecret)
+	if err != nil {
+		return err
+	}
+	replVal, err := secrets.LoadSecret(ctx, cfg.ReplaceSecret)
+	if err != nil {
+		return err
+	}
+
+	// URL components
+	r.URL.Scheme = replaceAll(r.URL.Scheme, findVal, replVal)
+	r.URL.Host = replaceAll(r.URL.Host, findVal, replVal)
+	r.Host = replaceAll(r.Host, findVal, replVal)
+	r.URL.Path = replaceAll(r.URL.Path, findVal, replVal)
+	if r.URL.RawPath != "" {
+		r.URL.RawPath = replaceAll(r.URL.RawPath, findVal, replVal)
+	}
+	r.URL.RawQuery = replaceAll(r.URL.RawQuery, findVal, replVal)
+	r.RequestURI = r.URL.RequestURI()
+
+	// Headers
+	newHeader := http.Header{}
+	for k, vals := range r.Header {
+		nk := replaceAll(k, findVal, replVal)
+		for _, v := range vals {
+			newHeader.Add(nk, replaceAll(v, findVal, replVal))
+		}
+	}
+	r.Header = newHeader
+
+	// Body
+	if r.Body != nil {
+		b, err := io.ReadAll(r.Body)
+		if err != nil {
+			return err
+		}
+		_ = r.Body.Close()
+		nb := replaceAll(string(b), findVal, replVal)
+		r.Body = io.NopCloser(bytes.NewBufferString(nb))
+		r.ContentLength = int64(len(nb))
+	}
+
+	return nil
+}
+
+func init() { authplugins.RegisterOutgoing(&FindReplace{}) }

--- a/app/auth/plugins/plugins.go
+++ b/app/auth/plugins/plugins.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/basic"
+	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/findreplace"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/gcp_token"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/github_signature"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/google_oidc"

--- a/docs/auth-plugins.md
+++ b/docs/auth-plugins.md
@@ -36,6 +36,7 @@ AuthTranslator’s behaviour is extended by **plugins** – small Go packages th
 | Outbound  | `token`            | Adds a token header on outgoing requests. |
 | Outbound  | `passthrough`      | Does nothing; useful when upstream handles auth. |
 | Outbound  | `url_path`         | Appends a secret segment to the request path. |
+| Outbound  | `find_replace`     | Replaces occurrences of one secret value with another across the URL, headers and body. |
 ---
 
 ## Detailed examples


### PR DESCRIPTION
## Summary
- add find_replace plugin for outgoing auth
- document it in auth plugin docs
- register plugin in plugins.go
- test plugin behaviour

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_687dfb3da8788326b51ec11ca2c17375