### PR TITLE
[codex] Bump Go to 1.26.2

### DIFF
--- a/.github/workflows/releaser.yml
+++ b/.github/workflows/releaser.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.3'
+          go-version: '1.26.2'
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
-          go-version: '1.24.3'
+          go-version: '1.26.2'
       - name: Export Go module cache path
         run: echo "GOMODCACHE=$(go env GOMODCACHE)" >> "$GITHUB_ENV"
       - name: Restore module cache

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/winhowes/AuthTranslator
 
-go 1.24.3
+go 1.26.2
 
 require (
 	github.com/fsnotify/fsnotify v1.9.0


### PR DESCRIPTION
### Motivation

- Keep AuthTranslator on the latest stable Go release.
- Align the module `go` directive, CI test toolchain, and release workflow toolchain on the same version.

### Description

- Updated `go.mod` from `go 1.24.3` to `go 1.26.2`.
- Updated the Go version used by `.github/workflows/test.yml` to `1.26.2`.
- Updated the Go version used by `.github/workflows/releaser.yml` to `1.26.2`.

### Testing

- Verified the latest stable release from `https://go.dev/VERSION?m=text`, which reported `go1.26.2`.
- `GOTOOLCHAIN=go1.26.2 go mod tidy`
- `GOTOOLCHAIN=go1.26.2 go version`
- `GOTOOLCHAIN=go1.26.2 go test ./...`
- `GOTOOLCHAIN=go1.26.2 go vet ./...`
- `test -z "$(git ls-files '*.go' | xargs gofmt -l)"`

------
[Codex Task](https://chatgpt.com/codex/tasks/local)