### PR TITLE
Use default transport settings for mTLS outgoing plugin

### DIFF
--- a/app/auth/plugins/mtls/mtls_test.go
+++ b/app/auth/plugins/mtls/mtls_test.go
@@ -299,6 +299,12 @@ func TestMTLSOutgoingTransportFallsBackWhenDefaultWrapped(t *testing.T) {
 	if tr.TLSHandshakeTimeout <= 0 {
 		t.Fatal("expected fallback TLS handshake timeout")
 	}
+	if tr.MaxIdleConns != 100 {
+		t.Fatalf("expected fallback MaxIdleConns=100, got %d", tr.MaxIdleConns)
+	}
+	if tr.MaxIdleConnsPerHost != http.DefaultMaxIdleConnsPerHost {
+		t.Fatalf("expected fallback MaxIdleConnsPerHost=%d, got %d", http.DefaultMaxIdleConnsPerHost, tr.MaxIdleConnsPerHost)
+	}
 }
 
 func TestMTLSAuthNoSubjects(t *testing.T) {

--- a/app/auth/plugins/mtls/mtls_test.go
+++ b/app/auth/plugins/mtls/mtls_test.go
@@ -219,6 +219,42 @@ func TestMTLSOutgoingTransport(t *testing.T) {
 	}
 }
 
+func TestMTLSOutgoingTransportUsesDefaultTimeouts(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	t.Setenv("CERT", string(certPEM))
+	t.Setenv("KEY", string(keyPEM))
+
+	p := MTLSAuthOut{}
+	cfg, err := p.ParseParams(map[string]interface{}{"cert": "env:CERT", "key": "env:KEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := p.Transport(cfg)
+	if tr == nil {
+		t.Fatal("missing transport")
+	}
+	if tr.Proxy == nil {
+		t.Fatal("expected proxy function from default transport")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected dialer from default transport")
+	}
+	if tr.TLSHandshakeTimeout <= 0 {
+		t.Fatal("expected TLS handshake timeout from default transport")
+	}
+}
+
 func TestMTLSAuthNoSubjects(t *testing.T) {
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "any"}}
 	r := &http.Request{TLS: &tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}}}

--- a/app/auth/plugins/mtls/mtls_test.go
+++ b/app/auth/plugins/mtls/mtls_test.go
@@ -20,6 +20,10 @@ import (
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
 func TestMTLSAuth(t *testing.T) {
 	cert := &x509.Certificate{Subject: pkix.Name{CommonName: "client"}}
 	r := &http.Request{TLS: &tls.ConnectionState{VerifiedChains: [][]*x509.Certificate{{cert}}, PeerCertificates: []*x509.Certificate{cert}}}
@@ -252,6 +256,48 @@ func TestMTLSOutgoingTransportUsesDefaultTimeouts(t *testing.T) {
 	}
 	if tr.TLSHandshakeTimeout <= 0 {
 		t.Fatal("expected TLS handshake timeout from default transport")
+	}
+}
+
+func TestMTLSOutgoingTransportFallsBackWhenDefaultWrapped(t *testing.T) {
+	orig := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(*http.Request) (*http.Response, error) {
+		return nil, errors.New("unexpected call")
+	})
+	defer func() { http.DefaultTransport = orig }()
+
+	key, _ := rsa.GenerateKey(rand.Reader, 1024)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "client"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+	}
+	der, _ := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+
+	t.Setenv("CERT", string(certPEM))
+	t.Setenv("KEY", string(keyPEM))
+
+	p := MTLSAuthOut{}
+	cfg, err := p.ParseParams(map[string]interface{}{"cert": "env:CERT", "key": "env:KEY"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tr := p.Transport(cfg)
+	if tr == nil {
+		t.Fatal("missing transport")
+	}
+	if tr.Proxy == nil {
+		t.Fatal("expected fallback proxy function")
+	}
+	if tr.DialContext == nil {
+		t.Fatal("expected fallback dialer")
+	}
+	if tr.TLSHandshakeTimeout <= 0 {
+		t.Fatal("expected fallback TLS handshake timeout")
 	}
 }
 

--- a/app/auth/plugins/mtls/outgoing.go
+++ b/app/auth/plugins/mtls/outgoing.go
@@ -35,6 +35,7 @@ func defaultLikeTransport() *http.Transport {
 		}).DialContext,
 		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   http.DefaultMaxIdleConnsPerHost,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/app/auth/plugins/mtls/outgoing.go
