### PR TITLE
[codex] Fix cached body after find-replace auth

### DIFF
--- a/app/auth/body.go
+++ b/app/auth/body.go
@@ -62,10 +62,14 @@ func GetBody(r *http.Request) ([]byte, error) {
 
 // SetBody replaces the request body and updates the cached body bytes used by
 // GetBody.
-func SetBody(r *http.Request, b []byte) {
+func SetBody(r *http.Request, b []byte) error {
+	if MaxBodySize > 0 && int64(len(b)) > MaxBodySize {
+		return ErrBodyTooLarge
+	}
 	body := append([]byte(nil), b...)
 	r.Body = io.NopCloser(bytes.NewReader(body))
 	r.ContentLength = int64(len(body))
 	ctx := context.WithValue(r.Context(), bodyKey{}, body)
 	*r = *r.WithContext(ctx)
+	return nil
 }

--- a/app/auth/body.go
+++ b/app/auth/body.go
@@ -59,3 +59,13 @@ func GetBody(r *http.Request) ([]byte, error) {
 	*r = *r.WithContext(ctx)
 	return b, nil
 }
+
+// SetBody replaces the request body and updates the cached body bytes used by
+// GetBody.
+func SetBody(r *http.Request, b []byte) {
+	body := append([]byte(nil), b...)
+	r.Body = io.NopCloser(bytes.NewReader(body))
+	r.ContentLength = int64(len(body))
+	ctx := context.WithValue(r.Context(), bodyKey{}, body)
+	*r = *r.WithContext(ctx)
+}

--- a/app/auth/body_test.go
+++ b/app/auth/body_test.go
@@ -56,7 +56,9 @@ func TestSetBodyUpdatesCacheAndResetsBody(t *testing.T) {
 		t.Fatalf("unexpected setup error: %v", err)
 	}
 
-	SetBody(r, []byte("updated"))
+	if err := SetBody(r, []byte("updated")); err != nil {
+		t.Fatalf("unexpected set body error: %v", err)
+	}
 
 	cached, err := GetBody(r)
 	if err != nil {
@@ -74,6 +76,17 @@ func TestSetBodyUpdatesCacheAndResetsBody(t *testing.T) {
 	}
 	if r.ContentLength != int64(len("updated")) {
 		t.Fatalf("expected content length %d, got %d", len("updated"), r.ContentLength)
+	}
+}
+
+func TestSetBodyPreservesMaxBodySize(t *testing.T) {
+	old := MaxBodySize
+	MaxBodySize = 5
+	defer func() { MaxBodySize = old }()
+
+	r := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString("hello"))
+	if err := SetBody(r, []byte("abcdef")); !errors.Is(err, ErrBodyTooLarge) {
+		t.Fatalf("expected ErrBodyTooLarge, got %v", err)
 	}
 }
 

--- a/app/auth/body_test.go
+++ b/app/auth/body_test.go
@@ -50,6 +50,33 @@ func TestGetBodyCachesAndResets(t *testing.T) {
 	}
 }
 
+func TestSetBodyUpdatesCacheAndResetsBody(t *testing.T) {
+	r := httptest.NewRequest(http.MethodPost, "http://example.com", bytes.NewBufferString("hello"))
+	if _, err := GetBody(r); err != nil {
+		t.Fatalf("unexpected setup error: %v", err)
+	}
+
+	SetBody(r, []byte("updated"))
+
+	cached, err := GetBody(r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(cached) != "updated" {
+		t.Fatalf("expected cached body 'updated', got %q", string(cached))
+	}
+	readBack, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("unexpected read error: %v", err)
+	}
+	if string(readBack) != "updated" {
+		t.Fatalf("expected request body 'updated', got %q", string(readBack))
+	}
+	if r.ContentLength != int64(len("updated")) {
+		t.Fatalf("expected content length %d, got %d", len("updated"), r.ContentLength)
+	}
+}
+
 func TestGetBodyReadError(t *testing.T) {
 	r := httptest.NewRequest(http.MethodPost, "http://example.com", nil)
 	r.Body = errReadCloser{}

--- a/app/auth/plugins/findreplace/findreplace_test.go
+++ b/app/auth/plugins/findreplace/findreplace_test.go
@@ -138,6 +138,29 @@ func TestFindReplaceAddAuthUpdatesCachedBody(t *testing.T) {
 	}
 }
 
