### PR TITLE
[codex] Add metrics for proxy-generated responses

### DIFF
--- a/app/main.go
+++ b/app/main.go
@@ -1228,6 +1228,19 @@ func metricsHandler(w http.ResponseWriter, r *http.Request) {
 	metrics.Handler(w, r, *metricsUser, *metricsPass)
 }
 
+const (
+	internalReasonIntegrationNotFound    = "integration_not_found"
+	internalReasonIncomingAuthFailure    = "incoming_auth_failure"
+	internalReasonCallerRateLimited      = "caller_rate_limited"
+	internalReasonIntegrationRateLimited = "integration_rate_limited"
+	internalReasonDenylistMatch          = "denylist_match"
+	internalReasonNoAllowlistMatch       = "no_allowlist_match"
+	internalReasonConstraintFailure      = "constraint_failure"
+	internalReasonInvalidDestination     = "invalid_destination"
+	internalReasonOutgoingAuthFailure    = "outgoing_auth_failure"
+	internalReasonNoProxyConfigured      = "no_proxy_configured"
+)
+
 // proxyHandler handles incoming requests and proxies them according to the integration.
 func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	host := r.Host
@@ -1242,6 +1255,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		logger.Warn("no integration configured", "host", host)
 		metrics.IncRequest("unknown")
