### PR TITLE
[codex] log only configured XFCC header

### DIFF
--- a/app/auth/plugins/envoy_xfcc/envoy_xfcc_test.go
+++ b/app/auth/plugins/envoy_xfcc/envoy_xfcc_test.go
@@ -49,7 +49,7 @@ func TestEnvoyXFCCDisallowedURIFails(t *testing.T) {
 	}
 }
 
-func TestEnvoyXFCCAuthenticateFailureLogsHeaders(t *testing.T) {
+func TestEnvoyXFCCAuthenticateFailureLogsConfiguredHeaderOnly(t *testing.T) {
 	var buf bytes.Buffer
 	oldLogger := authplugins.SetLogger(slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
 	t.Cleanup(func() { authplugins.SetLogger(oldLogger) })
@@ -76,11 +76,14 @@ func TestEnvoyXFCCAuthenticateFailureLogsHeaders(t *testing.T) {
 		"X-Forwarded-Client-Cert",
 		"spiffe://denied",
 		"spiffe://also-denied",
-		"X-Debug-Header",
-		"debug-value",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("expected log to contain %q; got %s", want, got)
+		}
+	}
+	for _, notWant := range []string{"X-Debug-Header", "debug-value"} {
+		if strings.Contains(got, notWant) {
+			t.Fatalf("expected log to omit %q; got %s", notWant, got)
 		}
 	}
 }

--- a/app/auth/plugins/envoy_xfcc/incoming.go
+++ b/app/auth/plugins/envoy_xfcc/incoming.go
@@ -73,16 +73,17 @@ func (e *EnvoyXFCCAuth) StripAuth(r *http.Request, p interface{}) {
 }
 
 func logAuthFailure(ctx context.Context, r *http.Request, header, reason string) {
-	headers := http.Header{}
-	if r != nil {
-		headers = r.Header.Clone()
-	}
 	attrs := []any{
 		"reason", reason,
-		"headers", headers,
 	}
 	if header != "" {
-		attrs = append(attrs, "configured_header", header)
+		headers := http.Header{}
+		if r != nil {
+			if values := r.Header.Values(header); len(values) > 0 {
+				headers[http.CanonicalHeaderKey(header)] = append([]string(nil), values...)
+			}
+		}
+		attrs = append(attrs, "configured_header", header, "headers", headers)
 	}
 	authplugins.Logger().WarnContext(ctx, "envoy_xfcc authentication failed", attrs...)
 }


### PR DESCRIPTION
## Summary
- Restrict `envoy_xfcc` auth failure logs to the configured XFCC header values instead of cloning the full request header map.
- Keep `reason` and `configured_header` in the structured log payload.
- Update the existing XFCC logging test to assert unrelated request headers are omitted.

## Impact
Auth failure diagnostics still include the XFCC evidence needed for debugging, but unrelated headers such as tokens, cookies, or debug headers are not logged by this plugin failure path.

## Validation
- `go test ./app/auth ./app/auth/plugins/envoy_xfcc -coverprofile=/tmp/xfcc-only.cover`
  - total: 100.0% statements
- `go test ./app/auth ./app/auth/plugins/envoy_xfcc -count=5`
- `go test ./... -run '^$' -count=1`
- `git diff --check`