### PR TITLE
Enforce configured token auth prefix on incoming headers

### DIFF
--- a/app/auth/plugins/token/incoming.go
+++ b/app/auth/plugins/token/incoming.go
@@ -42,7 +42,11 @@ func (t *TokenAuth) Authenticate(ctx context.Context, r *http.Request, p interfa
 	if !ok {
 		return false
 	}
-	tokenValue := strings.TrimPrefix(r.Header.Get(cfg.Header), cfg.Prefix)
+	headerValue := r.Header.Get(cfg.Header)
+	if cfg.Prefix != "" && !strings.HasPrefix(headerValue, cfg.Prefix) {
+		return false
+	}
+	tokenValue := strings.TrimPrefix(headerValue, cfg.Prefix)
 	for _, ref := range cfg.Secrets {
 		token, err := secrets.LoadSecret(ctx, ref)
 		if err != nil {

--- a/app/auth/plugins/token/token_test.go
+++ b/app/auth/plugins/token/token_test.go
@@ -56,6 +56,19 @@ func TestTokenIncomingPrefix(t *testing.T) {
 	}
 }
 
+func TestTokenIncomingConfiguredPrefixMissingInHeader(t *testing.T) {
+	r := &http.Request{Header: http.Header{"Authorization": []string{"secret"}}}
+	p := TokenAuth{}
+	t.Setenv("TOK", "secret")
+	cfg, err := p.ParseParams(map[string]interface{}{"secrets": []string{"env:TOK"}, "header": "Authorization", "prefix": "Bearer "})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Authenticate(context.Background(), r, cfg) {
+		t.Fatal("expected authentication to fail when configured prefix is missing from header")
+	}
+}
+
 func TestTokenIncomingPrefixMismatch(t *testing.T) {
 	r := &http.Request{Header: http.Header{"Authorization": []string{"Bearer secret"}}}
 	p := TokenAuth{}


### PR DESCRIPTION
### Motivation
- The incoming token auth previously used `strings.TrimPrefix` without verifying the prefix existed, allowing bare tokens to authenticate when a `prefix` was configured.
- This change prevents accidental weakening of the expected header format by enforcing the configured prefix before accepting the token.

### Description
- Require the configured `prefix` to be present on the incoming header by checking `strings.HasPrefix` before trimming in `app/auth/plugins/token/incoming.go`.
- Continue to use `strings.TrimPrefix` after verification and perform the constant-time comparison against loaded secrets to preserve behavior.
- Add a regression test `TestTokenIncomingConfiguredPrefixMissingInHeader` to `app/auth/plugins/token/token_test.go` that asserts authentication fails when the header omits a configured prefix.
- Updated tests are added to the existing token plugin test file per repository guidelines.

### Testing
- Ran `go test ./app/auth/plugins/token` and the package tests passed successfully.
- The new regression test `TestTokenIncomingConfiguredPrefixMissingInHeader` executes as part of the package tests and verifies the fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4976680c83268672ecd636adab0e)