### PR TITLE
Fix Redis bucket limiter race with atomic Lua EVAL

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -736,11 +736,13 @@ local ttl = tonumber(ARGV[4])
 local val = redis.call("GET", key)
 local tokens = limit
 local last = now
+local updatedLast = now
 if val then
   local currentTokens, currentLast = string.match(val, "([^ ]+) ([^ ]+)")
   if currentTokens and currentLast then
     tokens = tonumber(currentTokens) or limit
     last = tonumber(currentLast) or now
+    updatedLast = last
   end
 end
 if windowSeconds > 0 then
@@ -751,14 +753,16 @@ if windowSeconds > 0 then
       tokens = limit
     end
     last = now
+    updatedLast = now
   end
 end
 local allowed = 0
 if tokens >= 1 then
   tokens = tokens - 1
   allowed = 1
+  updatedLast = now
 end
-redis.call("SET", key, tostring(tokens) .. " " .. tostring(now))
+redis.call("SET", key, tostring(tokens) .. " " .. tostring(updatedLast))
 if ttl <= 0 then
   redis.call("EXPIRE", key, 0)
 else

--- a/app/main.go
+++ b/app/main.go
@@ -722,98 +722,122 @@ func (rl *RateLimiter) allowRedis(key string) (bool, error) {
 }
 
 func (rl *RateLimiter) allowRedisTokenBucket(conn net.Conn, key string) (bool, error) {
-	now := time.Now()
-	val, err := redisCmdString(conn, "GET", key)
+	ttlMS := rl.window.Milliseconds()
+	if rl.window <= 0 {
+		ttlMS = 0
+	} else if ttlMS == 0 {
+		ttlMS = 1
+	}
+	const script = `local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local windowSeconds = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local val = redis.call("GET", key)
+local tokens = limit
+local last = now
+if val then
+  local currentTokens, currentLast = string.match(val, "([^ ]+) ([^ ]+)")
+  if currentTokens and currentLast then
+    tokens = tonumber(currentTokens) or limit
+    last = tonumber(currentLast) or now
+  end
+end
+if windowSeconds > 0 then
+  local refill = ((now - last) / 1000000000.0) * limit / windowSeconds
+  if refill > 0 then
+    tokens = tokens + refill
+    if tokens > limit then
+      tokens = limit
+    end
+    last = now
+  end
+end
+local allowed = 0
+if tokens >= 1 then
+  tokens = tokens - 1
+  allowed = 1
+end
+redis.call("SET", key, tostring(tokens) .. " " .. tostring(now))
+if ttl <= 0 then
+  redis.call("EXPIRE", key, 0)
+else
+  redis.call("PEXPIRE", key, ttl)
+end
+return allowed`
+	n, err := redisCmdInt(
+		conn,
+		"EVAL",
+		script,
+		"1",
+		key,
+		strconv.Itoa(rl.limit),
+		strconv.FormatFloat(rl.window.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(time.Now().UnixNano(), 10),
+		strconv.FormatInt(ttlMS, 10),
+	)
 	if err != nil {
 		return false, err
 	}
-	var tokens float64
-	var last int64
-	if val != "" {
-		parts := strings.Fields(val)
-		if len(parts) == 2 {
-			tokens, _ = strconv.ParseFloat(parts[0], 64)
-			last, _ = strconv.ParseInt(parts[1], 10, 64)
-		}
-	} else {
-		tokens = float64(rl.limit)
-		last = now.UnixNano()
-	}
-	lastTime := time.Unix(0, last)
-	refill := now.Sub(lastTime).Seconds() * float64(rl.limit) / rl.window.Seconds()
-	if refill > 0 {
-		tokens += refill
-		if tokens > float64(rl.limit) {
-			tokens = float64(rl.limit)
-		}
-		lastTime = now
-	}
-	if tokens < 1 {
-		val = fmt.Sprintf("%f %d", tokens, lastTime.UnixNano())
-		if err := redisCmd(conn, "SET", key, val); err != nil {
-			return false, err
-		}
-		cmd, ttl := redisTTLArgs(rl.window)
-		_, err := redisCmdInt(conn, cmd, key, ttl)
-		return false, err
-	}
-	tokens--
-	val = fmt.Sprintf("%f %d", tokens, now.UnixNano())
-	if err := redisCmd(conn, "SET", key, val); err != nil {
-		return false, err
-	}
-	cmd, ttl := redisTTLArgs(rl.window)
-	_, err = redisCmdInt(conn, cmd, key, ttl)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return n == 1, nil
 }
 
 func (rl *RateLimiter) allowRedisLeakyBucket(conn net.Conn, key string) (bool, error) {
-	now := time.Now()
-	val, err := redisCmdString(conn, "GET", key)
+	ttlMS := rl.window.Milliseconds()
+	if rl.window <= 0 {
+		ttlMS = 0
+	} else if ttlMS == 0 {
+		ttlMS = 1
+	}
+	const script = `local key = KEYS[1]
+local limit = tonumber(ARGV[1])
+local windowSeconds = tonumber(ARGV[2])
+local now = tonumber(ARGV[3])
+local ttl = tonumber(ARGV[4])
+local val = redis.call("GET", key)
+local level = 0
+local last = now
+if val then
+  local currentLevel, currentLast = string.match(val, "([^ ]+) ([^ ]+)")
+  if currentLevel and currentLast then
+    level = tonumber(currentLevel) or 0
+    last = tonumber(currentLast) or now
+  end
+end
+if windowSeconds > 0 then
+  local leaked = ((now - last) / 1000000000.0) * limit / windowSeconds
+  level = level - leaked
+  if level < 0 then
+    level = 0
+  end
+end
+local allowed = 0
+if level + 1 <= limit then
+  level = level + 1
+  allowed = 1
+end
+redis.call("SET", key, tostring(level) .. " " .. tostring(now))
+if ttl <= 0 then
+  redis.call("EXPIRE", key, 0)
+else
+  redis.call("PEXPIRE", key, ttl)
+end
+return allowed`
+	n, err := redisCmdInt(
+		conn,
+		"EVAL",
+		script,
+		"1",
+		key,
+		strconv.Itoa(rl.limit),
+		strconv.FormatFloat(rl.window.Seconds(), 'f', -1, 64),
+		strconv.FormatInt(time.Now().UnixNano(), 10),
+		strconv.FormatInt(ttlMS, 10),
+	)
 	if err != nil {
 		return false, err
 	}
-	var level float64
-	var last int64
-	if val != "" {
-		parts := strings.Fields(val)
-		if len(parts) == 2 {
-			level, _ = strconv.ParseFloat(parts[0], 64)
-			last, _ = strconv.ParseInt(parts[1], 10, 64)
-		}
-	} else {
-		level = 0
-		last = now.UnixNano()
-	}
-	lastTime := time.Unix(0, last)
-	leaked := now.Sub(lastTime).Seconds() * float64(rl.limit) / rl.window.Seconds()
-	level -= leaked
-	if level < 0 {
-		level = 0
-	}
-	if level+1 > float64(rl.limit) {
-		val = fmt.Sprintf("%f %d", level, now.UnixNano())
-		if err := redisCmd(conn, "SET", key, val); err != nil {
-			return false, err
-		}
-		cmd, ttl := redisTTLArgs(rl.window)
-		_, err := redisCmdInt(conn, cmd, key, ttl)
-		return false, err
-	}
-	level++
-	val = fmt.Sprintf("%f %d", level, now.UnixNano())
-	if err := redisCmd(conn, "SET", key, val); err != nil {
-		return false, err
-	}
-	cmd, ttl := redisTTLArgs(rl.window)
-	_, err = redisCmdInt(conn, cmd, key, ttl)
-	if err != nil {
-		return false, err
-	}
-	return true, nil
+	return n == 1, nil
 }
 
 func (rl *RateLimiter) retryAfterRedis(key string) (time.Duration, error) {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -420,8 +420,20 @@ func readRedisRequest(br *bufio.Reader) error {
 	if err != nil {
 		return err
 	}
-	for i := 0; i < n*2; i++ {
-		if _, err := br.ReadString('\n'); err != nil {
+	for i := 0; i < n; i++ {
+		bulkLenLine, err := br.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if len(bulkLenLine) == 0 || bulkLenLine[0] != '$' {
+			return fmt.Errorf("bad bulk prefix %q", bulkLenLine)
+		}
+		sz, err := strconv.Atoi(strings.TrimSpace(bulkLenLine[1:]))
+		if err != nil {
+			return err
+		}
+		buf := make([]byte, sz+2)
+		if _, err := io.ReadFull(br, buf); err != nil {
 			return err
 		}
 	}
@@ -445,14 +457,22 @@ func parseRedisCommand(t *testing.T, br *bufio.Reader) (string, []string) {
 	}
 	args := make([]string, 0, count)
 	for i := 0; i < count; i++ {
-		if _, err := br.ReadString('\n'); err != nil {
-			t.Fatal(err)
-		}
-		line, err := br.ReadString('\n')
+		lenLine, err := br.ReadString('\n')
 		if err != nil {
 			t.Fatal(err)
 		}
-		args = append(args, strings.TrimSpace(line))
+		if len(lenLine) == 0 || lenLine[0] != '$' {
+			t.Fatalf("bad bulk prefix %q", lenLine)
+		}
+		sz, err := strconv.Atoi(strings.TrimSpace(lenLine[1:]))
+		if err != nil {
+			t.Fatal(err)
+		}
+		buf := make([]byte, sz+2)
+		if _, err := io.ReadFull(br, buf); err != nil {
+			t.Fatal(err)
+		}
+		args = append(args, string(buf[:sz]))
 	}
 	if len(args) == 0 {
 		t.Fatal("no command received")
@@ -618,18 +638,8 @@ func TestAllowRedisTokenBucket(t *testing.T) {
 	go func() {
 		defer func() { srv.Close(); close(done) }()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("$-1\r\n"))
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
 			return
 		}
 		srv.Write([]byte(":1\r\n"))
@@ -652,19 +662,8 @@ func TestAllowRedisTokenBucketRefillClamp(t *testing.T) {
 	go func() {
 		defer func() { srv.Close(); close(done) }()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		val := fmt.Sprintf("%f %d", float64(rl.limit)+5, time.Now().Add(-time.Minute).UnixNano())
-		fmt.Fprintf(srv, "$%d\r\n%s\r\n", len(val), val)
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
 			return
 		}
 		srv.Write([]byte(":1\r\n"))
@@ -689,22 +688,12 @@ func TestAllowRedisTokenBucketReject(t *testing.T) {
 	go func() {
 		defer func() { srv.Close(); close(done) }()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
 			return
 		}
-		val := fmt.Sprintf("0 %d", ts)
-		srv.Write([]byte(fmt.Sprintf("$%d\r\n%s\r\n", len(val), val)))
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
-			return
-		}
-		srv.Write([]byte(":1\r\n"))
+		_ = ts
+		srv.Write([]byte(":0\r\n"))
 	}()
 	ok, err := rl.allowRedisTokenBucket(cli, "k")
 	if err != nil {
@@ -730,10 +719,12 @@ func TestAllowRedisLeakyBucketPoolFullClosesConnection(t *testing.T) {
 	rc := &recordingConn{Conn: cli}
 	rl.conns <- rc
 	phReady := make(chan struct{})
+	phInserted := make(chan struct{})
 	phSrv, phCli := net.Pipe()
 	go func() {
 		<-phReady
 		rl.conns <- phCli
+		close(phInserted)
 	}()
 	done := make(chan struct{})
 	go func() {
@@ -742,21 +733,12 @@ func TestAllowRedisLeakyBucketPoolFullClosesConnection(t *testing.T) {
 			close(done)
 		}()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
 			return
 		}
 		phReady <- struct{}{}
-		srv.Write([]byte("$-1\r\n"))
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
-			return
-		}
+		<-phInserted
 		srv.Write([]byte(":1\r\n"))
 	}()
 
@@ -788,22 +770,12 @@ func TestAllowRedisLeakyBucketReject(t *testing.T) {
 	go func() {
 		defer func() { srv.Close(); close(done) }()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
 			return
 		}
-		val := fmt.Sprintf("1 %d", ts)
-		srv.Write([]byte(fmt.Sprintf("$%d\r\n%s\r\n", len(val), val)))
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
-			return
-		}
-		srv.Write([]byte(":1\r\n"))
+		_ = ts
+		srv.Write([]byte(":0\r\n"))
 	}()
 	ok, err := rl.allowRedisLeakyBucket(cli, "k")
 	if err != nil {
@@ -823,18 +795,8 @@ func TestAllowRedisLeakyBucketAllow(t *testing.T) {
 	go func() {
 		defer func() { srv.Close(); close(done) }()
 		br := bufio.NewReader(srv)
-		if cmd, args := parseRedisCommand(t, br); cmd != "GET" || args[0] != "k" {
+		if cmd, args := parseRedisCommand(t, br); cmd != "EVAL" || args[1] != "1" || args[2] != "k" {
 			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("$-1\r\n"))
-		if cmd, args := parseRedisCommand(t, br); cmd != "SET" || args[0] != "k" {
-			t.Errorf("unexpected command %s %v", cmd, args)
-			return
-		}
-		srv.Write([]byte("+OK\r\n"))
-		if cmd, _ := parseRedisCommand(t, br); cmd != "EXPIRE" && cmd != "PEXPIRE" {
-			t.Errorf("unexpected command %s", cmd)
 			return
 		}
 		srv.Write([]byte(":1\r\n"))


### PR DESCRIPTION
### Motivation
- The Redis-backed `token_bucket` and `leaky_bucket` implementations performed non-atomic `GET -> compute -> SET` sequences, which allowed concurrent clients to observe the same state and bypass limits in distributed deployments.

### Description
- Replace the GET/SET sequences with a single atomic Redis `EVAL` Lua script for both `token_bucket` and `leaky_bucket` paths in `app/main.go`, preserving the existing stored state format (`"value timestamp"`) and TTL semantics.
- Compute refill/leak and decide allow/reject inside the Lua scripts so updates for a given key are serialized by Redis.
- Update test helpers in `app/main_test.go` to correctly parse RESP bulk strings by length (required for multi-line Lua script payloads) and change the Redis bucket tests to assert the `EVAL` command and integer allow/reject replies.

### Testing
- Ran the package test suite with `go test ./app`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb3431dc8326aa657aaf4de937bb)