### PR TITLE
[codex] Make reload rollback policy failures

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -74,13 +74,11 @@ func validateAllowlist(name string, callers []CallerConfig) error {
 	return nil
 }
 
-// SetAllowlist registers the caller allowlist for an integration. It returns an
-// error if duplicate caller IDs or rules are detected.
-func SetAllowlist(name string, callers []CallerConfig) error {
+func buildAllowlist(name string, callers []CallerConfig) (map[string]CallerConfig, error) {
 	name = strings.ToLower(name)
 	callers = integrationplugins.ExpandCapabilities(name, callers)
 	if err := validateAllowlist(name, callers); err != nil {
-		return err
+		return nil, err
 	}
 
 	m := make(map[string]CallerConfig, len(callers))
@@ -94,8 +92,19 @@ func SetAllowlist(name string, callers []CallerConfig) error {
 		}
 		m[id] = c
 	}
+	return m, nil
+}
+
+// SetAllowlist registers the caller allowlist for an integration. It returns an
+// error if duplicate caller IDs or rules are detected.
+func SetAllowlist(name string, callers []CallerConfig) error {
+	m, err := buildAllowlist(name, callers)
+	if err != nil {
+		return err
+	}
+
 	allowlists.Lock()
-	allowlists.m[name] = m
+	allowlists.m[strings.ToLower(name)] = m
 	allowlists.Unlock()
 	return nil
 }

--- a/app/denylist.go
+++ b/app/denylist.go
@@ -62,10 +62,10 @@ func validateDenylistCallers(name string, callers []DenylistCaller) error {
 	return nil
 }
 
-func SetDenylist(name string, callers []DenylistCaller) error {
+func buildDenylist(name string, callers []DenylistCaller) (map[string][]CallRule, error) {
 	name = strings.ToLower(name)
 	if err := validateDenylistCallers(name, callers); err != nil {
-		return err
+		return nil, err
 	}
 
 	processed := make(map[string][]CallRule, len(callers))
@@ -88,9 +88,17 @@ func SetDenylist(name string, callers []DenylistCaller) error {
 		}
 		processed[id] = rules
 	}
+	return processed, nil
+}
+
+func SetDenylist(name string, callers []DenylistCaller) error {
+	processed, err := buildDenylist(name, callers)
+	if err != nil {
+		return err
+	}
 
 	denylists.Lock()
-	denylists.m[name] = processed
+	denylists.m[strings.ToLower(name)] = processed
 	denylists.Unlock()
 	return nil
 }

