### PR TITLE
Fix flaky transport mutation assertion in TestIntegrationPluginTransport

### DIFF
--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -822,6 +822,7 @@ func TestIntegrationPluginTransport(t *testing.T) {
 	if baseTr == nil {
 		t.Fatal("missing base transport")
 	}
+	baseIdleConnTimeout := baseTr.IdleConnTimeout
 
 	i := &Integration{
 		Name:              "plug",
@@ -853,7 +854,7 @@ func TestIntegrationPluginTransport(t *testing.T) {
 	if tr.IdleConnTimeout != time.Second || !tr.DisableKeepAlives {
 		t.Fatalf("integration settings not applied")
 	}
-	if baseTr.IdleConnTimeout != 0 {
+	if baseTr.IdleConnTimeout != baseIdleConnTimeout {
 		t.Fatalf("base transport mutated")
 	}
 	if tr.TLSClientConfig == nil || len(tr.TLSClientConfig.Certificates) == 0 {


### PR DESCRIPTION
### Motivation
- The test `TestIntegrationPluginTransport` assumed the base transport's `IdleConnTimeout` was `0`, which can vary by environment and caused intermittent failures; the test should instead snapshot and assert the value is preserved.

### Description
- Capture `baseTr.IdleConnTimeout` before calling `AddIntegration` and assert `baseTr.IdleConnTimeout` remains equal to that snapshot after the call, updating `app/integration_test.go` accordingly.

### Testing
- Ran `go test ./app -run TestIntegrationPluginTransport -count=1` which passed, and `go test ./...` which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4cb5d1a883268389435c52695a7b)