+++ b/app/auth/plugins/mtls/outgoing.go
@@ -5,7 +5,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
+	"net"
 	"net/http"
+	"time"
 
 	"github.com/winhowes/AuthTranslator/app/auth"
 	"github.com/winhowes/AuthTranslator/app/secrets"
@@ -19,6 +21,25 @@ type outParams struct {
 }
 
 type MTLSAuthOut struct{}
+
+func defaultLikeTransport() *http.Transport {
+	if t, ok := http.DefaultTransport.(*http.Transport); ok {
+		return t.Clone()
+	}
+
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+}
 
 func (m *MTLSAuthOut) Name() string             { return "mtls" }
 func (m *MTLSAuthOut) RequiredParams() []string { return []string{"cert", "key"} }
@@ -44,11 +65,7 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 	if err != nil {
 		return nil, fmt.Errorf("tls pair: %w", err)
 	}
-	t, ok := http.DefaultTransport.(*http.Transport)
-	if !ok {
-		return nil, fmt.Errorf("default transport type mismatch")
-	}
-	t = t.Clone()
+	t := defaultLikeTransport()
 	if t.TLSClientConfig == nil {
 		t.TLSClientConfig = &tls.Config{}
 	} else {

--- a/app/auth/plugins/mtls/outgoing.go
+++ b/app/auth/plugins/mtls/outgoing.go
@@ -44,7 +44,18 @@ func (m *MTLSAuthOut) ParseParams(mp map[string]interface{}) (interface{}, error
 	if err != nil {
 		return nil, fmt.Errorf("tls pair: %w", err)
 	}
-	p.transport = &http.Transport{TLSClientConfig: &tls.Config{Certificates: []tls.Certificate{tlsCert}}}
+	t, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("default transport type mismatch")
+	}
+	t = t.Clone()
+	if t.TLSClientConfig == nil {
+		t.TLSClientConfig = &tls.Config{}
+	} else {
+		t.TLSClientConfig = t.TLSClientConfig.Clone()
+	}
+	t.TLSClientConfig.Certificates = []tls.Certificate{tlsCert}
+	p.transport = t
 	return p, nil
 }
 


### PR DESCRIPTION
### Motivation
- The mTLS outgoing plugin previously constructed a bare `http.Transport` with only `TLSClientConfig` set, which removed default proxy handling and dial/TLS timeouts and could allow outbound connections to hang indefinitely.
- The change aims to preserve the mTLS functionality (injecting client certs) while keeping the safe defaults from `http.DefaultTransport` to avoid resource exhaustion/DoS risks.

### Description
- Change `ParseParams` in the mTLS outgoing plugin to clone `http.DefaultTransport` (using `http.DefaultTransport.(*http.Transport).Clone()`), then clone/initialize its `TLSClientConfig` and inject the client certificate into that cloned transport.
- Assign the cloned transport with the certificate to the plugin's `transport` field so integrations that reuse the transport keep default timeouts and proxy behavior.
- Add a regression test `TestMTLSOutgoingTransportUsesDefaultTimeouts` in the existing `mtls_test.go` that verifies the generated transport exposes `Proxy`, `DialContext`, and a non-zero `TLSHandshakeTimeout` from the default transport.

### Testing
- Ran `go test ./app/auth/plugins/mtls -count=1`, which passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb38f7208326a62692b8a37bc8f1)