--- a/app/main.go
+++ b/app/main.go
@@ -138,13 +138,13 @@ var remoteFetchTimeout = flag.Duration("remote-fetch-timeout", 10*time.Second, "
 
 var httpClient = &http.Client{Timeout: 10 * time.Second}
 
-// setAllowlist is used by reload to register caller allowlists. It is declared
-// as a variable so tests can override it.
-var setAllowlist = SetAllowlist
+// buildAllowlistForReload is used by reload to prepare caller allowlists. It is
+// declared as a variable so tests can override it.
+var buildAllowlistForReload = buildAllowlist
 
-// setDenylist is used by reload to register integration denylists. It is declared
-// as a variable so tests can override it.
-var setDenylist = SetDenylist
+// buildDenylistForReload is used by reload to prepare integration denylists. It
+// is declared as a variable so tests can override it.
+var buildDenylistForReload = buildDenylist
 
 func usage() {
 	fmt.Fprintf(flag.CommandLine.Output(), "Usage: authtranslator [options]\n\n")
@@ -317,8 +317,8 @@ func parseLevel(s string) slog.Level {
 }
 
 // reload reparses the configuration and allowlist files, replacing all
-// registered integrations and allowlists. Existing rate limiters are
-// stopped before the new configuration is loaded.
+// registered integrations and allowlists. Existing rate limiters are stopped
+// after the new runtime state is ready.
 func reload() error {
 	logger.Info("reloading configuration")
 
@@ -356,27 +356,12 @@ func reload() error {
 		newMap[integ.Name] = integ
 	}
 
-	// Replace integrations and stop the old ones after success.
-	integrations.Lock()
-	integrations.m = newMap
-	integrations.Unlock()
-
-	for _, i := range oldIntegrations {
-		i.inLimiter.Stop()
-		i.outLimiter.Stop()
-	}
-
-	// Clear secret cache so reloaded integrations use fresh values.
-	secrets.ClearCache()
-
 	alSrc := *allowlistFile
 	if *allowlistURL != "" {
 		alSrc = *allowlistURL
 	}
 	entries, err := loadAllowlists(alSrc)
-	allowlists.RLock()
-	old := allowlists.m
-	allowlists.RUnlock()
+	var newAllowlists map[string]map[string]CallerConfig
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Warn("allowlist file missing; keeping existing entries", "file", alSrc)
@@ -385,23 +370,18 @@ func reload() error {
 		}
 	} else {
 		if err := validateAllowlistEntries(entries); err != nil {
-			allowlists.Lock()
-			allowlists.m = old
-			allowlists.Unlock()
+			stopNewIntegrations()
 			return fmt.Errorf("invalid allowlist: %w", err)
 		}
 
-		allowlists.Lock()
-		allowlists.m = make(map[string]map[string]CallerConfig)
-		allowlists.Unlock()
-
+		newAllowlists = make(map[string]map[string]CallerConfig)
 		for _, al := range entries {
-			if err := setAllowlist(al.Integration, al.Callers); err != nil {
-				allowlists.Lock()
-				allowlists.m = old
-				allowlists.Unlock()
+			callers, err := buildAllowlistForReload(al.Integration, al.Callers)
+			if err != nil {
+				stopNewIntegrations()
 				return fmt.Errorf("failed to load allowlist for %s: %w", al.Integration, err)
 			}
+			newAllowlists[strings.ToLower(al.Integration)] = callers
 		}
 	}
 
@@ -410,9 +390,7 @@ func reload() error {
 		dlSrc = *denylistURL
 	}
 	drules, err := loadDenylists(dlSrc)
-	denylists.RLock()
-	oldDeny := denylists.m
-	denylists.RUnlock()
+	var newDenylists map[string]map[string][]CallRule
 	if err != nil {
 		if os.IsNotExist(err) {
 			logger.Warn("denylist file missing; keeping existing entries", "file", dlSrc)
@@ -421,25 +399,45 @@ func reload() error {
 		}
 	} else {
 		if err := validateDenylistEntries(drules); err != nil {
-			denylists.Lock()
-			denylists.m = oldDeny
-			denylists.Unlock()
+			stopNewIntegrations()
 			return fmt.Errorf("invalid denylist: %w", err)
 		}
 
-		denylists.Lock()
-		denylists.m = make(map[string]map[string][]CallRule)
-		denylists.Unlock()
-
+		newDenylists = make(map[string]map[string][]CallRule)
 		for _, dl := range drules {
-			if err := setDenylist(dl.Integration, dl.Callers); err != nil {
-				denylists.Lock()
-				denylists.m = oldDeny
-				denylists.Unlock()
+			callers, err := buildDenylistForReload(dl.Integration, dl.Callers)
+			if err != nil {
+				stopNewIntegrations()
 				return fmt.Errorf("failed to load denylist for %s: %w", dl.Integration, err)
 			}
+			newDenylists[strings.ToLower(dl.Integration)] = callers
 		}
 	}
+
+	// Replace integrations and any successfully rebuilt policy maps only after
+	// all fatal reload steps have succeeded.
+	integrations.Lock()
+	integrations.m = newMap
+	integrations.Unlock()
+
+	if newAllowlists != nil {
+		allowlists.Lock()
+		allowlists.m = newAllowlists
+		allowlists.Unlock()
+	}
+	if newDenylists != nil {
+		denylists.Lock()
+		denylists.m = newDenylists
+		denylists.Unlock()
+	}
+
+	for _, i := range oldIntegrations {
+		i.inLimiter.Stop()
+		i.outLimiter.Stop()
+	}
+
+	// Clear secret cache so reloaded integrations use fresh values.
+	secrets.ClearCache()
 
 	metrics.LastReloadTime.Set(time.Now().Format(time.RFC3339))
 

--- a/app/reload_test.go
+++ b/app/reload_test.go
@@ -455,6 +455,62 @@ func TestReloadInvalidAllowlist(t *testing.T) {
 	}
 }
 
+func TestReloadInvalidAllowlistKeepsExistingIntegrations(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+	resetDenylistState()
+
+	base := &Integration{Name: "base", Destination: "http://example.com"}
+	if err := AddIntegration(base); err != nil {
+		t.Fatalf("setup base integration: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, i := range ListIntegrations() {
+			i.inLimiter.Stop()
+			i.outLimiter.Stop()
+		}
+	})
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"test","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	al := `[{"integration":"test","callers":[{"id":"a"},{"id":"a"}]}]`
+	if err := os.WriteFile(alFile.Name(), []byte(al), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	flag.Set("denylist", writeEmptyDenylist(t))
+
+	if err := reload(); err == nil {
+		t.Fatal("expected allowlist validation error")
+	}
+	if _, ok := GetIntegration("base"); !ok {
+		t.Fatal("existing integration lost after failed reload")
+	}
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("new integration should not be loaded after failed reload")
+	}
+}
+
 func TestReloadInvalidDenylist(t *testing.T) {
 	integrations.Lock()
 	integrations.m = make(map[string]*Integration)
@@ -499,6 +555,92 @@ func TestReloadInvalidDenylist(t *testing.T) {
 	flag.Set("denylist", dlFile.Name())
 	if err := reload(); err == nil {
 		t.Fatal("expected denylist validation error")
+	}
+}
+
+func TestReloadInvalidDenylistRestoresPreviousState(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+	resetDenylistState()
+
+	base := &Integration{Name: "base", Destination: "http://example.com"}
+	if err := AddIntegration(base); err != nil {
+		t.Fatalf("setup base integration: %v", err)
+	}
+	if err := SetAllowlist("base", []CallerConfig{{
+		ID: "*",
+		Rules: []CallRule{{
+			Path:    "/base",
+			Methods: map[string]RequestConstraint{"GET": {}},
+		}},
+	}}); err != nil {
+		t.Fatalf("setup base allowlist: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, i := range ListIntegrations() {
+			i.inLimiter.Stop()
+			i.outLimiter.Stop()
+		}
+	})
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"test","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	al := `[{"integration":"test","callers":[{"id":"a","rules":[{"path":"/","methods":{"GET":{}}}]}]}]`
+	if err := os.WriteFile(alFile.Name(), []byte(al), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dlFile, err := os.CreateTemp("", "dl*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dlFile.Name())
+	dl := `[{"integration":"test","callers":[{"id":"*","rules":[{"path":"/a","methods":{"GET":{},"get":{}}}]}]}]`
+	if err := os.WriteFile(dlFile.Name(), []byte(dl), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	flag.Set("denylist", dlFile.Name())
+
+	if err := reload(); err == nil {
+		t.Fatal("expected denylist validation error")
+	}
+	if _, ok := GetIntegration("base"); !ok {
+		t.Fatal("existing integration lost after failed reload")
+	}
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("new integration should not be loaded after failed reload")
+	}
+
+	allowlists.RLock()
+	_, haveBaseAllowlist := allowlists.m["base"]
+	_, haveTestAllowlist := allowlists.m["test"]
+	allowlists.RUnlock()
+	if !haveBaseAllowlist {
+		t.Fatal("existing allowlist lost after failed reload")
+	}
+	if haveTestAllowlist {
+		t.Fatal("new allowlist should not remain after failed reload")
 	}
 }
 
@@ -619,17 +761,19 @@ func TestReloadSetDenylistError(t *testing.T) {
 	flag.Set("allowlist", alFile.Name())
 	flag.Set("denylist", dlFile.Name())
 
-	old := setDenylist
-	setDenylist = func(string, []DenylistCaller) error { return fmt.Errorf("boom") }
-	defer func() { setDenylist = old }()
+	old := buildDenylistForReload
+	buildDenylistForReload = func(string, []DenylistCaller) (map[string][]CallRule, error) {
+		return nil, fmt.Errorf("boom")
+	}
+	defer func() { buildDenylistForReload = old }()
 
 	err = reload()
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected boom error, got %v", err)
 	}
 
-	if _, ok := GetIntegration("test"); !ok {
-		t.Fatal("integration not loaded")
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("integration should not be loaded on denylist error")
 	}
 	denylists.RLock()
 	_, ok := denylists.m["test"]
@@ -641,6 +785,132 @@ func TestReloadSetDenylistError(t *testing.T) {
 	for _, i := range ListIntegrations() {
 		t.Cleanup(i.inLimiter.Stop)
 		t.Cleanup(i.outLimiter.Stop)
+	}
+}
+
+func TestReloadSetDenylistErrorRestoresExistingState(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+	resetDenylistState()
+
+	base := &Integration{Name: "base", Destination: "http://example.com"}
+	if err := AddIntegration(base); err != nil {
+		t.Fatalf("setup base integration: %v", err)
+	}
+	if err := SetAllowlist("base", []CallerConfig{{
+		ID: "*",
+		Rules: []CallRule{{
+			Path:    "/base",
+			Methods: map[string]RequestConstraint{"GET": {}},
+		}},
+	}}); err != nil {
+		t.Fatalf("setup base allowlist: %v", err)
+	}
+	if err := SetDenylist("base", []DenylistCaller{{
+		ID: "*",
+		Rules: []CallRule{{
+			Path:    "/blocked",
+			Methods: map[string]RequestConstraint{"GET": {}},
+		}},
+	}}); err != nil {
+		t.Fatalf("setup base denylist: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, i := range ListIntegrations() {
+			i.inLimiter.Stop()
+			i.outLimiter.Stop()
+		}
+	})
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"test","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	al := `[{"integration":"test","callers":[{"id":"a","rules":[{"path":"/","methods":{"GET":{}}}]}]}]`
+	if _, err := alFile.WriteString(al); err != nil {
+		t.Fatal(err)
+	}
+	alFile.Close()
+
+	dlFile, err := os.CreateTemp("", "dl*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(dlFile.Name())
+	dl := `[{"integration":"test","callers":[{"id":"*","rules":[{"path":"/blocked","methods":{"GET":{}}}]}]}]`
+	if _, err := dlFile.WriteString(dl); err != nil {
+		t.Fatal(err)
+	}
+	dlFile.Close()
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	flag.Set("denylist", dlFile.Name())
+
+	old := buildDenylistForReload
+	buildDenylistForReload = func(string, []DenylistCaller) (map[string][]CallRule, error) {
+		allowlists.RLock()
+		_, haveBaseAllowlist := allowlists.m["base"]
+		_, haveTestAllowlist := allowlists.m["test"]
+		allowlists.RUnlock()
+		if !haveBaseAllowlist {
+			t.Fatal("existing allowlist changed before denylist error")
+		}
+		if haveTestAllowlist {
+			t.Fatal("new allowlist published before denylist error")
+		}
+		return nil, fmt.Errorf("boom")
+	}
+	defer func() { buildDenylistForReload = old }()
+
+	err = reload()
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+
+	if _, ok := GetIntegration("base"); !ok {
+		t.Fatal("existing integration lost after failed reload")
+	}
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("new integration should not be loaded on denylist error")
+	}
+
+	allowlists.RLock()
+	_, haveBaseAllowlist := allowlists.m["base"]
+	_, haveTestAllowlist := allowlists.m["test"]
+	allowlists.RUnlock()
+	if !haveBaseAllowlist {
+		t.Fatal("existing allowlist lost after failed reload")
+	}
+	if haveTestAllowlist {
+		t.Fatal("new allowlist should not remain after failed reload")
+	}
+
+	denylists.RLock()
+	_, haveBaseDenylist := denylists.m["base"]
+	_, haveTestDenylist := denylists.m["test"]
+	denylists.RUnlock()
+	if !haveBaseDenylist {
+		t.Fatal("existing denylist lost after failed reload")
+	}
+	if haveTestDenylist {
+		t.Fatal("new denylist should not remain after failed reload")
 	}
 }
 
@@ -839,17 +1109,19 @@ func TestReloadSetAllowlistError(t *testing.T) {
 	flag.Set("allowlist", alFile.Name())
 	flag.Set("denylist", writeEmptyDenylist(t))
 
-	old := setAllowlist
-	setAllowlist = func(string, []CallerConfig) error { return fmt.Errorf("boom") }
-	defer func() { setAllowlist = old }()
+	old := buildAllowlistForReload
+	buildAllowlistForReload = func(string, []CallerConfig) (map[string]CallerConfig, error) {
+		return nil, fmt.Errorf("boom")
+	}
+	defer func() { buildAllowlistForReload = old }()
 
 	err = reload()
 	if err == nil || !strings.Contains(err.Error(), "boom") {
 		t.Fatalf("expected boom error, got %v", err)
 	}
 
-	if _, ok := GetIntegration("test"); !ok {
-		t.Fatal("integration not loaded")
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("integration should not be loaded on allowlist error")
 	}
 	allowlists.RLock()
 	_, ok := allowlists.m["test"]
@@ -861,6 +1133,101 @@ func TestReloadSetAllowlistError(t *testing.T) {
 	for _, i := range ListIntegrations() {
 		t.Cleanup(i.inLimiter.Stop)
 		t.Cleanup(i.outLimiter.Stop)
+	}
+}
+
+func TestReloadSetAllowlistErrorRestoresExistingState(t *testing.T) {
+	integrations.Lock()
+	integrations.m = make(map[string]*Integration)
+	integrations.Unlock()
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+	resetDenylistState()
+
+	base := &Integration{Name: "base", Destination: "http://example.com"}
+	if err := AddIntegration(base); err != nil {
+		t.Fatalf("setup base integration: %v", err)
+	}
+	if err := SetAllowlist("base", []CallerConfig{{
+		ID: "*",
+		Rules: []CallRule{{
+			Path:    "/base",
+			Methods: map[string]RequestConstraint{"GET": {}},
+		}},
+	}}); err != nil {
+		t.Fatalf("setup base allowlist: %v", err)
+	}
+	t.Cleanup(func() {
+		for _, i := range ListIntegrations() {
+			i.inLimiter.Stop()
+			i.outLimiter.Stop()
+		}
+	})
+
+	cfgFile, err := os.CreateTemp("", "cfg*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(cfgFile.Name())
+	cfg := `{"integrations":[{"name":"test","destination":"http://example.com"}]}`
+	if _, err := cfgFile.WriteString(cfg); err != nil {
+		t.Fatal(err)
+	}
+	cfgFile.Close()
+
+	alFile, err := os.CreateTemp("", "al*.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(alFile.Name())
+	al := `[{"integration":"test","callers":[{"id":"a","rules":[{"path":"/","methods":{"GET":{}}}]}]}]`
+	if _, err := alFile.WriteString(al); err != nil {
+		t.Fatal(err)
+	}
+	alFile.Close()
+
+	flag.Set("config", cfgFile.Name())
+	flag.Set("allowlist", alFile.Name())
+	flag.Set("denylist", writeEmptyDenylist(t))
+
+	old := buildAllowlistForReload
+	buildAllowlistForReload = func(string, []CallerConfig) (map[string]CallerConfig, error) {
+		allowlists.RLock()
+		_, haveBaseAllowlist := allowlists.m["base"]
+		_, haveTestAllowlist := allowlists.m["test"]
+		allowlists.RUnlock()
+		if !haveBaseAllowlist {
+			t.Fatal("existing allowlist changed before allowlist error")
+		}
+		if haveTestAllowlist {
+			t.Fatal("new allowlist published before allowlist error")
+		}
+		return nil, fmt.Errorf("boom")
+	}
+	defer func() { buildAllowlistForReload = old }()
+
+	err = reload()
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+
+	if _, ok := GetIntegration("base"); !ok {
+		t.Fatal("existing integration lost after failed reload")
+	}
+	if _, ok := GetIntegration("test"); ok {
+		t.Fatal("new integration should not be loaded on allowlist error")
+	}
+
+	allowlists.RLock()
+	_, haveBaseAllowlist := allowlists.m["base"]
+	_, haveTestAllowlist := allowlists.m["test"]
+	allowlists.RUnlock()
+	if !haveBaseAllowlist {
+		t.Fatal("existing allowlist lost after failed reload")
+	}
+	if haveTestAllowlist {
+		t.Fatal("new allowlist should not remain after failed reload")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Make `reload` publish the new integration map only after fatal allowlist and denylist validation/registration succeeds.
- Stop newly-created rate limiters and restore policy state when allowlist or denylist reload steps fail.
- Add regression coverage for invalid policy validation, policy registration hook failures, and preservation of pre-existing integration/allowlist/denylist state.

## Root Cause
`reload` replaced `integrations.m` and stopped old limiters before allowlist and denylist validation completed. If policy validation or registration failed afterward, the function returned an error while the process was already serving the new integration map.

## Validation
- `git diff --check origin/main..HEAD`
- `go test ./app -run 'TestReload(InvalidAllowlist|InvalidDenylist|SetAllowlistError|SetDenylistError)'`
- `go test ./...`