+func TestFindReplaceAddAuthPreservesMaxBodySize(t *testing.T) {
+	old := authplugins.MaxBodySize
+	authplugins.MaxBodySize = int64(len("body SECRET") - 1)
+	defer func() { authplugins.MaxBodySize = old }()
+
+	r := &http.Request{
+		URL:    &url.URL{Path: "/"},
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("body PLACE")),
+	}
+	p := FindReplace{}
+	t.Setenv("FIND", "PLACE")
+	t.Setenv("REP", "SECRET")
+	cfg, err := p.ParseParams(map[string]interface{}{"find_secret": "env:FIND", "replace_secret": "env:REP"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.AddAuth(context.Background(), r, cfg); err != authplugins.ErrBodyTooLarge {
+		t.Fatalf("expected ErrBodyTooLarge, got %v", err)
+	}
+}
+
 func TestFindReplaceAddAuthRawPathAndNilBody(t *testing.T) {
 	r := &http.Request{
 		URL: &url.URL{ // RawPath should also be rewritten

--- a/app/auth/plugins/findreplace/findreplace_test.go
+++ b/app/auth/plugins/findreplace/findreplace_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	authplugins "github.com/winhowes/AuthTranslator/app/auth"
 	"github.com/winhowes/AuthTranslator/app/secrets"
 	_ "github.com/winhowes/AuthTranslator/app/secrets/plugins"
 )
@@ -97,6 +98,43 @@ func TestFindReplaceAddAuthNoMatch(t *testing.T) {
 	b, _ := io.ReadAll(r.Body)
 	if string(b) != "bar" {
 		t.Fatalf("body changed: %q", string(b))
+	}
+}
+
+func TestFindReplaceAddAuthUpdatesCachedBody(t *testing.T) {
+	r := &http.Request{
+		URL:    &url.URL{Path: "/"},
+		Header: http.Header{},
+		Body:   io.NopCloser(strings.NewReader("body PLACE")),
+	}
+	p := FindReplace{}
+	t.Setenv("FIND", "PLACE")
+	t.Setenv("REP", "SECRET")
+	cfg, err := p.ParseParams(map[string]interface{}{"find_secret": "env:FIND", "replace_secret": "env:REP"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if body, err := authplugins.GetBody(r); err != nil || string(body) != "body PLACE" {
+		t.Fatalf("cached body setup failed: %q %v", string(body), err)
+	}
+
+	if err := p.AddAuth(context.Background(), r, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	cached, err := authplugins.GetBody(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(cached) != "body SECRET" {
+		t.Fatalf("cached body not updated: %q", string(cached))
+	}
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != "body SECRET" {
+		t.Fatalf("request body not updated: %q", string(body))
 	}
 }
 

--- a/app/auth/plugins/findreplace/outgoing.go
+++ b/app/auth/plugins/findreplace/outgoing.go
@@ -1,7 +1,6 @@
 package findreplace
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -85,8 +84,7 @@ func (f *FindReplace) AddAuth(ctx context.Context, r *http.Request, params inter
 		}
 		_ = r.Body.Close()
 		nb := replaceAll(string(b), findVal, replVal)
-		r.Body = io.NopCloser(bytes.NewBufferString(nb))
-		r.ContentLength = int64(len(nb))
+		authplugins.SetBody(r, []byte(nb))
 	}
 
 	return nil

--- a/app/auth/plugins/findreplace/outgoing.go
+++ b/app/auth/plugins/findreplace/outgoing.go
@@ -84,7 +84,9 @@ func (f *FindReplace) AddAuth(ctx context.Context, r *http.Request, params inter
 		}
 		_ = r.Body.Close()
 		nb := replaceAll(string(b), findVal, replVal)
-		authplugins.SetBody(r, []byte(nb))
+		if err := authplugins.SetBody(r, []byte(nb)); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add `auth.SetBody` to replace request bodies while keeping `auth.GetBody` cache state in sync.
- Update outgoing `find_replace` auth to use the shared body setter after rewriting body content.
- Add regression coverage for stale cached body reads after `find_replace` rewrites a request body.

## Root cause
`auth.GetBody` caches request body bytes in the request context. If an earlier policy or auth step cached the body, outgoing `find_replace` could rewrite `r.Body` without updating that cache. Later auth plugins that call `GetBody`, such as HMAC signing, would read/sign the stale pre-rewrite body while the proxy sent the rewritten body.

## Validation
- `go test ./...`
- `go vet ./...`
- `go test -race ./app/auth ./app/auth/plugins/findreplace`