### PR TITLE
[codex] Bump GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -14,23 +14,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           version: v2
           args: release --clean --config=.goreleaser.yml

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -14,23 +14,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
+        uses: docker/setup-qemu-action@v4.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@v4.0.0
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.24.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@v7.0.0
         with:
           version: v2
           args: release --clean --config=.goreleaser.yml

--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -14,23 +14,23 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Log in to GHCR
-        uses: docker/login-action@v4.1.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4.0.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4.0.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Set up Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.3'
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7.0.0
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:
           version: v2
           args: release --clean --config=.goreleaser.yml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@v6.4.0
         with:
           go-version: '1.24.3'
       - name: Export Go module cache path
         run: echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
       - name: Restore module cache
         id: modcache
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v5.0.5
         with:
           path: ${{ env.GOMODCACHE }}
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Save module cache
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v5.0.5
         if: ${{ steps.modcache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.GOMODCACHE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Set up Go
-        uses: actions/setup-go@v6.4.0
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version: '1.24.3'
       - name: Export Go module cache path
         run: echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
       - name: Restore module cache
         id: modcache
-        uses: actions/cache/restore@v5.0.5
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ env.GOMODCACHE }}
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
@@ -38,11 +38,11 @@ jobs:
       - name: Run tests with coverage
         run: go test -coverprofile=coverage.out ./...
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Save module cache
-        uses: actions/cache/save@v5.0.5
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         if: ${{ steps.modcache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.GOMODCACHE }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.24.3'
       - name: Export Go module cache path
         run: echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
       - name: Restore module cache
         id: modcache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v5
         with:
           path: ${{ env.GOMODCACHE }}
           key: ${{ runner.os }}-gomod-${{ hashFiles('**/go.sum') }}
@@ -42,7 +42,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Save module cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v5
         if: ${{ steps.modcache.outputs.cache-hit != 'true' }}
         with:
           path: ${{ env.GOMODCACHE }}


### PR DESCRIPTION
## Summary
- bump GitHub Actions workflow pins to Node 24-capable releases in the test and release workflows
- update `actions/cache` in the test workflow so cache restore/save do not remain on the old Node 20 runtime
- leave the existing SHA-pinned `codecov/codecov-action` ref unchanged

## Why
GitHub flagged the release workflow because several actions were still running on the deprecated Node 20 runtime. This updates the affected actions to current major versions whose `action.yml` metadata uses `node24`.

## Validation
- parsed `.github/workflows/releaser.yml` and `.github/workflows/test.yml` with Ruby YAML
- `git diff --check`
- `actionlint` not installed locally, so no actionlint run was performed
