### PR TITLE
Fix integration pointer aliasing during config reload

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -248,8 +248,8 @@ func reload() error {
 
 	newMap := make(map[string]*Integration)
 	for i := range cfg.Integrations {
-		integ := cfg.Integrations[i]
-		if err := prepareIntegration(&integ); err != nil {
+		integ := &cfg.Integrations[i]
+		if err := prepareIntegration(integ); err != nil {
 			// cleanup any created limiters
 			for _, ni := range newMap {
 				ni.inLimiter.Stop()
@@ -270,7 +270,7 @@ func reload() error {
 		}
 		integ.inLimiter = NewRateLimiter(integ.InRateLimit, window, integ.RateLimitStrategy)
 		integ.outLimiter = NewRateLimiter(integ.OutRateLimit, window, integ.RateLimitStrategy)
-		newMap[integ.Name] = &integ
+		newMap[integ.Name] = integ
 	}
 
 	// Replace integrations and stop the old ones after success.

--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -183,6 +183,65 @@ func TestReloadMissingConfig(t *testing.T) {
 	}
 }
 
+func TestReloadMultipleIntegrationsRemainDistinct(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+	resetDenylistState()
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"one","destination":"http://one.example.com"},{"name":"two","destination":"http://two.example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	if err := os.WriteFile(alFile.Name(), []byte("[]"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := flag.Set("config", cfgFile.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Set("allowlist", alFile.Name()); err != nil {
+		t.Fatal(err)
+	}
+	if err := flag.Set("denylist", writeEmptyDenylist(t)); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := reload(); err != nil {
+		t.Fatalf("reload failed: %v", err)
+	}
+
+	one, ok := GetIntegration("one")
+	if !ok {
+		t.Fatal("integration one not loaded")
+	}
+	two, ok := GetIntegration("two")
+	if !ok {
+		t.Fatal("integration two not loaded")
+	}
+	if one == two {
+		t.Fatal("integrations alias the same pointer")
+	}
+	if one.Destination == two.Destination {
+		t.Fatalf("expected distinct destinations, got one=%q two=%q", one.Destination, two.Destination)
+	}
+}
+
 func TestReloadIntegrationError(t *testing.T) {
 	// reset global state
 	integrations.Lock()


### PR DESCRIPTION
### Motivation
- A reload bug caused each map entry to store the address of a loop-local copy, making all integrations alias the same object and behave like the final integration in the config. 
- This could cause incorrect auth/allowlist enforcement and route traffic to the wrong upstreams after a reload, so integrations must keep distinct pointers.

### Description
- Stop taking the address of the loop-local copy and instead take a pointer to the slice element with `integ := &cfg.Integrations[i]` and store that in the map via `newMap[integ.Name] = integ` in `reload()` (`app/main.go`).
- Add a regression test `TestReloadMultipleIntegrationsRemainDistinct` in `app/reload_test.go` that reloads two integrations and asserts they are distinct pointers and have different destinations.

### Testing
- Ran `go test ./app -run TestReloadMultipleIntegrationsRemainDistinct -count=1 -v` and it passed. 
- Ran `go test ./app -run TestReload -count=1` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9d43277c88326993afaf75051f380)