### PR TITLE
Redact sensitive parts of remote config URLs in errors and improve fetch error messages

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -229,6 +229,25 @@ func redactSourceInError(err error, rawSource, redactedSource string) string {
 	if rawSource != redactedSource {
 		msg = strings.ReplaceAll(msg, rawSource, redactedSource)
 	}
+
+	u, parseErr := url.Parse(rawSource)
+	if parseErr != nil {
+		return msg
+	}
+
+	// http.Client errors may normalize URL rendering (for example masking
+	// passwords with ***). Replace common normalized forms as well.
+	msg = strings.ReplaceAll(msg, u.Redacted(), redactedSource)
+	if u.RawQuery != "" {
+		msg = strings.ReplaceAll(msg, u.RawQuery, "REDACTED")
+	}
+	if u.Fragment != "" {
+		msg = strings.ReplaceAll(msg, u.Fragment, "REDACTED")
+	}
+	if u.User != nil {
+		userMasked := u.User.Username() + ":***@"
+		msg = strings.ReplaceAll(msg, userMasked, "REDACTED:REDACTED@")
+	}
 	return msg
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -163,11 +163,21 @@ func openSource(path string) (io.ReadCloser, error) {
 		src := redactConfigSource(path)
 		req, err := http.NewRequestWithContext(context.Background(), "GET", path, nil)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %s: invalid URL: %s", src, redactSourceInError(err, path, src))
+			return nil, &redactedWrappedError{
+				msg:            fmt.Sprintf("fetch %s: invalid URL", src),
+				cause:          err,
+				rawSource:      path,
+				redactedSource: src,
+			}
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %s: request failed: %s", src, redactSourceInError(err, path, src))
+			return nil, &redactedWrappedError{
+				msg:            fmt.Sprintf("fetch %s: request failed", src),
+				cause:          err,
+				rawSource:      path,
+				redactedSource: src,
+			}
 		}
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
@@ -220,6 +230,21 @@ func redactSourceInError(err error, rawSource, redactedSource string) string {
 		msg = strings.ReplaceAll(msg, rawSource, redactedSource)
 	}
 	return msg
+}
+
+type redactedWrappedError struct {
+	msg            string
+	cause          error
+	rawSource      string
+	redactedSource string
+}
+
+func (e *redactedWrappedError) Error() string {
+	return fmt.Sprintf("%s: %s", e.msg, redactSourceInError(e.cause, e.rawSource, e.redactedSource))
+}
+
+func (e *redactedWrappedError) Unwrap() error {
+	return e.cause
 }
 
 func loadConfig(filename string) (*Config, error) {

--- a/app/main.go
+++ b/app/main.go
@@ -160,17 +160,18 @@ func openSource(path string) (io.ReadCloser, error) {
 		return os.Open(strings.TrimPrefix(path, "file://"))
 	}
 	if isRemote(path) {
+		src := redactConfigSource(path)
 		req, err := http.NewRequestWithContext(context.Background(), "GET", path, nil)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", path, err)
+			return nil, fmt.Errorf("fetch %s: invalid URL: %s", src, redactSourceInError(err, path, src))
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return nil, fmt.Errorf("fetch %s: %w", path, err)
+			return nil, fmt.Errorf("fetch %s: request failed: %s", src, redactSourceInError(err, path, src))
 		}
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
-			return nil, fmt.Errorf("remote fetch %s: %s", path, resp.Status)
+			return nil, fmt.Errorf("remote fetch %s failed: %s", src, resp.Status)
 		}
 		return resp.Body, nil
 	}
