### PR TITLE
fix: enforce Redis TLS certificate verification for rate limiter

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -118,7 +118,7 @@ var logLevel = flag.String("log-level", "INFO", "log level: DEBUG, INFO, WARN, E
 var logFormat = flag.String("log-format", "text", "log output format: text or json")
 var redisAddr = flag.String("redis-addr", "", "redis address for rate limits (host:port or redis:// URL)")
 var redisTimeout = flag.Duration("redis-timeout", 5*time.Second, "dial timeout for redis")
-var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS; disables InsecureSkipVerify")
+var redisCA = flag.String("redis-ca", "", "path to CA certificate for Redis TLS")
 var maxBodySizeFlag = flag.Int64("max_body_size", authplugins.MaxBodySize, "maximum bytes buffered from request bodies (0 to disable)")
 var secretRefresh = flag.Duration("secret-refresh", 0, "refresh interval for cached secrets (0 disables)")
 var readTimeout = flag.Duration("read-timeout", 0, "HTTP server read timeout")
@@ -651,8 +651,6 @@ func (rl *RateLimiter) allowRedis(key string) (bool, error) {
 					return false, fmt.Errorf("failed to load CA file")
 				}
 				tlsConf.RootCAs = pool
-			} else {
-				tlsConf.InsecureSkipVerify = true
 			}
 			conn, err = tls.DialWithDialer(&d, "tcp", addr, tlsConf)
 		} else {
@@ -862,8 +860,6 @@ func (rl *RateLimiter) retryAfterRedis(key string) (time.Duration, error) {
 					return 0, fmt.Errorf("failed to load CA file")
 				}
 				tlsConf.RootCAs = pool
-			} else {
-				tlsConf.InsecureSkipVerify = true
 			}
 			conn, err = tls.DialWithDialer(&d, "tcp", addr, tlsConf)
 		} else {

--- a/app/redis_tls_auth_test.go
+++ b/app/redis_tls_auth_test.go
@@ -145,7 +145,7 @@ func TestRateLimiterRedisAuthUsername(t *testing.T) {
 	<-done
 }
 
-func TestRateLimiterRedisTLSAuth(t *testing.T) {
+func TestRateLimiterRedisTLSAuthRequiresVerification(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 1024)
 	tmpl := &x509.Certificate{
 		SerialNumber: big.NewInt(1),
@@ -166,29 +166,6 @@ func TestRateLimiterRedisTLSAuth(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		c, err := ln.Accept()
-		if err != nil {
-			return
-		}
-		defer c.Close()
-		br := bufio.NewReader(c)
-		if cmd, _ := readCommand(t, br); cmd != "AUTH" {
-			t.Errorf("cmd %s, want AUTH", cmd)
-			return
-		}
-		c.Write([]byte("+OK\r\n"))
-		if cmd, _ := readCommand(t, br); cmd != "INCR" {
-			t.Errorf("cmd %s, want INCR", cmd)
-		}
-		c.Write([]byte(":1\r\n"))
-		if cmd, _ := readCommand(t, br); cmd != "EXPIRE" {
-			t.Errorf("cmd %s, want EXPIRE", cmd)
-		}
-		c.Write([]byte(":1\r\n"))
-	}()
 	oldAddr := *redisAddr
 	oldTimeout := *redisTimeout
 	*redisAddr = "rediss://:pw@" + ln.Addr().String()
@@ -199,10 +176,9 @@ func TestRateLimiterRedisTLSAuth(t *testing.T) {
 		*redisAddr = oldAddr
 		*redisTimeout = oldTimeout
 	}()
-	if !rl.Allow("k") {
-		t.Fatal("allow failed")
+	if _, err := rl.allowRedis("k"); err == nil {
+		t.Fatal("expected TLS verification error")
 	}
-	<-done
 }
 
 func TestRateLimiterRedisTLSWithCA(t *testing.T) {

--- a/app/redis_tls_auth_test.go
+++ b/app/redis_tls_auth_test.go
@@ -8,6 +8,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"math/big"
 	"net"
 	"os"
@@ -166,6 +167,16 @@ func TestRateLimiterRedisTLSAuthRequiresVerification(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer ln.Close()
+	hsErr := make(chan error, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			hsErr <- err
+			return
+		}
+		defer c.Close()
+		hsErr <- c.(*tls.Conn).Handshake()
+	}()
 	oldAddr := *redisAddr
 	oldTimeout := *redisTimeout
 	*redisAddr = "rediss://:pw@" + ln.Addr().String()
@@ -178,6 +189,14 @@ func TestRateLimiterRedisTLSAuthRequiresVerification(t *testing.T) {
 	}()
 	if _, err := rl.allowRedis("k"); err == nil {
 		t.Fatal("expected TLS verification error")
+	} else {
+		var unknownAuthorityErr x509.UnknownAuthorityError
+		if !errors.As(err, &unknownAuthorityErr) {
+			t.Fatalf("expected x509.UnknownAuthorityError, got %v", err)
+		}
+	}
+	if err := <-hsErr; err == nil {
+		t.Fatal("expected server handshake error")
 	}
 }
 


### PR DESCRIPTION
### Motivation
- Close a security regression where `rediss://` connections disabled certificate validation via `InsecureSkipVerify`, allowing on‑path attackers to impersonate Redis and capture AUTH credentials or tamper with rate limiting state. 
- Ensure operators who opt into TLS get authentic server verification by default. 

### Description
- Removed the fallback that set `tls.Config.InsecureSkipVerify = true` when `--redis-ca` was not provided so TLS connections perform normal certificate verification by default in both `allowRedis` and `retryAfterRedis`. 
- Updated the `--redis-ca` flag description (removed the wording implying it "disables InsecureSkipVerify").
- Modified the existing tests in `app/redis_tls_auth_test.go` to assert that `rediss://` with an untrusted certificate fails verification unless a CA is provided, and renamed the test to `TestRateLimiterRedisTLSAuthRequiresVerification`.

### Testing
- Ran the package test suite with `go test ./app` and all tests passed. 
- The modified TLS verification tests exercise both failure without a CA and success when a CA is supplied (existing tests cover the latter), validating the behavior change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9eb35177083268f36d7bc1c2a9c95)