### PR TITLE
Avoid holding metrics locks during Prometheus writes (fix DoS)

### DIFF
--- a/app/metrics/builtin.go
+++ b/app/metrics/builtin.go
@@ -90,15 +90,18 @@ func (h *histogram) String() string {
 
 func (h *histogram) writeProm(w http.ResponseWriter, integ string) {
 	h.mu.Lock()
-	defer h.mu.Unlock()
+	buckets := append([]float64(nil), h.buckets...)
+	counts := append([]uint64(nil), h.counts...)
+	sum := h.sum
+	h.mu.Unlock()
 	var cum uint64
-	for i, b := range h.buckets {
-		cum += h.counts[i]
+	for i, b := range buckets {
+		cum += counts[i]
 		fmt.Fprintf(w, "authtranslator_request_duration_seconds_bucket{integration=%q,le=%q} %d\n", integ, strconv.FormatFloat(b, 'f', -1, 64), cum)
 	}
-	cum += h.counts[len(h.buckets)]
+	cum += counts[len(buckets)]
 	fmt.Fprintf(w, "authtranslator_request_duration_seconds_bucket{integration=%q,le=\"+Inf\"} %d\n", integ, cum)
-	fmt.Fprintf(w, "authtranslator_request_duration_seconds_sum{integration=%q} %f\n", integ, h.sum)
+	fmt.Fprintf(w, "authtranslator_request_duration_seconds_sum{integration=%q} %f\n", integ, sum)
 	fmt.Fprintf(w, "authtranslator_request_duration_seconds_count{integration=%q} %d\n", integ, cum)
 }
 
@@ -137,10 +140,18 @@ func WriteProm(w http.ResponseWriter) {
 		fmt.Fprintf(w, "authtranslator_requests_total{integration=%q} %s\n", kv.Key, kv.Value.String())
 	})
 	durationHistsMu.Lock()
+	type histSnapshot struct {
+		name string
+		h    *histogram
+	}
+	hists := make([]histSnapshot, 0, len(durationHists))
 	for name, h := range durationHists {
-		h.writeProm(w, name)
+		hists = append(hists, histSnapshot{name: name, h: h})
 	}
 	durationHistsMu.Unlock()
+	for _, hs := range hists {
+		hs.h.writeProm(w, hs.name)
+	}
 	rateLimitCounts.Do(func(kv expvar.KeyValue) {
 		fmt.Fprintf(w, "authtranslator_rate_limit_events_total{integration=%q} %s\n", kv.Key, kv.Value.String())
 	})

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,25 @@ type promPlugin struct{}
 func (*promPlugin) OnRequest(string, *http.Request)                          {}
 func (*promPlugin) OnResponse(string, string, *http.Request, *http.Response) {}
 func (*promPlugin) WriteProm(w http.ResponseWriter)                          { fmt.Fprintln(w, "custom_metric 1") }
+
+type blockingResponseWriter struct {
+	header  http.Header
+	blockCh <-chan struct{}
+	started chan<- struct{}
+	once    sync.Once
+}
+
+func (w *blockingResponseWriter) Header() http.Header { return w.header }
+
+func (w *blockingResponseWriter) Write(b []byte) (int, error) {
+	w.once.Do(func() {
+		close(w.started)
+	})
+	<-w.blockCh
+	return len(b), nil
+}
+
+func (w *blockingResponseWriter) WriteHeader(_ int) {}
 
 func TestMetricsHandlerEmpty(t *testing.T) {
 	Reset()
@@ -197,5 +217,49 @@ func TestWritePromSkipsMalformedUpstreamKeys(t *testing.T) {
 	}
 	if !strings.Contains(body, `authtranslator_upstream_responses_total{integration="foo",code="200"} 1`) {
 		t.Fatalf("missing valid upstream status metric: %s", body)
+	}
+}
+
+func TestWritePromDoesNotBlockRecordDurationForOtherIntegrations(t *testing.T) {
+	Reset()
+	RecordDuration("one", 100*time.Millisecond)
+
+	blockCh := make(chan struct{})
+	started := make(chan struct{})
+	bw := &blockingResponseWriter{
+		header:  make(http.Header),
+		blockCh: blockCh,
+		started: started,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		WriteProm(bw)
+		close(done)
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteProm did not start writing")
+	}
+
+	recordDone := make(chan struct{})
+	go func() {
+		RecordDuration("two", 50*time.Millisecond)
+		close(recordDone)
+	}()
+
+	select {
+	case <-recordDone:
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("RecordDuration blocked while metrics response writer was blocked")
+	}
+
+	close(blockCh)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteProm did not finish after unblocking writer")
 	}
 }

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )


### PR DESCRIPTION
### Motivation
- The `/metrics` exporter held the global `durationHistsMu` while writing histogram output and also held each histogram's `h.mu` during ResponseWriter I/O, which allowed a slow or malicious `/metrics` client to block `RecordDuration` for all requests and cause a DoS. 
- The change prevents long-running network writes from stalling request handlers by minimizing lock hold times while preserving exported metric semantics.

### Description
- Snapshot the `durationHists` map under `durationHistsMu` and release the lock before emitting any response data so the global mutex is not held during I/O (changed in `app/metrics/builtin.go`).
- For each histogram, copy `buckets`, `counts`, and `sum` under `h.mu` and release the per-histogram lock before calling `fmt.Fprintf`, preventing histogram-level locks from spanning slow writes (changed in `app/metrics/builtin.go`).
- Add a regression test to `app/metrics/metrics_test.go` that simulates a blocked metrics writer and verifies `RecordDuration` for another integration completes while the writer is stalled.

### Testing
- Ran `go test ./app/metrics` and the metrics package tests passed successfully. 
- Ran `go test ./...` and the full test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9ecdf2c30832690dd8f0d80020723)