### PR TITLE
tests: clean up integration fixtures with DeleteIntegration

### DIFF
--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -662,8 +662,7 @@ func TestIntegrationRateLimitWindow(t *testing.T) {
 		t.Fatalf("add: %v", err)
 	}
 	t.Cleanup(func() {
-		i.inLimiter.Stop()
-		i.outLimiter.Stop()
+		DeleteIntegration(i.Name)
 	})
 
 	if !i.inLimiter.Allow("a") {
@@ -706,8 +705,7 @@ func TestIntegrationTransportSettings(t *testing.T) {
 		t.Fatalf("add: %v", err)
 	}
 	t.Cleanup(func() {
-		i.inLimiter.Stop()
-		i.outLimiter.Stop()
+		DeleteIntegration(i.Name)
 	})
 
 	tr, ok := i.proxy.Transport.(*http.Transport)
@@ -840,8 +838,7 @@ func TestIntegrationPluginTransport(t *testing.T) {
 		t.Fatalf("add: %v", err)
 	}
 	t.Cleanup(func() {
-		i.inLimiter.Stop()
-		i.outLimiter.Stop()
+		DeleteIntegration(i.Name)
 	})
 
 	tr, ok := i.proxy.Transport.(*http.Transport)


### PR DESCRIPTION
### Motivation
- Several integration tests were leaking state into the global integration registry by only stopping limiter goroutines, causing intermittent failures like "integration ... already exists" when tests ran repeatedly or in different orders. 
- Use the public cleanup function to ensure both the registry entry and associated limiters are removed to avoid cross-test interference.

### Description
- Replace direct calls to `i.inLimiter.Stop()` / `i.outLimiter.Stop()` with `DeleteIntegration(i.Name)` in tests. 
- Applied the change in `TestIntegrationRateLimitWindow`, `TestIntegrationTransportSettings`, and `TestIntegrationPluginTransport` in `app/integration_test.go`. 
- This centralizes cleanup so the integration entry is removed from the global map and its limiters are stopped consistently.

### Testing
- Ran `go test ./app -run 'TestIntegrationRateLimitWindow|TestIntegrationPluginTransport' -count=1` and both tests passed. 
- Ran `go test ./app -count=1` and the package tests passed. 
- Ran `go test ./... -count=1` and the full test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd4ec0e43c832680f7f8f14bc13431)