### PR TITLE
Prevent JWT alg confusion by rejecting HS256 when secret is an RSA public key

### DIFF
--- a/app/auth/plugins/jwt/incoming.go
+++ b/app/auth/plugins/jwt/incoming.go
@@ -117,6 +117,28 @@ func verifyRS256(parts []string, pemData []byte) bool {
 	return rsa.VerifyPKCS1v15(rsaPub, crypto.SHA256, hash[:], sig) == nil
 }
 
+func isRSAPublicPEM(data []byte) bool {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return false
+	}
+
+	switch block.Type {
+	case "PUBLIC KEY":
+		pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+		if err != nil {
+			return false
+		}
+		_, ok := pub.(*rsa.PublicKey)
+		return ok
+	case "RSA PUBLIC KEY":
+		_, err := x509.ParsePKCS1PublicKey(block.Bytes)
+		return err == nil
+	default:
+		return false
+	}
+}
+
 func matchAudience(claim interface{}, want string) bool {
 	switch v := claim.(type) {
 	case string:
@@ -154,6 +176,9 @@ func (j *JWTAuth) Authenticate(ctx context.Context, r *http.Request, p interface
 		}
 		switch alg {
 		case "HS256":
+			if isRSAPublicPEM([]byte(key)) {
+				continue
+			}
 			if verifyHS256(parts, []byte(key)) {
 				verified = true
 			}

--- a/app/auth/plugins/jwt/jwt_test.go
+++ b/app/auth/plugins/jwt/jwt_test.go
@@ -208,6 +208,31 @@ func TestJWTAuthRS256PKCS1PublicKey(t *testing.T) {
 	}
 }
 
+func TestJWTAuthRejectsHS256WithRSAPublicKeySecret(t *testing.T) {
+	secrets.ClearCache()
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, err := x509.MarshalPKIXPublicKey(&key.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})
+	publicKey := string(pemBytes)
+	tok := makeHS256Token("aud", "user", publicKey, time.Now().Add(time.Hour).Unix())
+	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer " + tok}}}
+	p := JWTAuth{}
+	t.Setenv("PUB", publicKey)
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:PUB"}, "audience": "aud"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to fail for HS256 token signed with RSA public key")
+	}
+}
+
 func TestJWTAuthUnsupportedAlgo(t *testing.T) {
 	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none"}`))
 	payload := base64.RawURLEncoding.EncodeToString([]byte(`{}`))
@@ -540,5 +565,39 @@ func TestVerifyRS256FailurePaths(t *testing.T) {
 	badParts := []string{parts[0], parts[1], "!!"}
 	if verifyRS256(badParts, pemData) {
 		t.Fatal("expected false for bad signature")
+	}
+}
+
+func TestIsRSAPublicPEM(t *testing.T) {
+	rsaKey, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubBytes, err := x509.MarshalPKIXPublicKey(&rsaKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !isRSAPublicPEM(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes})) {
+		t.Fatal("expected PUBLIC KEY rsa pem to be detected")
+	}
+	if !isRSAPublicPEM(pem.EncodeToMemory(&pem.Block{Type: "RSA PUBLIC KEY", Bytes: x509.MarshalPKCS1PublicKey(&rsaKey.PublicKey)})) {
+		t.Fatal("expected RSA PUBLIC KEY pem to be detected")
+	}
+	if isRSAPublicPEM([]byte("not pem")) {
+		t.Fatal("expected non-pem data to return false")
+	}
+	if isRSAPublicPEM(pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("x")})) {
+		t.Fatal("expected non-key pem block to return false")
+	}
+	ecKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ecPubBytes, err := x509.MarshalPKIXPublicKey(&ecKey.PublicKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if isRSAPublicPEM(pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: ecPubBytes})) {
+		t.Fatal("expected non-rsa public key to return false")
 	}
 }


### PR DESCRIPTION
### Motivation
- The JWT incoming plugin selected the verification algorithm based on the untrusted token `alg` header and attempted HS256 verification against all configured secrets, enabling algorithm confusion when an RSA public key was supplied as a secret. 
- The intent of the change is to block that auth-bypass vector by ensuring RSA public key material cannot be used as an HMAC secret.

### Description
- Add a new helper `isRSAPublicPEM` that safely detects PEM-encoded RSA public keys in either `PUBLIC KEY` or `RSA PUBLIC KEY` formats. 
- Skip HS256 verification for any configured secret that `isRSAPublicPEM` identifies as an RSA public key, preserving RS256 behavior for RSA keys. 
- Add `TestJWTAuthRejectsHS256WithRSAPublicKeySecret` to assert HS256 tokens signed with an RSA public key are rejected. 
- Add `TestIsRSAPublicPEM` unit test to cover detection of RSA and non-RSA PEM inputs.

### Testing
- Ran `go test ./app/auth/plugins/jwt` and all tests passed (`ok`).
- The new tests `TestJWTAuthRejectsHS256WithRSAPublicKeySecret` and `TestIsRSAPublicPEM` were executed as part of the package test run and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7fb06eb008326bad0958f9ef5e79e)