### PR TITLE
[codex] fix allowlist case-insensitive lookup

### DIFF
--- a/app/allowlist.go
+++ b/app/allowlist.go
@@ -113,7 +113,7 @@ func SetAllowlist(name string, callers []CallerConfig) error {
 // GetAllowlist retrieves the allowlist for an integration.
 func GetAllowlist(name string) []CallerConfig {
 	allowlists.RLock()
-	m := allowlists.m[name]
+	m := allowlists.m[strings.ToLower(name)]
 	res := make([]CallerConfig, 0, len(m))
 	for _, c := range m {
 		res = append(res, c)

--- a/app/allowlist_test.go
+++ b/app/allowlist_test.go
@@ -193,6 +193,21 @@ func TestSetAllowlistIndexing(t *testing.T) {
 	}
 }
 
+func TestGetAllowlistCaseInsensitive(t *testing.T) {
+	allowlists.Lock()
+	allowlists.m = make(map[string]map[string]CallerConfig)
+	allowlists.Unlock()
+
+	if err := SetAllowlist("MiXeD", []CallerConfig{{ID: "caller"}}); err != nil {
+		t.Fatalf("failed to set allowlist: %v", err)
+	}
+
+	got := GetAllowlist("MIXED")
+	if len(got) != 1 || got[0].ID != "caller" {
+		t.Fatalf("expected case-insensitive allowlist lookup, got %#v", got)
+	}
+}
+
 func TestFindConstraintWildcard(t *testing.T) {
 	allowlists.Lock()
 	allowlists.m = make(map[string]map[string]CallerConfig)


### PR DESCRIPTION
## Summary

- Normalize integration names in `GetAllowlist` before reading the stored allowlist map.
- Add a regression test covering mixed-case set and uppercase get behavior.

## Root Cause

`SetAllowlist` lowercased integration names when storing allowlist entries, but `GetAllowlist` used the caller-provided name as-is. Direct mixed-case lookups could incorrectly return an empty allowlist even though one was configured.

## Impact

The current proxy path passes the already-normalized integration name, so this was primarily a latent correctness issue. Fixing it keeps allowlist retrieval consistent with integration and denylist lookups and prevents future callers from accidentally treating a configured allowlist as absent.

## Validation

- `go test ./app -run TestGetAllowlistCaseInsensitive -count=1`
- `go test ./...`
- `go vet ./...`