### PR TITLE
Namespace inbound rate limit keys by integration

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -1150,11 +1150,12 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	logger.Info("incoming request", "method", r.Method, "integration", integ.Name, "path", r.URL.Path, "caller_id", callerID)
 
 	r = r.WithContext(metrics.WithCaller(r.Context(), callerID))
+	limiterKey := integrationRateLimitKey(integ.Name, rateKey)
 
-	if !integ.inLimiter.Allow(rateKey) {
+	if !integ.inLimiter.Allow(limiterKey) {
 		logger.Warn("caller exceeded rate limit", "caller", rateKey, "host", host)
 		metrics.IncRateLimit(integ.Name)
-		if d := integ.inLimiter.RetryAfter(rateKey); d > 0 {
+		if d := integ.inLimiter.RetryAfter(limiterKey); d > 0 {
 			secs := int(math.Ceil(d.Seconds()))
 			if secs < 1 {
 				secs = 1
@@ -1259,6 +1260,10 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		rec.status = http.StatusOK
 	}
 	logger.Info("upstream response", "host", host, "status", rec.status)
+}
+
+func integrationRateLimitKey(integrationName, callerKey string) string {
+	return integrationName + ":" + callerKey
 }
 
 type server interface {

--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -698,7 +698,7 @@ func TestProxyHandlerIdentifierSetsCallerID(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 	integ.inLimiter.mu.Lock()
-	count := integ.inLimiter.requests["known-caller"]
+	count := integ.inLimiter.requests[integrationRateLimitKey(integ.Name, "known-caller")]
 	integ.inLimiter.mu.Unlock()
 	if count != 1 {
 		t.Fatalf("expected rate limit key for caller, got %d", count)


### PR DESCRIPTION
### Motivation
- Prevent cross-integration rate-limit collisions when Redis-backed limiting is enabled by ensuring counters are not keyed globally by caller IP or ID.

### Description
- Introduce `integrationRateLimitKey(integrationName, callerKey string) string` and use it to derive the limiter key for inbound checks in `proxyHandler` so rate keys are namespaced per integration.
- Use the new namespaced key for `inLimiter.Allow` and `inLimiter.RetryAfter` while leaving logging and user-facing messages using the original caller key unchanged.
- Update an existing test (`TestProxyHandlerIdentifierSetsCallerID` in `app/proxy_test.go`) to assert the namespaced in-memory key so the behaviour change is covered without adding a new test file.

### Testing
- Ran `go test ./app -run TestProxyHandlerIdentifierSetsCallerID -count=1` and it passed.
- Ran `go test ./app -run 'TestRateLimiterExceedLimit|TestRateLimiterRedisFallback' -count=1` and both tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ecdfb7fc832698a37f0e280c0804)