+		metrics.IncInternalResponse("unknown", http.StatusNotFound, internalReasonIntegrationNotFound)
 		w.Header().Set("X-AT-Upstream-Error", "false")
 		w.Header().Set("X-AT-Error-Reason", "integration not found")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1261,6 +1275,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 			if !p.Authenticate(r.Context(), r, cfg.parsed) {
 				logger.Warn("authentication failed", "host", host, "remote", r.RemoteAddr)
 				metrics.IncAuthFailure(integ.Name)
+				metrics.IncInternalResponse(integ.Name, http.StatusUnauthorized, internalReasonIncomingAuthFailure)
 				w.Header().Set("X-AT-Upstream-Error", "false")
 				w.Header().Set("X-AT-Error-Reason", "authentication failed")
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1287,6 +1302,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if !integ.inLimiter.Allow(limiterKey) {
 		logger.Warn("caller exceeded rate limit", "caller", rateKey, "host", host)
 		metrics.IncRateLimit(integ.Name)
+		metrics.IncInternalResponse(integ.Name, http.StatusTooManyRequests, internalReasonCallerRateLimited)
 		if d := integ.inLimiter.RetryAfter(limiterKey); d > 0 {
 			secs := int(math.Ceil(d.Seconds()))
 			if secs < 1 {
@@ -1303,6 +1319,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	if !integ.outLimiter.Allow(host) {
 		logger.Warn("host exceeded rate limit", "host", host)
 		metrics.IncRateLimit(integ.Name)
+		metrics.IncInternalResponse(integ.Name, http.StatusTooManyRequests, internalReasonIntegrationRateLimited)
 		if d := integ.outLimiter.RetryAfter(host); d > 0 {
 			secs := int(math.Ceil(d.Seconds()))
 			if secs < 1 {
@@ -1319,6 +1336,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 
 	if blocked, reason := matchDenylist(integ, callerID, r); blocked {
 		logger.Warn("request denied by denylist", "integration", integ.Name, "caller_id", callerID, "reason", reason)
+		metrics.IncInternalResponse(integ.Name, http.StatusForbidden, internalReasonDenylistMatch)
 		w.Header().Set("X-AT-Error-Reason", reason)
 		w.Header().Set("X-AT-Upstream-Error", "false")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1332,6 +1350,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		if !ok {
 			reason := "no allowlist match"
 			logger.Warn("request blocked", "integration", integ.Name, "caller_id", callerID, "reason", reason)
+			metrics.IncInternalResponse(integ.Name, http.StatusForbidden, internalReasonNoAllowlistMatch)
 			w.Header().Set("X-AT-Error-Reason", reason)
 			w.Header().Set("X-AT-Upstream-Error", "false")
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1340,6 +1359,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		if ok2, reason := validateRequestReason(r, cons); !ok2 {
 			logger.Warn("request failed constraints", "integration", integ.Name, "caller_id", callerID, "reason", reason)
+			metrics.IncInternalResponse(integ.Name, http.StatusForbidden, internalReasonConstraintFailure)
 			w.Header().Set("X-AT-Error-Reason", reason)
 			w.Header().Set("X-AT-Upstream-Error", "false")
 			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1351,6 +1371,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	resolvedDest, err := integ.resolveRequestDestination(r)
 	if err != nil {
 		logger.Warn("invalid destination header", "integration", integ.Name, "error", err)
+		metrics.IncInternalResponse(integ.Name, http.StatusBadRequest, internalReasonInvalidDestination)
 		w.Header().Set("X-AT-Upstream-Error", "false")
 		w.Header().Set("X-AT-Error-Reason", "invalid destination")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1368,6 +1389,8 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 		if p != nil {
 			if err := p.AddAuth(r.Context(), r, cfg.parsed); err != nil {
 				logger.Warn("outgoing auth failed", "integration", integ.Name, "plugin", cfg.Type, "error", err)
+				metrics.IncAuthFailure(integ.Name)
+				metrics.IncInternalResponse(integ.Name, http.StatusUnauthorized, internalReasonOutgoingAuthFailure)
 				w.Header().Set("X-AT-Upstream-Error", "false")
 				w.Header().Set("X-AT-Error-Reason", "authentication failed")
 				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
@@ -1378,6 +1401,7 @@ func proxyHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if integ.proxy == nil {
+		metrics.IncInternalResponse(integ.Name, http.StatusBadGateway, internalReasonNoProxyConfigured)
 		w.Header().Set("X-AT-Upstream-Error", "false")
 		w.Header().Set("X-AT-Error-Reason", "no proxy configured")
 		w.Header().Set("Content-Type", "text/plain; charset=utf-8")

--- a/app/metrics/builtin.go
+++ b/app/metrics/builtin.go
@@ -13,22 +13,23 @@ import (
 	"time"
 )
 
-// statusKeySeparator joins the integration name and HTTP status code when
-// storing upstream counters in expvar. We intentionally pick a character that
-// integrations cannot contain so parsing during Prometheus export stays
-// unambiguous even after allowing dots and underscores in names.
-const statusKeySeparator = "|"
+// metricKeySeparator joins expvar map key parts for metrics that need to
+// serialize multiple labels into a single string key. We intentionally pick a
+// character that integrations and the fixed internal reason labels cannot
+// contain so parsing during Prometheus export stays unambiguous.
+const metricKeySeparator = "|"
 
 var (
-	requestCounts        = expvar.NewMap("authtranslator_requests_total")
-	rateLimitCounts      = expvar.NewMap("authtranslator_rate_limit_events_total")
-	authFailureCounts    = expvar.NewMap("authtranslator_auth_failures_total")
-	upstreamStatusCounts = expvar.NewMap("authtranslator_upstream_responses_total")
-	requestDurations     = expvar.NewMap("authtranslator_request_duration_seconds")
-	LastReloadTime       = expvar.NewString("authtranslator_last_reload")
-	durationHistsMu      sync.Mutex
-	durationHists        = make(map[string]*histogram)
-	durationBuckets      = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10}
+	requestCounts          = expvar.NewMap("authtranslator_requests_total")
+	rateLimitCounts        = expvar.NewMap("authtranslator_rate_limit_events_total")
+	authFailureCounts      = expvar.NewMap("authtranslator_auth_failures_total")
+	internalResponseCounts = expvar.NewMap("authtranslator_internal_responses_total")
+	upstreamStatusCounts   = expvar.NewMap("authtranslator_upstream_responses_total")
+	requestDurations       = expvar.NewMap("authtranslator_request_duration_seconds")
+	LastReloadTime         = expvar.NewString("authtranslator_last_reload")
+	durationHistsMu        sync.Mutex
+	durationHists          = make(map[string]*histogram)
+	durationBuckets        = []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 10}
 )
 
 type histogram struct {
@@ -114,9 +115,16 @@ func IncRateLimit(integration string) { rateLimitCounts.Add(integration, 1) }
 // IncAuthFailure increments the auth failure counter for the integration.
 func IncAuthFailure(integration string) { authFailureCounts.Add(integration, 1) }
 
+// IncInternalResponse increments the counter for proxy-generated responses with
+// a coarse reason label to keep cardinality bounded.
+func IncInternalResponse(integration string, status int, reason string) {
+	key := fmt.Sprintf("%s%s%d%s%s", integration, metricKeySeparator, status, metricKeySeparator, reason)
+	internalResponseCounts.Add(key, 1)
+}
+
 // RecordStatus records the upstream status code for the integration.
 func RecordStatus(integration string, status int) {
-	key := fmt.Sprintf("%s%s%d", integration, statusKeySeparator, status)
+	key := fmt.Sprintf("%s%s%d", integration, metricKeySeparator, status)
 	upstreamStatusCounts.Add(key, 1)
 }
 
@@ -158,8 +166,16 @@ func WriteProm(w http.ResponseWriter) {
 	authFailureCounts.Do(func(kv expvar.KeyValue) {
 		fmt.Fprintf(w, "authtranslator_auth_failures_total{integration=%q} %s\n", kv.Key, kv.Value.String())
 	})
+	internalResponseCounts.Do(func(kv expvar.KeyValue) {
+		parts := strings.SplitN(kv.Key, metricKeySeparator, 3)
+		if len(parts) != 3 {
+			return
+		}
+		integ, code, reason := parts[0], parts[1], parts[2]
+		fmt.Fprintf(w, "authtranslator_internal_responses_total{integration=%q,code=%q,reason=%q} %s\n", integ, code, reason, kv.Value.String())
+	})
 	upstreamStatusCounts.Do(func(kv expvar.KeyValue) {
-		parts := strings.SplitN(kv.Key, statusKeySeparator, 2)
+		parts := strings.SplitN(kv.Key, metricKeySeparator, 2)
 		if len(parts) != 2 {
 			return
 		}

--- a/app/metrics/metrics_test.go
+++ b/app/metrics/metrics_test.go
@@ -56,6 +56,7 @@ func TestMetricsHandlerOutput(t *testing.T) {
 	IncRequest("foo")
 	IncRateLimit("foo")
 	IncAuthFailure("foo")
+	IncInternalResponse("foo", http.StatusUnauthorized, "incoming_auth_failure")
 	RecordStatus("foo", http.StatusOK)
 	RecordStatus("bar", http.StatusTeapot)
 	IncRequest("bar")
@@ -73,8 +74,8 @@ func TestMetricsHandlerOutput(t *testing.T) {
 
 	body := rr.Body.String()
 	lines := strings.Split(strings.TrimSpace(body), "\n")
-	if len(lines) < 26 {
-		t.Fatalf("expected at least 26 metrics lines, got %d", len(lines))
+	if len(lines) < 27 {
+		t.Fatalf("expected at least 27 metrics lines, got %d", len(lines))
 	}
 	if !strings.Contains(body, `authtranslator_requests_total{integration="foo"} 2`) {
 		t.Fatal("missing foo request metric")
@@ -87,6 +88,9 @@ func TestMetricsHandlerOutput(t *testing.T) {
 	}
 	if !strings.Contains(body, `authtranslator_auth_failures_total{integration="foo"} 1`) {
 		t.Fatal("missing foo auth failure metric")
+	}
+	if !strings.Contains(body, `authtranslator_internal_responses_total{integration="foo",code="401",reason="incoming_auth_failure"} 1`) {
+		t.Fatal("missing foo internal response metric")
 	}
 	if !strings.Contains(body, `authtranslator_upstream_responses_total{integration="foo",code="200"} 1`) {
 		t.Fatal("missing foo status metric")
@@ -111,6 +115,7 @@ func TestMetricsHandlerOutputWithPunctuation(t *testing.T) {
 	IncRequest(dotName)
 	RecordDuration(dotName, 150*time.Millisecond)
 	RecordStatus(dotName, http.StatusAccepted)
+	IncInternalResponse(dotName, http.StatusBadRequest, "invalid_destination")
 
 	RecordStatus(underscoreName, http.StatusBadGateway)
 
@@ -127,6 +132,9 @@ func TestMetricsHandlerOutputWithPunctuation(t *testing.T) {
 	}
 	if !strings.Contains(body, fmt.Sprintf(`authtranslator_upstream_responses_total{integration=%q,code=%q} 1`, dotName, "202")) {
 		t.Fatalf("missing status metric for %s: %s", dotName, body)
+	}
+	if !strings.Contains(body, fmt.Sprintf(`authtranslator_internal_responses_total{integration=%q,code=%q,reason=%q} 1`, dotName, "400", "invalid_destination")) {
+		t.Fatalf("missing internal response metric for %s: %s", dotName, body)
 	}
 	if !strings.Contains(body, fmt.Sprintf(`authtranslator_upstream_responses_total{integration=%q,code=%q} 1`, underscoreName, "502")) {
 		t.Fatalf("missing status metric for %s: %s", underscoreName, body)
@@ -206,7 +214,9 @@ func TestWritePromSkipsMalformedUpstreamKeys(t *testing.T) {
 	Reset()
 
 	upstreamStatusCounts.Add("badkey", 3)
+	internalResponseCounts.Add("stillbad", 2)
 	RecordStatus("foo", http.StatusOK)
+	IncInternalResponse("foo", http.StatusBadRequest, "invalid_destination")
 
 	rr := httptest.NewRecorder()
 	WriteProm(rr)
@@ -215,8 +225,14 @@ func TestWritePromSkipsMalformedUpstreamKeys(t *testing.T) {
 	if strings.Contains(body, "badkey") {
 		t.Fatalf("expected malformed upstream key to be ignored, got %q", body)
 	}
+	if strings.Contains(body, "stillbad") {
+		t.Fatalf("expected malformed internal response key to be ignored, got %q", body)
+	}
 	if !strings.Contains(body, `authtranslator_upstream_responses_total{integration="foo",code="200"} 1`) {
 		t.Fatalf("missing valid upstream status metric: %s", body)
+	}
+	if !strings.Contains(body, `authtranslator_internal_responses_total{integration="foo",code="400",reason="invalid_destination"} 1`) {
+		t.Fatalf("missing valid internal response metric: %s", body)
 	}
 }
 

--- a/app/metrics/registry.go
+++ b/app/metrics/registry.go
@@ -38,6 +38,7 @@ func Reset() {
 	requestCounts.Init()
 	rateLimitCounts.Init()
 	authFailureCounts.Init()
+	internalResponseCounts.Init()
 	upstreamStatusCounts.Init()
 	durationHistsMu.Lock()
 	durationHists = make(map[string]*histogram)

--- a/app/proxy_test.go
+++ b/app/proxy_test.go
@@ -7,11 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"testing"
 
 	authplugins "github.com/winhowes/AuthTranslator/app/auth"
 	_ "github.com/winhowes/AuthTranslator/app/auth/plugins/token"
+	"github.com/winhowes/AuthTranslator/app/metrics"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
 
@@ -101,6 +103,30 @@ func init() {
 type roundTripFunc func(*http.Request) (*http.Response, error)
 
 func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func promCounterValue(t *testing.T, prefix string) float64 {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "/_at_internal/metrics", nil)
+	rr := httptest.NewRecorder()
+	metrics.Handler(rr, req, "", "")
+
+	body := strings.TrimSpace(rr.Body.String())
+	if body == "" {
+		return 0
+	}
+	for _, line := range strings.Split(body, "\n") {
+		if !strings.HasPrefix(line, prefix+" ") {
+			continue
+		}
+		val, err := strconv.ParseFloat(strings.TrimSpace(strings.TrimPrefix(line, prefix+" ")), 64)
+		if err != nil {
+			t.Fatalf("parse metric %q: %v", line, err)
+		}
+		return val
+	}
+	return 0
+}
 
 func TestProxyHandlerPrefersHeader(t *testing.T) {
 	denylists.Lock()
@@ -451,6 +477,7 @@ func TestProxyHandlerRateLimiterUsesIP(t *testing.T) {
 	req2.Host = "rl-ip"
 	req2.RemoteAddr = "1.2.3.4:5678"
 	rr2 := httptest.NewRecorder()
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="rl-ip",code="429",reason="caller_rate_limited"}`)
 	proxyHandler(rr2, req2)
 	if rr2.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected rate limit rejection, got %d", rr2.Code)
@@ -463,6 +490,9 @@ func TestProxyHandlerRateLimiterUsesIP(t *testing.T) {
 	}
 	if rr2.Header().Get("X-AT-Error-Reason") != "caller rate limited" {
 		t.Fatalf("unexpected error reason: %s", rr2.Header().Get("X-AT-Error-Reason"))
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="rl-ip",code="429",reason="caller_rate_limited"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected caller rate limit metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -520,6 +550,7 @@ func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
 	req2 := httptest.NewRequest(http.MethodGet, "http://rl-out/", nil)
 	req2.Host = "rl-out"
 	rr2 := httptest.NewRecorder()
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="rl-out",code="429",reason="integration_rate_limited"}`)
 	proxyHandler(rr2, req2)
 	if rr2.Code != http.StatusTooManyRequests {
 		t.Fatalf("expected rate limit rejection, got %d", rr2.Code)
@@ -532,6 +563,9 @@ func TestProxyHandlerRetryAfterOutLimit(t *testing.T) {
 	}
 	if rr2.Header().Get("X-AT-Error-Reason") != "integration rate limited" {
 		t.Fatalf("unexpected error reason: %s", rr2.Header().Get("X-AT-Error-Reason"))
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="rl-out",code="429",reason="integration_rate_limited"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected integration rate limit metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -611,6 +645,7 @@ func TestProxyHandlerNotFound(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://missing/", nil)
 	req.Host = "missing"
 	rr := httptest.NewRecorder()
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="unknown",code="404",reason="integration_not_found"}`)
 	proxyHandler(rr, req)
 	if rr.Code != http.StatusNotFound {
 		t.Fatalf("expected 404, got %d", rr.Code)
@@ -623,6 +658,9 @@ func TestProxyHandlerNotFound(t *testing.T) {
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="unknown",code="404",reason="integration_not_found"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected integration not found metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -649,6 +687,8 @@ func TestProxyHandlerAuthFailure(t *testing.T) {
 	req.Host = "authfail"
 	req.Header.Set("X-Auth", "wrong")
 	rr := httptest.NewRecorder()
+	beforeAuthFailures := promCounterValue(t, `authtranslator_auth_failures_total{integration="authfail"}`)
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="authfail",code="401",reason="incoming_auth_failure"}`)
 	proxyHandler(rr, req)
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", rr.Code)
@@ -661,6 +701,12 @@ func TestProxyHandlerAuthFailure(t *testing.T) {
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)
+	}
+	if afterAuthFailures := promCounterValue(t, `authtranslator_auth_failures_total{integration="authfail"}`); afterAuthFailures != beforeAuthFailures+1 {
+		t.Fatalf("expected auth failure metric to increment by 1, got before=%v after=%v", beforeAuthFailures, afterAuthFailures)
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="authfail",code="401",reason="incoming_auth_failure"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected incoming auth failure metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -723,6 +769,7 @@ func TestProxyHandlerBadGateway(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://badgw/", nil)
 	req.Host = "badgw"
 	rr := httptest.NewRecorder()
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="badgw",code="502",reason="no_proxy_configured"}`)
 	proxyHandler(rr, req)
 	if rr.Code != http.StatusBadGateway {
 		t.Fatalf("expected 502, got %d", rr.Code)
@@ -735,6 +782,9 @@ func TestProxyHandlerBadGateway(t *testing.T) {
 	}
 	if ct := rr.Header().Get("Content-Type"); ct != "text/plain; charset=utf-8" {
 		t.Fatalf("unexpected content type %s", ct)
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="badgw",code="502",reason="no_proxy_configured"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected no proxy metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -783,6 +833,7 @@ func TestProxyHandlerWildcardMissingDestination(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://wild-missing/path", nil)
 	req.Host = "wild-missing"
 	rr := httptest.NewRecorder()
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="wild-missing",code="400",reason="invalid_destination"}`)
 
 	proxyHandler(rr, req)
 
@@ -791,6 +842,9 @@ func TestProxyHandlerWildcardMissingDestination(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Error-Reason") != "invalid destination" {
 		t.Fatalf("unexpected error reason: %s", rr.Header().Get("X-AT-Error-Reason"))
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="wild-missing",code="400",reason="invalid_destination"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected invalid destination metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 
@@ -960,6 +1014,8 @@ func TestProxyHandlerOutgoingAuthError(t *testing.T) {
 	req := httptest.NewRequest(http.MethodGet, "http://fail-auth/", nil)
 	req.Host = "fail-auth"
 	rr := httptest.NewRecorder()
+	beforeAuthFailures := promCounterValue(t, `authtranslator_auth_failures_total{integration="fail-auth"}`)
+	beforeInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="fail-auth",code="401",reason="outgoing_auth_failure"}`)
 
 	proxyHandler(rr, req)
 
@@ -968,6 +1024,12 @@ func TestProxyHandlerOutgoingAuthError(t *testing.T) {
 	}
 	if rr.Header().Get("X-AT-Error-Reason") != "authentication failed" {
 		t.Fatalf("unexpected error reason %q", rr.Header().Get("X-AT-Error-Reason"))
+	}
+	if afterAuthFailures := promCounterValue(t, `authtranslator_auth_failures_total{integration="fail-auth"}`); afterAuthFailures != beforeAuthFailures+1 {
+		t.Fatalf("expected auth failure metric to increment by 1, got before=%v after=%v", beforeAuthFailures, afterAuthFailures)
+	}
+	if afterInternal := promCounterValue(t, `authtranslator_internal_responses_total{integration="fail-auth",code="401",reason="outgoing_auth_failure"}`); afterInternal != beforeInternal+1 {
+		t.Fatalf("expected outgoing auth failure metric to increment by 1, got before=%v after=%v", beforeInternal, afterInternal)
 	}
 }
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -35,9 +35,12 @@ sets `X-AT-Error-Reason` with a short explanation such as "integration not found
 | `authtranslator_upstream_responses_total` | counter   | `integration`, `code` | HTTP status codes returned by upstreams.         |
 | `authtranslator_request_duration_seconds` | histogram | `integration`         | Histogram of upstream request latency.           |
 | `authtranslator_rate_limit_events_total`  | counter   | `integration`         | Incremented when a request is rejected with 429. |
-| `authtranslator_auth_failures_total`      | counter   | `integration`         | Authentication plugin failures.                  |
+| `authtranslator_auth_failures_total`      | counter   | `integration`         | Incoming and outgoing auth plugin failures.      |
+| `authtranslator_internal_responses_total` | counter   | `integration`, `code`, `reason` | Proxy-generated non-upstream responses grouped by coarse reason. |
 | `authtranslator_last_reload`             | gauge     | –
 | Timestamp of the most recent configuration reload. |
+
+The `reason` label on `authtranslator_internal_responses_total` uses bounded categories such as `integration_not_found`, `incoming_auth_failure`, `caller_rate_limited`, `integration_rate_limited`, `invalid_destination`, and `no_proxy_configured`.
 
 Missing a metric? Write a small **metrics plugin** to hook into requests and responses or open a PR—new counters are easy to wire in. `WriteProm` calls every registered plugin's own `WriteProm` method so any custom counters you output will appear alongside the built‑in ones. Plugins must manage their own state (typically in memory). See [Metrics Plugins](metrics-plugins.md) for a primer.
 
@@ -69,6 +72,7 @@ assume you scrape the metrics under the default job label
 | Error ratio                | `sum(rate(authtranslator_upstream_responses_total{job="authtranslator",code=~"5.."}[5m]))`<br>`/`<br>`sum(rate(authtranslator_upstream_responses_total{job="authtranslator"}[5m]))` | Surfaces spikes in upstream failures. |
 | 95th percentile latency    | `histogram_quantile(0.95, sum(rate(authtranslator_request_duration_seconds_bucket{job="authtranslator"}[5m])) by (le, integration))` | Watches for slowdowns before they hit the SLA. |
 | Rate-limit rejections      | `sum(rate(authtranslator_rate_limit_events_total{job="authtranslator"}[5m])) by (integration)` | Shows when callers are constrained and need more quota. |
+| Internal failures by reason | `sum(rate(authtranslator_internal_responses_total{job="authtranslator"}[5m])) by (integration, reason)` | Separates local proxy rejections from upstream failures. |
 
 You can convert the table above into Grafana time-series panels by pasting the
 queries into new panels and turning on **Legend → `{{integration}}`**. For a


### PR DESCRIPTION
### Motivation

- The metrics surface currently captures upstream responses, request latency, rate-limit events, and incoming auth failures, but several proxy-generated failures are either invisible or only partially covered.
- In particular, outgoing auth failures were not counted in `authtranslator_auth_failures_total`, and locally generated 4xx/5xx responses such as integration lookup failures, invalid destinations, rate-limit rejections, and missing proxy configuration were not exposed as a bounded Prometheus counter.
- This PR intentionally skips adding an inbound-auth-failure-by-plugin breakdown for now; per the current integration shape, the integration label is usually sufficient.

### Description

- Add a new builtin counter `authtranslator_internal_responses_total{integration,code,reason}` for proxy-generated non-upstream responses, using coarse bounded reason labels.
- Increment that counter across the existing local rejection/error paths in `proxyHandler`, including integration not found, incoming auth failure, caller/integration rate limiting, denylist/allowlist rejections, invalid destination, outgoing auth failure, and no proxy configured.
- Count outgoing auth failures in the existing `authtranslator_auth_failures_total` metric so auth failures are represented consistently regardless of direction.
- Extend the existing metrics and proxy tests to assert the new exports and metric deltas, and document the new counter in `docs/observability.md`.

### Impact

- Operators can now distinguish proxy-generated failures from upstream failures directly in Prometheus/Grafana.
- Outgoing auth failures are no longer missing from the builtin auth failure metric.
- The new `reason` label stays low-cardinality by using fixed categories rather than raw error text.

### Testing

- `go test ./app/metrics -count=1`
- `go test ./app -run 'TestProxyHandler(RateLimiterUsesIP|RetryAfterOutLimit|NotFound|AuthFailure|BadGateway|WildcardMissingDestination|OutgoingAuthError)$' -count=1`
- `go test ./app -run 'TestProxyHandler(Denylist|NotFound|AuthFailure|BadGateway|WildcardMissingDestination|OutgoingAuthError)$|TestConstraintFailureReasonHeader|TestAllowlist|TestProxyHandlerRateLimiterUsesIP|TestProxyHandlerRetryAfterOutLimit' -count=1`
- `go test ./... -count=1` currently fails in this environment due the pre-existing unrelated `TestRateLimiterRedisTLSAuthRequiresVerification` certificate-key-size error in `app/redis_tls_auth_test.go`.