@@ -190,7 +191,10 @@ func configSource() string {
 
 func redactConfigSource(source string) string {
 	u, err := url.Parse(source)
-	if err != nil || (u.Scheme == "" && u.Host == "") {
+	if err != nil {
+		return source
+	}
+	if u.Scheme == "" && u.Host == "" {
 		return source
 	}
 
@@ -205,6 +209,17 @@ func redactConfigSource(source string) string {
 	}
 
 	return u.String()
+}
+
+func redactSourceInError(err error, rawSource, redactedSource string) string {
+	msg := err.Error()
+	if rawSource == "" {
+		return msg
+	}
+	if rawSource != redactedSource {
+		msg = strings.ReplaceAll(msg, rawSource, redactedSource)
+	}
+	return msg
 }
 
 func loadConfig(filename string) (*Config, error) {

--- a/app/main.go
+++ b/app/main.go
@@ -163,21 +163,21 @@ func openSource(path string) (io.ReadCloser, error) {
 		src := redactConfigSource(path)
 		req, err := http.NewRequestWithContext(context.Background(), "GET", path, nil)
 		if err != nil {
-			return nil, &redactedWrappedError{
-				msg:            fmt.Sprintf("fetch %s: invalid URL", src),
-				cause:          err,
-				rawSource:      path,
-				redactedSource: src,
-			}
+			return nil, newRedactedWrappedError(
+				fmt.Sprintf("fetch %s: invalid URL", src),
+				err,
+				path,
+				src,
+			)
 		}
 		resp, err := httpClient.Do(req)
 		if err != nil {
-			return nil, &redactedWrappedError{
-				msg:            fmt.Sprintf("fetch %s: request failed", src),
-				cause:          err,
-				rawSource:      path,
-				redactedSource: src,
-			}
+			return nil, newRedactedWrappedError(
+				fmt.Sprintf("fetch %s: request failed", src),
+				err,
+				path,
+				src,
+			)
 		}
 		if resp.StatusCode != http.StatusOK {
 			resp.Body.Close()
@@ -237,6 +237,15 @@ type redactedWrappedError struct {
 	cause          error
 	rawSource      string
 	redactedSource string
+}
+
+func newRedactedWrappedError(msg string, cause error, rawSource, redactedSource string) error {
+	return &redactedWrappedError{
+		msg:            msg,
+		cause:          cause,
+		rawSource:      rawSource,
+		redactedSource: redactedSource,
+	}
 }
 
 func (e *redactedWrappedError) Error() string {

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -286,7 +286,7 @@ func TestOpenSourceHTTPStatus(t *testing.T) {
 		rc.Close()
 		t.Fatal("expected error")
 	}
-	want := fmt.Sprintf("remote fetch %s: 418 I'm a teapot", srv.URL)
+	want := fmt.Sprintf("remote fetch %s failed: 418 I'm a teapot", srv.URL)
 	if err.Error() != want {
 		t.Fatalf("unexpected error %v", err)
 	}
@@ -304,8 +304,22 @@ func TestOpenSourceHTTPRequestError(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid URL")
 	}
-	if !strings.Contains(err.Error(), "fetch http://[::1") {
+	if !strings.Contains(err.Error(), "fetch http://[::1: invalid URL") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestOpenSourceHTTPDialErrorRedactsSecrets(t *testing.T) {
+	addr := freeAddr(t)
+	_, err := openSource("http://user:pass@" + addr + "/config.yaml?token=abc#frag")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if strings.Contains(err.Error(), "user:pass@") {
+		t.Fatalf("expected raw credentials to be redacted: %v", err)
+	}
+	if !strings.Contains(err.Error(), "http://REDACTED:REDACTED@") {
+		t.Fatalf("expected redacted URL in error: %v", err)
 	}
 }
 
@@ -386,6 +400,11 @@ func TestRedactConfigSource(t *testing.T) {
 			name:  "file url with query is redacted",
 			input: "file:///tmp/config.yaml?sig=abc",
 			want:  "file:///tmp/config.yaml?REDACTED",
+		},
+		{
+			name:  "invalid remote url is unchanged",
+			input: "http://[::1",
+			want:  "http://[::1",
 		},
 	}
 

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -9,6 +9,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -17,6 +18,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -296,6 +298,18 @@ func TestOpenSourceHTTPDialError(t *testing.T) {
 	addr := freeAddr(t)
 	if _, err := openSource("http://" + addr + "/"); err == nil {
 		t.Fatal("expected error")
+	}
+}
+
+func TestOpenSourceHTTPDialErrorPreservesErrorChain(t *testing.T) {
+	addr := freeAddr(t)
+	_, err := openSource("http://" + addr + "/")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var uerr *url.Error
+	if !errors.As(err, &uerr) {
+		t.Fatalf("expected wrapped *url.Error, got %T (%v)", err, err)
 	}
 }
 

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -418,6 +418,28 @@ func TestRedactConfigSource(t *testing.T) {
 	}
 }
 
+func TestRedactSourceInErrorReplacesRawSource(t *testing.T) {
+	raw := "https://user:pass@example.com/config.yaml?token=abc#frag"
+	redacted := "https://REDACTED:REDACTED@example.com/config.yaml?REDACTED#REDACTED"
+	err := fmt.Errorf("Get %q: dial tcp: i/o timeout", raw)
+
+	got := redactSourceInError(err, raw, redacted)
+	if strings.Contains(got, raw) {
+		t.Fatalf("expected raw source to be replaced: %q", got)
+	}
+	if !strings.Contains(got, redacted) {
+		t.Fatalf("expected redacted source in result: %q", got)
+	}
+}
+
+func TestRedactSourceInErrorNoRawSource(t *testing.T) {
+	err := fmt.Errorf("plain error text")
+	got := redactSourceInError(err, "", "ignored")
+	if got != "plain error text" {
+		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
 func TestIsRemoteWindowsPath(t *testing.T) {
 	if isRemote("C:\\path\\to\\file.yaml") {
 		t.Fatal("windows path detected as remote")

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -332,6 +332,9 @@ func TestOpenSourceHTTPDialErrorRedactsSecrets(t *testing.T) {
 	if strings.Contains(err.Error(), "user:pass@") {
 		t.Fatalf("expected raw credentials to be redacted: %v", err)
 	}
+	if strings.Contains(err.Error(), "token=abc") || strings.Contains(err.Error(), "#frag") {
+		t.Fatalf("expected query/fragment to be redacted: %v", err)
+	}
 	if !strings.Contains(err.Error(), "http://REDACTED:REDACTED@") {
 		t.Fatalf("expected redacted URL in error: %v", err)
 	}
@@ -451,6 +454,23 @@ func TestRedactSourceInErrorNoRawSource(t *testing.T) {
 	got := redactSourceInError(err, "", "ignored")
 	if got != "plain error text" {
 		t.Fatalf("unexpected output: %q", got)
+	}
+}
+
+func TestRedactSourceInErrorReplacesNormalizedSource(t *testing.T) {
+	raw := "https://user:pass@example.com/config.yaml?token=abc#frag"
+	redacted := "https://REDACTED:REDACTED@example.com/config.yaml?REDACTED#REDACTED"
+	err := fmt.Errorf("Get %q: dial tcp: i/o timeout", "https://user:***@example.com/config.yaml?token=abc#frag")
+
+	got := redactSourceInError(err, raw, redacted)
+	if strings.Contains(got, "token=abc") || strings.Contains(got, "#frag") {
+		t.Fatalf("expected query/fragment redaction: %q", got)
+	}
+	if strings.Contains(got, "user:***@") {
+		t.Fatalf("expected masked userinfo to be replaced: %q", got)
+	}
+	if !strings.Contains(got, redacted) {
+		t.Fatalf("expected redacted source in result: %q", got)
 	}
 }
 


### PR DESCRIPTION
### Motivation

- Prevent leaking credentials, query parameters, or fragments from config URLs into error messages when fetching remote configs.
- Make remote fetch error messages clearer and more descriptive for debugging.

### Description

- Use `redactConfigSource` to produce a redacted `src` and reference it in `openSource` error messages instead of the raw `path` and enhance messages to say `invalid URL`, `request failed`, or `remote fetch ... failed` where appropriate. 
- Introduce `redactSourceInError` to replace occurrences of the raw source in underlying error text with the redacted source. 
- Change `redactConfigSource` parsing behavior to return the original input when URL parsing fails and keep a separate check for empty `Scheme` and `Host`. 
- Update and add unit tests to reflect the new messages and redaction behavior, including `TestOpenSourceHTTPDialErrorRedactsSecrets` and an additional `TestRedactConfigSource` case for invalid URLs.

### Testing

- Ran package unit tests with `go test ./...` covering `openSource` and `redactConfigSource` behavior. 
- All modified and added tests (including `TestOpenSourceHTTPStatus`, `TestOpenSourceHTTPRequestError`, `TestOpenSourceHTTPDialErrorRedactsSecrets`, and `TestRedactConfigSource`) passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dd55eef51c832685ccb23907248f30)