### PR TITLE
Normalize dynamically expanded capability rules during lookup

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -30,6 +30,19 @@ func splitPath(p string) []string {
 	return strings.Split(clean, "/")
 }
 
+func normalizeRule(r *CallRule) {
+	r.Segments = splitPath(r.Path)
+	methods := make(map[string]RequestConstraint, len(r.Methods))
+	for mth, cons := range r.Methods {
+		method := strings.TrimSpace(mth)
+		if method == "" {
+			continue
+		}
+		methods[strings.ToUpper(method)] = cons
+	}
+	r.Methods = methods
+}
+
 // validateAllowlist ensures callers and rules are unique after capability
 // expansion. The ID "" is treated as "*".
 func validateAllowlist(name string, callers []CallerConfig) error {
@@ -73,17 +86,7 @@ func SetAllowlist(name string, callers []CallerConfig) error {
 	m := make(map[string]CallerConfig, len(callers))
 	for _, c := range callers {
 		for ri := range c.Rules {
-			r := &c.Rules[ri]
-			r.Segments = splitPath(r.Path)
-			methods := make(map[string]RequestConstraint, len(r.Methods))
-			for mth, cons := range r.Methods {
-				method := strings.TrimSpace(mth)
-				if method == "" {
-					continue
-				}
-				methods[strings.ToUpper(method)] = cons
-			}
-			r.Methods = methods
+			normalizeRule(&c.Rules[ri])
 		}
 		id := c.ID
 		if id == "" {
@@ -487,6 +490,9 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 	if ok {
 		if len(c.Capabilities) > 0 {
 			c = integrationplugins.ExpandCapabilities(i.Name, []CallerConfig{c})[0]
+			for ri := range c.Rules {
+				normalizeRule(&c.Rules[ri])
+			}
 		}
 		for _, r := range c.Rules {
 			if matchSegments(r.Segments, segments) {
@@ -499,6 +505,9 @@ func findConstraint(i *Integration, callerID, pth, method string) (RequestConstr
 	if hasWildcard {
 		if len(wildcard.Capabilities) > 0 {
 			wildcard = integrationplugins.ExpandCapabilities(i.Name, []CallerConfig{wildcard})[0]
+			for ri := range wildcard.Rules {
+				normalizeRule(&wildcard.Rules[ri])
+			}
 		}
 		for _, r := range wildcard.Rules {
 			if matchSegments(r.Segments, segments) {

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -146,9 +146,8 @@ func TestFindConstraintExpandsCapabilitiesOnLookup(t *testing.T) {
 	integrationplugins.RegisterCapability("lookup", "cap", integrationplugins.CapabilitySpec{
 		Generate: func(map[string]interface{}) ([]integrationplugins.CallRule, error) {
 			return []integrationplugins.CallRule{{
-				Path:     "/capability",
-				Methods:  map[string]integrationplugins.RequestConstraint{http.MethodGet: {}},
-				Segments: splitPath("/capability"),
+				Path:    "/capability",
+				Methods: map[string]integrationplugins.RequestConstraint{" get ": {}},
 			}}, nil
 		},
 	})


### PR DESCRIPTION
### Motivation
- Dynamic capability expansion at lookup time produced CallRule entries without computed `Segments` and without normalized method keys, causing mismatches that could deny intended routes or incorrectly match the root path.
- The intent is to ensure runtime-expanded capability rules are normalized identically to rules produced during `SetAllowlist` so matching logic remains consistent.

### Description
- Add a `normalizeRule` helper that sets `CallRule.Segments` via `splitPath` and trims/upper-cases method keys on a rule.
- Replace inline normalization in `SetAllowlist` with `normalizeRule` to centralize behavior.
- After dynamically expanding capabilities in `findConstraint` apply `normalizeRule` to each generated rule for both direct and wildcard callers before matching.
- Update `TestFindConstraintExpandsCapabilitiesOnLookup` to register an unnormalized generated rule (mixed-case/whitespace method key and no precomputed `Segments`) so the runtime normalization path is exercised.

### Testing
- Ran targeted tests with `go test ./app -run 'TestFindConstraintExpandsCapabilitiesOnLookup|TestFindConstraintExpandsCallerAndWildcardCapabilities|TestSetAllowlistMethodNormalization'`, which passed.
- Ran the full package tests with `go test ./app`, which failed due to a pre-existing, unrelated `TestIntegrationPluginTransport` failure (`base transport mutated`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4b579f748326a0295a55de69fc05)