### PR TITLE
Pin Codecov GitHub Action to immutable commit SHA

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.out ./...
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Save module cache


### PR DESCRIPTION
### Motivation
- Mitigate a CI supply-chain risk by avoiding a mutable GitHub Action tag and pinning the Codecov action to a specific commit SHA instead of `codecov/codecov-action@v5`.

### Description
- Replace `uses: codecov/codecov-action@v5` with `uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5` in `.github/workflows/test.yml`, preserving the existing inputs and behavior.

### Testing
- Ran `go test ./...` in the repository root and all packages completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb34184c83268333aa43803cbcd1)