### PR TITLE
[codex] clear denylist when deleting integration

### DIFF
--- a/app/integration.go
+++ b/app/integration.go
@@ -624,4 +624,8 @@ func DeleteIntegration(name string) {
 	allowlists.Lock()
 	delete(allowlists.m, n)
 	allowlists.Unlock()
+
+	denylists.Lock()
+	delete(denylists.m, n)
+	denylists.Unlock()
 }

--- a/app/integration_test.go
+++ b/app/integration_test.go
@@ -650,6 +650,33 @@ func TestDeleteIntegrationRemovesAllowlist(t *testing.T) {
 	}
 }
 
+func TestDeleteIntegrationRemovesDenylist(t *testing.T) {
+	denylists.Lock()
+	denylists.m = make(map[string]map[string][]CallRule)
+	denylists.Unlock()
+
+	name := "deldl"
+	i := &Integration{Name: name, Destination: "http://example.com"}
+	if err := AddIntegration(i); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+	if err := SetDenylist(name, []DenylistCaller{{
+		ID: "*",
+		Rules: []CallRule{{
+			Path:    "/blocked",
+			Methods: map[string]RequestConstraint{"GET": {}},
+		}},
+	}}); err != nil {
+		t.Fatalf("set denylist: %v", err)
+	}
+
+	DeleteIntegration(name)
+
+	if got := GetDenylist(name); len(got) != 0 {
+		t.Fatalf("denylist not removed: %v", got)
+	}
+}
+
 func TestIntegrationRateLimitWindow(t *testing.T) {
 	i := &Integration{
 		Name:            "window",


### PR DESCRIPTION
## Summary

Clear an integration's denylist state when `DeleteIntegration` removes the integration. The existing deletion path already removed allowlist state, but left denylist entries behind.

## Root Cause

`DeleteIntegration` deleted from `integrations.m` and `allowlists.m`, but did not delete the matching entry in `denylists.m`. If an integration was deleted and later recreated with the same name, stale denylist rules could still block requests unexpectedly.

## Changes

- Delete the integration's denylist entry during `DeleteIntegration`.
- Add a regression test alongside the existing integration deletion tests.

## Validation

- `go test -run TestDeleteIntegration -count=1 ./app`
- `go test ./...`
- `go vet ./...`