### PR TITLE
Evict idle token-bucket entries to prevent unbounded map growth

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -435,6 +435,27 @@ func NewRateLimiter(limit int, duration time.Duration, strategy string) *RateLim
 			}
 		}()
 	}
+	if limit > 0 && strategy == "token_bucket" && duration > 0 {
+		rl.resetTicker = time.NewTicker(duration)
+
+		go func() {
+			for {
+				select {
+				case <-rl.resetTicker.C:
+					cutoff := time.Now().Add(-duration)
+					rl.mu.Lock()
+					for k, b := range rl.buckets {
+						if b.last.Before(cutoff) {
+							delete(rl.buckets, k)
+						}
+					}
+					rl.mu.Unlock()
+				case <-rl.done:
+					return
+				}
+			}
+		}()
+	}
 
 	return rl
 }

--- a/app/ratelimiter_test.go
+++ b/app/ratelimiter_test.go
@@ -229,6 +229,24 @@ func TestTokenBucketMaxTokens(t *testing.T) {
 	}
 }
 
+func TestTokenBucketEvictsIdleBuckets(t *testing.T) {
+	rl := NewRateLimiter(1, 30*time.Millisecond, "token_bucket")
+	t.Cleanup(rl.Stop)
+
+	if !rl.Allow("idle-caller") {
+		t.Fatal("initial call should be allowed")
+	}
+
+	time.Sleep(80 * time.Millisecond)
+
+	rl.mu.Lock()
+	_, ok := rl.buckets["idle-caller"]
+	rl.mu.Unlock()
+	if ok {
+		t.Fatal("idle token bucket entry should be evicted")
+	}
+}
+
 func TestLeakyBucketPartialLeak(t *testing.T) {
 	rl := NewRateLimiter(2, 100*time.Millisecond, "leaky_bucket")
 	t.Cleanup(rl.Stop)


### PR DESCRIPTION
### Motivation
- The `token_bucket` rate limiter allocated a per-key `tokenBucket` entry and never removed it, allowing an attacker to cause unbounded memory growth by using many unique keys. 
- The intent is to retain token-bucket behavior for active callers while preventing permanent growth from stale/idle keys.

### Description
- Add a periodic cleanup loop in `NewRateLimiter` for the `token_bucket` strategy that creates a `time.Ticker` and deletes bucket entries whose `last` timestamp is older than the configured window (duration). 
- The cleanup loop runs alongside existing reset logic and stops via the existing `done` channel so limiter lifecycle and `Stop()` behavior remain unchanged. 
- Add a regression test `TestTokenBucketEvictsIdleBuckets` in `app/ratelimiter_test.go` that verifies idle token-bucket entries are evicted after the configured window.
- Modified files: `app/main.go` and `app/ratelimiter_test.go`.

### Testing
- Ran the package test suite with `go test ./app` and all tests passed successfully. 
- The new `TestTokenBucketEvictsIdleBuckets` was executed as part of the test run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb341eb88326989d5c0358a96303)